### PR TITLE
remove references to CP 3.0.0

### DIFF
--- a/kafka-streams/README.md
+++ b/kafka-streams/README.md
@@ -1,4 +1,4 @@
-# Kafka Streams examples [![Build Status](https://travis-ci.org/confluentinc/examples.svg?branch=master)](https://travis-ci.org/confluentinc/examples)
+# Kafka Streams examples [![Build Status](https://travis-ci.org/confluentinc/examples.svg?branch=kafka-0.10.0.1-cp-3.0.1)](https://travis-ci.org/confluentinc/examples)
 
 This sub-folder contains code examples that demonstrate how to implement real-time processing applications using Kafka
 Streams, which is a new stream processing library included with the [Apache Kafka](http://kafka.apache.org/) open source
@@ -275,7 +275,7 @@ $ mvn test    # But no tests yet!
 
 | Branch (this repo)                                                             | Apache Kafka      | Confluent Platform | Notes                                                                                 |
 | -------------------------------------------------------------------------------|-------------------|--------------------|---------------------------------------------------------------------------------------|
-| [master](../../../tree/master/kafka-streams)                                   | 0.10.1.0-SNAPSHOT | 3.0.1              | You must manually build the `trunk` version of Apache Kafka.  See instructions above. |
+| [master](../../../tree/master/kafka-streams)                                   | 0.10.1.0-SNAPSHOT | 3.1.0-SNAPSHOT     | You must manually build the `trunk` version of Apache Kafka.  See instructions above. |
 | [kafka-0.10.0.1-cp-3.0.1](../../../tree/kafka-0.10.0.1-cp-3.0.1/kafka-streams) | 0.10.0.1(-cp1)    | 3.0.1              | Works out of the box                                                                  |
 | [kafka-0.10.0.0-cp-3.0.0](../../../tree/kafka-0.10.0.0-cp-3.0.0/kafka-streams) | 0.10.0.0(-cp1)    | 3.0.0              | Works out of the box                                                                  |
 

--- a/kafka-streams/README.md
+++ b/kafka-streams/README.md
@@ -1,4 +1,4 @@
-# Kafka Streams examples [![Build Status](https://travis-ci.org/confluentinc/examples.svg?branch=kafka-0.10.0.0-cp-3.0.0)](https://travis-ci.org/confluentinc/examples)
+# Kafka Streams examples [![Build Status](https://travis-ci.org/confluentinc/examples.svg?branch=master)](https://travis-ci.org/confluentinc/examples)
 
 This sub-folder contains code examples that demonstrate how to implement real-time processing applications using Kafka
 Streams, which is a new stream processing library included with the [Apache Kafka](http://kafka.apache.org/) open source
@@ -157,8 +157,8 @@ The code in this repository requires Confluent Platform 3.0.x.
 See [Version Compatibility Matrix](#version-compatibility) for further details, as different branches of this
 repository may have different Confluent Platform requirements.
 
-* [Confluent Platform 3.0.0 Quickstart](http://docs.confluent.io/3.0.0/quickstart.html) (how to download and install)
-* [Confluent Platform 3.0.0 documentation](http://docs.confluent.io/3.0.0/)
+* [Confluent Platform Quickstart](http://docs.confluent.io/current/quickstart.html) (how to download and install)
+* [Confluent Platform documentation](http://docs.confluent.io/current/)
 
 If you just run the integration tests (`mvn test`), then you do not need to install anything -- all maven artifacts
 will be downloaded automatically for the build.  However, if you want to interactively test-drive the examples under
@@ -204,7 +204,7 @@ and SAM / Java lambda (e.g. Scala 2.11 with `-Xexperimental` compiler flag, or 2
 
 The first step is to install and run a Kafka cluster, which must consist of at least one Kafka broker as well as
 at least one ZooKeeper instance.  Some examples may also require a running instance of Confluent schema registry.
-The [Confluent Platform 3.0.0 Quickstart](http://docs.confluent.io/3.0.0/quickstart.html) guide provides the full
+The [Confluent Platform Quickstart](http://docs.confluent.io/current/quickstart.html) guide provides the full
 details.
 
 In a nutshell:
@@ -275,7 +275,8 @@ $ mvn test    # But no tests yet!
 
 | Branch (this repo)                                                             | Apache Kafka      | Confluent Platform | Notes                                                                                 |
 | -------------------------------------------------------------------------------|-------------------|--------------------|---------------------------------------------------------------------------------------|
-| [master](../../../tree/master/kafka-streams)                                   | 0.10.1.0-SNAPSHOT | 3.1.0-SNAPSHOT     | You must manually build the `trunk` version of Apache Kafka.  See instructions above. |
+| [master](../../../tree/master/kafka-streams)                                   | 0.10.1.0-SNAPSHOT | 3.0.1              | You must manually build the `trunk` version of Apache Kafka.  See instructions above. |
+| [kafka-0.10.0.1-cp-3.0.1](../../../tree/kafka-0.10.0.1-cp-3.0.1/kafka-streams) | 0.10.0.1(-cp1)    | 3.0.1              | Works out of the box                                                                  |
 | [kafka-0.10.0.0-cp-3.0.0](../../../tree/kafka-0.10.0.0-cp-3.0.0/kafka-streams) | 0.10.0.0(-cp1)    | 3.0.0              | Works out of the box                                                                  |
 
 The `master` branch of this repository represents active development, and may require additional steps on your side to

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/AnomalyDetectionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/AnomalyDetectionLambdaExample.java
@@ -48,7 +48,7 @@ import java.util.Properties;
  * }
  * </pre>
  *
- * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
+ * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/AnomalyDetectionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/AnomalyDetectionLambdaExample.java
@@ -35,8 +35,7 @@ import java.util.Properties;
  *
  * HOW TO RUN THIS EXAMPLE
  *
- * 1) Start Zookeeper and Kafka. Please refer to <a href='http://docs.confluent.io/3.0.0/quickstart.html#quickstart'>CP3.0.0
- * QuickStart</a>.
+ * 1) Start Zookeeper and Kafka. Please refer to <a href='http://docs.confluent.io/current/quickstart.html#quickstart'>QuickStart</a>.
  *
  * 2) Create the input and output topics used by this example.
  *
@@ -49,7 +48,7 @@ import java.util.Properties;
  * }
  * </pre>
  *
- * Note: The above commands are for CP 3.0.0 only. For Apache Kafka it should be
+ * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.
@@ -59,7 +58,7 @@ import java.util.Properties;
  *
  * <pre>
  * {@code
- * $ java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.AnomalyDetectionLambdaExample
+ * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.AnomalyDetectionLambdaExample
  * }
  * </pre>
  *

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/MapFunctionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/MapFunctionLambdaExample.java
@@ -35,8 +35,7 @@ import java.util.Properties;
  *
  * HOW TO RUN THIS EXAMPLE
  *
- * 1) Start Zookeeper and Kafka. Please refer to <a href='http://docs.confluent.io/3.0.0/quickstart.html#quickstart'>CP3.0.0
- * QuickStart</a>.
+ * 1) Start Zookeeper and Kafka. Please refer to <a href='http://docs.confluent.io/current/quickstart.html#quickstart'>QuickStart</a>.
  *
  * 2) Create the input and output topics used by this example.
  *
@@ -51,7 +50,7 @@ import java.util.Properties;
  * }
  * </pre>
  *
- * Note: The above commands are for CP 3.0.0 only. For Apache Kafka it should be
+ * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.
@@ -61,7 +60,7 @@ import java.util.Properties;
  *
  * <pre>
  * {@code
- * $ java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.MapFunctionLambdaExample
+ * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.MapFunctionLambdaExample
  * }
  * </pre>
  *

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/MapFunctionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/MapFunctionLambdaExample.java
@@ -50,7 +50,7 @@ import java.util.Properties;
  * }
  * </pre>
  *
- * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
+ * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExample.java
@@ -71,7 +71,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  * }
  * </pre>*
  *
- * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
+ * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExample.java
@@ -54,7 +54,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  * HOW TO RUN THIS EXAMPLE
  *
  * 1) Start Zookeeper, Kafka, and Confluent Schema Registry. Please refer to <a
- * href='http://docs.confluent.io/3.0.0/quickstart.html#quickstart'>CP3.0.0 QuickStart</a>.
+ * href='http://docs.confluent.io/current/quickstart.html#quickstart'>QuickStart</a>.
  *
  * 2) Create the input/intermediate/output topics used by this example.
  *
@@ -71,7 +71,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  * }
  * </pre>*
  *
- * Note: The above commands are for CP 3.0.0 only. For Apache Kafka it should be
+ * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.
@@ -81,7 +81,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  *
  * <pre>
  * {@code
- * $ java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.PageViewRegionLambdaExample
+ * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.PageViewRegionLambdaExample
  * }
  * </pre>
  *
@@ -93,7 +93,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  * {@code
  * # Here: Write input data using the example driver.  Once the driver has stopped generating data,
  * # you can terminate it via `Ctrl-C`.
- * $ java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.PageViewRegionExampleDriver
+ * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.PageViewRegionExampleDriver
  * }
  * </pre>
  *

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExampleDriver.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExampleDriver.java
@@ -45,7 +45,7 @@ import java.util.stream.IntStream;
  * <a href='https://github.com/confluentinc/examples/tree/master/kafka-streams#packaging-and-running'>Packaging</a>
  *
  * Once packaged you can then run:
- * java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.PageViewRegionExampleDriver
+ * java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.PageViewRegionExampleDriver
  *
  * You should terminate with Ctrl-C
  */

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionLambdaExample.java
@@ -51,8 +51,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  * HOW TO RUN THIS EXAMPLE
  *
  * 1) Start Zookeeper, Kafka, and Confluent Schema Registry.
- *    Please refer to <a href='http://docs.confluent.io/3.0.0/quickstart.html#quickstart'>CP3.0.0
- *    QuickStart</a>.
+ *    Please refer to <a href='http://docs.confluent.io/current/quickstart.html#quickstart'>QuickStart</a>.
  *
  * 2) Create the input/intermediate/output topics used by this example.
  *
@@ -69,7 +68,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  * }
  * </pre>*
  *
- * Note: The above commands are for CP 3.0.0 only. For Apache Kafka it should be
+ * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.
@@ -79,7 +78,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  *
  * <pre>
  * {@code
- * $ java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.PageViewRegionLambdaExample
+ * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.PageViewRegionLambdaExample
  * }
  * </pre>
  *
@@ -91,7 +90,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  * {@code
  * # Here: Write input data using the example driver.  Once the driver has stopped generating data,
  * # you can terminate it via `Ctrl-C`.
- * $ java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.PageViewRegionExampleDriver
+ * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.PageViewRegionExampleDriver
  * }
  * </pre>
  *

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionLambdaExample.java
@@ -68,7 +68,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  * }
  * </pre>*
  *
- * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
+ * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SecureKafkaStreamsExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SecureKafkaStreamsExample.java
@@ -40,7 +40,7 @@ import java.util.Properties;
  *
  * Tip: The configuration of this VM follows the instructions at <a href="http://www.confluent.io/blog/apache-kafka-security-authorization-authentication-encryption">Apache
  * Kafka Security 101</a>.  We recommend to read this article as well as <a
- * href="http://docs.confluent.io/3.0.0/kafka/security.html">Kafka Security</a> to understand how
+ * href="http://docs.confluent.io/current/kafka/security.html">Kafka Security</a> to understand how
  * you can install a secure Kafka cluster yourself.
  *
  * 1) Start a secure ZooKeeper instance and a secure Kafka broker.
@@ -98,14 +98,14 @@ import java.util.Properties;
  * {@code
  * [vagrant@kafka ~]$ git clone https://github.com/confluentinc/examples.git
  * [vagrant@kafka ~]$ cd examples/kafka-streams
- * [vagrant@kafka ~]$ git checkout kafka-0.10.0.0-cp-3.0.0
+ * [vagrant@kafka ~]$ git checkout master
  *
  * # Build and package the examples.  We skip the test suite because running the test suite
  * # requires more main memory than is available to the Vagrant VM by default.
  * [vagrant@kafka ~]$ mvn clean -DskipTests=true package
  *
  * # Now we can start this example application
- * [vagrant@kafka ~]$ java -cp target/streams-examples-3.0.0-standalone.jar \
+ * [vagrant@kafka ~]$ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar \
  *                             io.confluent.examples.streams.SecureKafkaStreamsExample
  * }
  * </pre>

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExample.java
@@ -31,8 +31,7 @@ import java.util.Properties;
  *
  * HOW TO RUN THIS EXAMPLE
  *
- * 1) Start Zookeeper and Kafka. Please refer to <a href='http://docs.confluent.io/3.0.0/quickstart.html#quickstart'>CP3.0.0
- * QuickStart</a>.
+ * 1) Start Zookeeper and Kafka. Please refer to <a href='http://docs.confluent.io/current/quickstart.html#quickstart'>QuickStart</a>.
  *
  * 2) Create the input and output topics used by this example.
  *
@@ -45,7 +44,7 @@ import java.util.Properties;
  * }
  * </pre>
  *
- * Note: The above commands are for CP 3.0.0 only. For Apache Kafka it should be
+ * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.
@@ -55,7 +54,7 @@ import java.util.Properties;
  *
  * <pre>
  * {@code
- * $ java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.SumLambdaExample
+ * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.SumLambdaExample
  * }
  * </pre>
  *
@@ -67,7 +66,7 @@ import java.util.Properties;
  * {@code
  * # Here: Write input data using the example driver.  Once the driver has stopped generating data,
  * # you can terminate it via `Ctrl-C`.
- * $ java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.SumLambdaExampleDriver
+ * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.SumLambdaExampleDriver
  * }
  * </pre>
  *

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExample.java
@@ -44,7 +44,7 @@ import java.util.Properties;
  * }
  * </pre>
  *
- * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
+ * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExampleDriver.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExampleDriver.java
@@ -36,7 +36,7 @@ import java.util.stream.IntStream;
  * <a href='https://github.com/confluentinc/examples/tree/master/kafka-streams#packaging-and-running'>Packaging</a>
  *
  * Once packaged you can then run:
- * java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.SumLambdaExampleDriver
+ * java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.SumLambdaExampleDriver
  *
  * You should terminate with Ctrl-C
  * Please refer to {@link SumLambdaExample} for instructions on running the example.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/UserRegionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/UserRegionLambdaExample.java
@@ -45,7 +45,7 @@ import java.util.Properties;
  * }
  * </pre>
  *
- * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
+ * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/UserRegionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/UserRegionLambdaExample.java
@@ -32,8 +32,7 @@ import java.util.Properties;
  *
  * HOW TO RUN THIS EXAMPLE
  *
- * 1) Start Zookeeper and Kafka. Please refer to <a href='http://docs.confluent.io/3.0.0/quickstart.html#quickstart'>CP3.0.0
- * QuickStart</a>.
+ * 1) Start Zookeeper and Kafka. Please refer to <a href='http://docs.confluent.io/current/quickstart.html#quickstart'>QuickStart</a>.
  *
  * 2) Create the input and output topics used by this example.
  *
@@ -46,7 +45,7 @@ import java.util.Properties;
  * }
  * </pre>
  *
- * Note: The above commands are for CP 3.0.0 only. For Apache Kafka it should be
+ * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.
@@ -56,7 +55,7 @@ import java.util.Properties;
  *
  * <pre>
  * {@code
- * $ java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.UserRegionLambdaExample
+ * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.UserRegionLambdaExample
  * }
  * </pre>
  *

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
@@ -55,7 +55,7 @@ import java.util.regex.Pattern;
  * }
  * </pre>
  *
- * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
+ * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
@@ -42,8 +42,7 @@ import java.util.regex.Pattern;
  *
  * HOW TO RUN THIS EXAMPLE
  *
- * 1) Start Zookeeper and Kafka. Please refer to <a href='http://docs.confluent.io/3.0.0/quickstart.html#quickstart'>CP3.0.0
- * QuickStart</a>.
+ * 1) Start Zookeeper and Kafka. Please refer to <a href='http://docs.confluent.io/current/quickstart.html#quickstart'>QuickStart</a>.
  *
  * 2) Create the input and output topics used by this example.
  *
@@ -56,7 +55,7 @@ import java.util.regex.Pattern;
  * }
  * </pre>
  *
- * Note: The above commands are for CP 3.0.0 only. For Apache Kafka it should be
+ * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  * 3) Start this example application either in your IDE or on the command line.
@@ -66,7 +65,7 @@ import java.util.regex.Pattern;
  *
  * <pre>
  * {@code
- * $ java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.WordCountLambdaExample
+ * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.WordCountLambdaExample
  * }
  * </pre>
  *

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/InteractiveQueriesExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/InteractiveQueriesExample.java
@@ -61,7 +61,7 @@ import java.util.Properties;
  * }
  * </pre>
  *
- * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
+ * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  *

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/InteractiveQueriesExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/InteractiveQueriesExample.java
@@ -50,8 +50,7 @@ import java.util.Properties;
  *
  * HOW TO RUN THIS EXAMPLE
  *
- * 1) Start Zookeeper and Kafka. Please refer to <a href='http://docs.confluent.io/3.0.0/quickstart.html#quickstart'>CP3.0.0
- * QuickStart</a>.
+ * 1) Start Zookeeper and Kafka. Please refer to <a href='http://docs.confluent.io/current/quickstart.html#quickstart'>QuickStart</a>.
  *
  * 2) Create the input and output topics used by this example.
  *
@@ -62,7 +61,7 @@ import java.util.Properties;
  * }
  * </pre>
  *
- * Note: The above commands are for CP 3.0.0 only. For Apache Kafka it should be
+ * Note: The above commands are the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.
  *
  *
@@ -74,7 +73,7 @@ import java.util.Properties;
  *
  * <pre>
  * {@code
- * $ java -cp target/streams-examples-3.0.0-standalone.jar \
+ * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar \
  *      io.confluent.examples.streams.interactivequeries.InteractiveQueriesExample 7070
  * }
  * </pre>
@@ -85,7 +84,7 @@ import java.util.Properties;
  *
  * <pre>
  * {@code
- * $ java -cp target/streams-examples-3.0.0-standalone.jar \
+ * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar \
  *      io.confluent.examples.streams.interactivequeries.InteractiveQueriesExample 7071
  * }
  * </pre>

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/InteractiveQueriesExampleDriver.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/InteractiveQueriesExampleDriver.java
@@ -35,7 +35,7 @@ import java.util.Random;
  * Once packaged you can then run:
  * <pre>
  * {@code
- * $ java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.interactivequeries.InteractiveQueriesExampleDriver
+ * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.interactivequeries.InteractiveQueriesExampleDriver
  * }
  * </pre>
  * You should terminate with Ctrl-C

--- a/kafka-streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
+++ b/kafka-streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
@@ -45,7 +45,8 @@ import org.apache.kafka.streams.kstream.{KStream, KStreamBuilder}
   * $ bin/kafka-topics --create --topic OriginalAndUppercasedTopic --zookeeper localhost:2181 --partitions 1 --replication-factor 1
   * }}}
   *
-  * Note: The above commands are the Confluent Platform. For Apache Kafka it should be `bin/kafka-topics.sh ...`.
+  * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be
+  * `bin/kafka-topics.sh ...`.
   *
   * 3) Start this example application either in your IDE or on the command line.
   *

--- a/kafka-streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
+++ b/kafka-streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
@@ -35,7 +35,7 @@ import org.apache.kafka.streams.kstream.{KStream, KStreamBuilder}
   * HOW TO RUN THIS EXAMPLE
   *
   * 1) Start Zookeeper and Kafka.
-  * Please refer to <a href='http://docs.confluent.io/3.0.0/quickstart.html#quickstart'>CP3.0.0 QuickStart</a>.
+  * Please refer to <a href='http://docs.confluent.io/current/quickstart.html#quickstart'>QuickStart</a>.
   *
   * 2) Create the input and output topics used by this example.
   *
@@ -45,7 +45,7 @@ import org.apache.kafka.streams.kstream.{KStream, KStreamBuilder}
   * $ bin/kafka-topics --create --topic OriginalAndUppercasedTopic --zookeeper localhost:2181 --partitions 1 --replication-factor 1
   * }}}
   *
-  * Note: The above commands are for CP 3.0.0 only. For Apache Kafka it should be `bin/kafka-topics.sh ...`.
+  * Note: The above commands are the Confluent Platform. For Apache Kafka it should be `bin/kafka-topics.sh ...`.
   *
   * 3) Start this example application either in your IDE or on the command line.
   *
@@ -54,7 +54,7 @@ import org.apache.kafka.streams.kstream.{KStream, KStreamBuilder}
   * Once packaged you can then run:
   *
   * {{{
-  * $ java -cp target/streams-examples-3.0.0-standalone.jar io.confluent.examples.streams.MapFunctionScalaExample
+  * $ java -cp target/streams-examples-3.1.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.MapFunctionScalaExample
   * }
   * }}}
   *


### PR DESCRIPTION
Update to point to http://docs.confluent.io/current rather than a specific version.
Remove references to CP 3.0.0.
Update all example instructions to use streams-examples-3.1.0-SNAPSHOT
