### PR TITLE
Update class to object in MapFunctionScalaExample.scala

### DIFF
--- a/kafka-streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
+++ b/kafka-streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.streams.kstream.{KStream, KStreamBuilder}
   * Requires a version of Scala that supports Java 8 and SAM / Java lambda (e.g. Scala 2.11 with
   * `-Xexperimental` compiler flag, or 2.12).
   */
-class MapFunctionScalaExample {
+object MapFunctionScalaExample {
 
   def main(args: Array[String]) {
     val builder: KStreamBuilder = new KStreamBuilder


### PR DESCRIPTION
Prior to this, I was running into the following issue when trying to run locally:

```bash
$ java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.MapFunctionScalaExample
Error: Main method is not static in class io.confluent.examples.streams.MapFunctionScalaExample, please define the main method as:
   public static void main(String[] args)
```

Changing `class` to `object` now allows me to run the example, and it works as expected.