### PR TITLE
Add new consumer example

### DIFF
--- a/new-consumer/README.md
+++ b/new-consumer/README.md
@@ -1,0 +1,29 @@
+Quickstart
+----------
+
+Before running the examples, make sure that Zookeeper and Kafka are running. In what follows, 
+we assume that Zookeeper and Kafka are started with the default settings.
+
+    # Start Zookeeper
+    $ bin/zookeeper-server-start etc/kafka/zookeeper.properties
+
+    # Start Kafka
+    $ bin/kafka-server-start etc/kafka/server.properties
+
+   
+First create a topic called test:
+
+    # Create test topic
+    $ bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 \
+      --partitions 1 --topic test
+
+Then start the new-consumer example: 
+    
+    $ mvn exec:java -Dexec.mainClass="io.confluent.examples.consumer.NewConsumerExample" \
+     -Dexec.args="5"
+
+Finally start the console producer:
+
+    $ bin/kafka-console-producer.sh --broker-list localhost:9092 --topic test
+    This is a message
+    This is another message

--- a/new-consumer/pom.xml
+++ b/new-consumer/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.confluent</groupId>
+    <artifactId>new-consumer-example</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+
+    <properties>
+        <kafka.version>0.9.0.0</kafka.version>
+        <kafka.scala.version>2.11</kafka.scala.version>
+        <confluent.version>2.0.0</confluent.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>${confluent.maven.repo}</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/new-consumer/src/main/java/io/confluent/examples/consumer/ConsumeLoop.java
+++ b/new-consumer/src/main/java/io/confluent/examples/consumer/ConsumeLoop.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.examples.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ConsumeLoop implements Runnable {
+  private static final Logger log = LoggerFactory.getLogger(ConsumeLoop.class);
+  private final KafkaConsumer<Object, Object> consumer;
+  private final List<String> topics;
+  private final AtomicBoolean shutdown;
+  private final CountDownLatch shutdownLatch;
+
+  private final Queue<ConsumerRecord<Object, Object>> queue;
+  private final State<Object, Object> state;
+  private int numProcessors;
+  private Processor[] processors;
+  private Thread[] processorThreads;
+  private boolean committed = true;
+
+  public ConsumeLoop(Properties config, List<String> topics, int numProcessors) {
+    this.consumer = new KafkaConsumer<>(config);
+    this.topics = topics;
+    this.shutdown = new AtomicBoolean(false);
+    this.shutdownLatch = new CountDownLatch(1);
+
+    this.numProcessors = numProcessors;
+    processors = new Processor[numProcessors];
+    processorThreads = new Thread[numProcessors];
+
+    queue = new LinkedList<>();
+    state = new RecordCounterState();
+
+    for (int i = 0; i < numProcessors; ++i) {
+      processors[i] = new RecordCounter(i, queue, state);
+      processorThreads[i] = new Thread(processors[i]);
+    }
+
+    for (int i = 0; i < numProcessors; ++i) {
+      processorThreads[i].start();
+    }
+  }
+
+  public void run() {
+    try {
+      consumer.subscribe(topics);
+      while (!shutdown.get()) {
+        if (processFinished()) {
+          if (!committed) {
+            log.info("Committing offset!");
+            consumer.commitSync();
+            committed = true;
+          }
+
+          for (TopicPartition tp : consumer.assignment()) {
+            consumer.resume(tp);
+          }
+        }
+
+        ConsumerRecords<Object, Object> records = consumer.poll(2000);
+
+        if (!records.isEmpty()) {
+          committed = false;
+          synchronized (queue) {
+            for (ConsumerRecord<Object, Object> record : records) {
+              log.info("Putting " + record + " to queue for future processing");
+              queue.offer(record);
+            }
+            queue.notifyAll();
+          }
+
+          for (TopicPartition tp : consumer.assignment()) {
+            consumer.pause(tp);
+          }
+        }
+      }
+    } catch (WakeupException e) {
+      // ignore
+    } catch (Exception e) {
+      log.error("Unexpected error", e);
+    } finally {
+      consumer.close();
+      try {
+        log.info("Shutting down processor threads");
+        for (int i = 0; i < numProcessors; ++i) {
+          log.info("Shutting down processor " + processors[i].getId());
+          processors[i].shutdown();
+        }
+       } catch (InterruptedException e) {
+         // ignore
+      }
+      shutdownLatch.countDown();
+    }
+  }
+
+  private boolean processFinished() {
+    boolean finished = true;
+    synchronized (queue) {
+      if (!queue.isEmpty()) {
+        return false;
+      }
+      for (int i = 0; i < numProcessors; ++i) {
+        finished = finished && processors[i].isProcessFinished();
+      }
+      return finished;
+    }
+  }
+
+  public void shutdown() throws InterruptedException {
+    log.info("Shutting down consumer thread");
+    shutdown.set(true);
+    shutdownLatch.await();
+    log.info("Shutting down consumer thread finished");
+  }
+}

--- a/new-consumer/src/main/java/io/confluent/examples/consumer/NewConsumerExample.java
+++ b/new-consumer/src/main/java/io/confluent/examples/consumer/NewConsumerExample.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.consumer;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+public class NewConsumerExample {
+  private static final String CLIENT_ID_CONFIG = "client.id";
+  private static final String GROUP_ID_CONFIG = "group.id";
+  private static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
+  private static final String ENABLE_AUTO_COMMIT_CONFIG = "enable.auto.commit";
+  private static final String KEY_DESERILIZER_CONFIG = "key.deserializer";
+  private static final String VALUE_DESERILIZER_CONFIG = "value.deserializer";
+
+  private ConsumeLoop consumeLoop;
+  private Thread consumeLoopThread;
+
+  public NewConsumerExample(int numProcessors) {
+    Properties config = createConfig();
+    List<String> topics = Collections.singletonList("test");
+    consumeLoop = new ConsumeLoop(config, topics, numProcessors);
+    consumeLoopThread = new Thread(consumeLoop);
+    consumeLoopThread.start();
+  }
+
+  private Properties createConfig()  {
+    Properties config = new Properties();
+    config.put(CLIENT_ID_CONFIG, "example_client");
+    config.put(GROUP_ID_CONFIG, "example");
+    config.put(BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    config.put(ENABLE_AUTO_COMMIT_CONFIG, false);
+    config.put(KEY_DESERILIZER_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+    config.put(VALUE_DESERILIZER_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+    return config;
+  }
+
+  public void shutdown() throws InterruptedException {
+    consumeLoop.shutdown();
+  }
+
+  public static void main(String[] args) {
+    if (args.length != 1) {
+      System.out.println("The only allowed argument is numProcessors.");
+      System.exit(-1);
+    }
+
+    int numProcessors = Integer.parseInt(args[0]);
+    if (numProcessors <= 0) {
+      System.out.println("numProcessors should be positive.");
+      System.exit(-1);
+    }
+
+    final NewConsumerExample example = new NewConsumerExample(numProcessors);
+
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        try {
+          example.shutdown();
+        } catch (InterruptedException e) {
+          //
+        }
+      }
+    });
+  }
+}

--- a/new-consumer/src/main/java/io/confluent/examples/consumer/Processor.java
+++ b/new-consumer/src/main/java/io/confluent/examples/consumer/Processor.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.examples.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public abstract class Processor<K, V> implements Runnable {
+  private static final Logger log = LoggerFactory.getLogger(Processor.class);
+  private final AtomicBoolean shutdown = new AtomicBoolean(false);
+  private final CountDownLatch shutdownLatch = new CountDownLatch(1);
+  private int id;
+  private final Queue<ConsumerRecord<K,V>> queue;
+  private volatile boolean processFinished;
+  private State<K, V> state;
+
+  public Processor(int id, Queue<ConsumerRecord<K, V>> queue, State<K,V> state) {
+    this.id = id;
+    this.queue = queue;
+    this.state = state;
+    processFinished = true;
+  }
+
+  @Override
+  public void run() {
+    try {
+      while (!shutdown.get()) {
+        ConsumerRecord<K, V> record;
+        synchronized (queue) {
+          while (queue.isEmpty()) {
+            try {
+              queue.wait();
+            } catch (InterruptedException e) {
+              // ignore
+            }
+          }
+          record = queue.poll();
+          log.info("Pulled " + record + " from queue to be processed by Processor " + id);
+          processFinished = false;
+        }
+        process(record, state);
+        getResult();
+        processFinished = true;
+      }
+    } finally {
+      shutdownLatch.countDown();
+    }
+  }
+
+  public abstract void process(ConsumerRecord<K, V> record, State<K, V> state);
+
+  public abstract void getResult();
+
+  public void shutdown() throws InterruptedException {
+    shutdown.set(true);
+    shutdownLatch.countDown();
+  }
+
+  public boolean isProcessFinished() {
+    return processFinished;
+  }
+
+  public int getId() {
+    return id;
+  }
+}

--- a/new-consumer/src/main/java/io/confluent/examples/consumer/RecordCounter.java
+++ b/new-consumer/src/main/java/io/confluent/examples/consumer/RecordCounter.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.examples.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Queue;
+
+public class RecordCounter extends Processor<Object, Object> {
+  private static final Logger log = LoggerFactory.getLogger(Processor.class);
+  private Map<String, Integer> count;
+
+  @SuppressWarnings("unchecked")
+  public RecordCounter(int id, Queue<ConsumerRecord<Object, Object>> queue, State<Object, Object> state) {
+    super(id, queue, state);
+    count = (Map<String, Integer>) state.getState();
+  }
+
+  @Override
+  public void process(ConsumerRecord<Object, Object> record, State<Object, Object> state) {
+    state.updateState(record);
+  }
+
+  @Override
+  public void getResult() {
+    for (Map.Entry<String, Integer> entry: count.entrySet()) {
+      System.out.println("[" + entry.getKey() + ":" + entry.getValue() + "]");
+    }
+  }
+}

--- a/new-consumer/src/main/java/io/confluent/examples/consumer/RecordCounterState.java
+++ b/new-consumer/src/main/java/io/confluent/examples/consumer/RecordCounterState.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.examples.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class RecordCounterState implements State<Object, Object> {
+
+  private Map<String, Integer> count;
+
+  public RecordCounterState() {
+    count = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public void updateState(ConsumerRecord<Object, Object> record) {
+    String topic = record.topic();
+    if (!count.containsKey(topic)) {
+      count.put(topic, 1);
+    } else {
+      count.put(topic, count.get(topic) + 1);
+    }
+  }
+
+  @Override
+  public Object getState() {
+    return count;
+  }
+}

--- a/new-consumer/src/main/java/io/confluent/examples/consumer/State.java
+++ b/new-consumer/src/main/java/io/confluent/examples/consumer/State.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.examples.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public interface State<K, V> {
+  void updateState(ConsumerRecord<K, V> record);
+  Object getState();
+}

--- a/new-consumer/src/main/resources/log4j.properties
+++ b/new-consumer/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+##
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+
+log4j.rootLogger=DEBUG, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
+log4j.logger.org.apache.kafka=ERROR


### PR DESCRIPTION
This is a simple example using a queue to decouple data consumption from data processing.  The implementation is straightforward:
1. We have one consumption thread plus a number of processor thread on each machine.  
2. Putting data returned by poll() to a queue. Which will be later processed by one of the processor thread. 
3. Synchronous offset commit is used. 
3. This only works if the result does not depending on the order of data. 

@hachikuji @ewencp 