### PR TITLE
Allow users to override bootstrap.servers and schema.registry.url via CLI

### DIFF
--- a/kafka-streams/README.md
+++ b/kafka-streams/README.md
@@ -340,7 +340,8 @@ $ java -cp target/streams-examples-3.2.0-standalone.jar \
 
 Keep in mind that the machine on which you run the command above must have access to the Kafka/ZK clusters you
 configured in the code examples.  By default, the code examples assume the Kafka cluster is accessible via
-`localhost:9092` (Kafka broker) and the ZooKeeper ensemble via `localhost:2181`.
+`localhost:9092` (aka Kafka's ``bootstrap.servers`` parameter) and the ZooKeeper ensemble via `localhost:2181`.
+You can override the default ``bootstrap.servers`` parameter through a command line argument.
 
 
 <a name="development"/>

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/AnomalyDetectionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/AnomalyDetectionLambdaExample.java
@@ -82,7 +82,7 @@ import java.util.Properties;
  * <pre>
  * {@code
  * $ bin/kafka-console-consumer --topic AnomalousUsers --from-beginning \
- *                              --zookeeper localhost:2181 \
+ *                              --new-consumer --bootstrap-server localhost:9092 \
  *                              --property print.key=true \
  *                              --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer
  * }</pre>

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/AnomalyDetectionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/AnomalyDetectionLambdaExample.java
@@ -99,12 +99,13 @@ import java.util.Properties;
 public class AnomalyDetectionLambdaExample {
 
   public static void main(final String[] args) throws Exception {
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
     final Properties streamsConfiguration = new Properties();
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "anomaly-detection-lambda-example");
     // Where to find Kafka broker(s).
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Specify default (de)serializers for record keys and for record values.
     streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
     streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/ApplicationResetExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/ApplicationResetExample.java
@@ -109,13 +109,14 @@ import java.util.Properties;
 public class ApplicationResetExample {
 
   public static void main(final String[] args) throws Exception {
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
     // Kafka Streams configuration
     final Properties streamsConfiguration = new Properties();
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "application-reset-demo");
     // Where to find Kafka broker(s).
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Specify default (de)serializers for record keys and for record values.
     streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
     streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/ApplicationResetExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/ApplicationResetExample.java
@@ -62,7 +62,7 @@ import java.util.Properties;
  * <pre>
  * {@code
  * $ bin/kafka-console-consumer --topic my-output-topic --from-beginning \
- *                              --zookeeper localhost:2181 \
+ *                              --new-consumer --bootstrap-server localhost:9092 \
  *                              --property print.key=true \
  *                              --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer
  * }</pre>

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/GlobalKTablesExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/GlobalKTablesExample.java
@@ -92,9 +92,11 @@ public class GlobalKTablesExample {
   static final String ENRICHED_ORDER_TOPIC = "enriched-order";
 
   public static void main(String[] args) {
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 1 ? args[1] : "http://localhost:8081";
     final KafkaStreams
         streams =
-        createStreams("localhost:9092", "http://localhost:8081", "/tmp/kafka-streams-global-tables");
+        createStreams(bootstrapServers, schemaRegistryUrl, "/tmp/kafka-streams-global-tables");
     // Always (and unconditionally) clean local state prior to starting the processing topology.
     // We opt for this unconditional call here because this will make it easier for you to play around with the example
     // when resetting the application for doing a re-run (via the Application Reset Tool,

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/GlobalKTablesExampleDriver.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/GlobalKTablesExampleDriver.java
@@ -64,8 +64,8 @@ public class GlobalKTablesExampleDriver {
   private static final int RECORDS_TO_GENERATE = 100;
 
   public static void main(String[] args) {
-    final String bootstrapServers = "localhost:9092";
-    final String schemaRegistryUrl = "http://localhost:8081";
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 1 ? args[1] : "http://localhost:8081";
     generateCustomers(bootstrapServers, schemaRegistryUrl, RECORDS_TO_GENERATE);
     generateProducts(bootstrapServers, schemaRegistryUrl, RECORDS_TO_GENERATE);
     generateOrders(bootstrapServers, schemaRegistryUrl, RECORDS_TO_GENERATE, RECORDS_TO_GENERATE, RECORDS_TO_GENERATE);

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/MapFunctionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/MapFunctionLambdaExample.java
@@ -91,12 +91,13 @@ import java.util.Properties;
 public class MapFunctionLambdaExample {
 
   public static void main(final String[] args) throws Exception {
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
     final Properties streamsConfiguration = new Properties();
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "map-function-lambda-example");
     // Where to find Kafka broker(s).
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Specify default (de)serializers for record keys and for record values.
     streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
     streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/MapFunctionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/MapFunctionLambdaExample.java
@@ -75,9 +75,9 @@ import java.util.Properties;
  * <pre>
  * {@code
  * $ bin/kafka-console-consumer --topic UppercasedTextLinesTopic --from-beginning \
- *                              --zookeeper localhost:2181
+ *                              --new-consumer --bootstrap-server localhost:9092
  * $ bin/kafka-console-consumer --topic OriginalAndUppercasedTopic --from-beginning \
- *                              --zookeeper localhost:2181
+ *                              --new-consumer --bootstrap-server localhost:9092
  * }</pre>
  * You should see output data similar to:
  * <pre>

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExample.java
@@ -111,14 +111,16 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 public class PageViewRegionExample {
 
   public static void main(final String[] args) throws Exception {
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 1 ? args[1] : "http://localhost:8081";
     final Properties streamsConfiguration = new Properties();
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "pageview-region-example");
     // Where to find Kafka broker(s).
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Where to find the Confluent schema registry instance(s)
-    streamsConfiguration.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://localhost:8081");
+    streamsConfiguration.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl);
     // Specify default (de)serializers for record keys and for record values.
     streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
     streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, GenericAvroSerde.class);

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExample.java
@@ -92,7 +92,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  * <pre>
  * {@code
  * $ bin/kafka-console-consumer --topic PageViewsByRegion --from-beginning \
- *                              --zookeeper localhost:2181 \
+ *                              --new-consumer --bootstrap-server localhost:9092 \
  *                              --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer
  * }</pre>
  * You should see output data similar to:

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExample.java
@@ -93,6 +93,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  * {@code
  * $ bin/kafka-console-consumer --topic PageViewsByRegion --from-beginning \
  *                              --new-consumer --bootstrap-server localhost:9092 \
+ *                              --property print.key=true \
  *                              --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer
  * }</pre>
  * You should see output data similar to:

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExampleDriver.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExampleDriver.java
@@ -52,19 +52,21 @@ import java.util.stream.IntStream;
 public class PageViewRegionExampleDriver {
 
   public static void main(final String[] args) throws IOException {
-    produceInputs();
-    consumeOutput();
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 1 ? args[1] : "http://localhost:8081";
+    produceInputs(bootstrapServers, schemaRegistryUrl);
+    consumeOutput(bootstrapServers);
   }
 
-  private static void produceInputs() throws IOException {
+  private static void produceInputs(String bootstrapServers, String schemaRegistryUrl) throws IOException {
     final String[] users = {"erica", "bob", "joe", "damian", "tania", "phil", "sam", "lauren", "joseph"};
     final String[] regions = {"europe", "usa", "asia", "africa"};
 
     final Properties props = new Properties();
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, io.confluent.kafka.serializers.KafkaAvroSerializer.class);
-    props.put("schema.registry.url", "http://localhost:8081");
+    props.put("schema.registry.url", schemaRegistryUrl);
     final KafkaProducer<String, GenericRecord> producer = new KafkaProducer<>(props);
 
     final GenericRecordBuilder pageViewBuilder =
@@ -94,10 +96,10 @@ public class PageViewRegionExampleDriver {
     producer.flush();
   }
 
-  private static void consumeOutput() {
+  private static void consumeOutput(String bootstrapServers) {
     final String resultTopic = "PageViewsByRegion";
     final Properties consumerProperties = new Properties();
-    consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
     consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG,

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionLambdaExample.java
@@ -108,14 +108,16 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 public class PageViewRegionLambdaExample {
 
   public static void main(final String[] args) throws Exception {
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 1 ? args[1] : "http://localhost:8081";
     final Properties streamsConfiguration = new Properties();
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "pageview-region-lambda-example");
     // Where to find Kafka broker(s).
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Where to find the Confluent schema registry instance(s)
-    streamsConfiguration.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://localhost:8081");
+    streamsConfiguration.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl);
     // Specify default (de)serializers for record keys and for record values.
     streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
     streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, GenericAvroSerde.class);

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionLambdaExample.java
@@ -88,7 +88,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  * <pre>
  * {@code
  * $ bin/kafka-console-consumer --topic PageViewsByRegion --from-beginning \
- *                              --zookeeper localhost:2181 \
+ *                              --new-consumer --bootstrap-server localhost:9092 \
  *                              --property print.key=true \
  *                              --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer
  * }</pre>

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SecureKafkaStreamsExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SecureKafkaStreamsExample.java
@@ -138,13 +138,14 @@ import java.util.Properties;
 public class SecureKafkaStreamsExample {
 
   public static void main(final String[] args) throws Exception {
+    final String secureBootstrapServers = args.length > 0 ? args[0] : "localhost:9093";
     final Properties streamsConfiguration = new Properties();
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "secure-kafka-streams-app");
     // Where to find secure (!) Kafka broker(s).  In the VM, the broker listens on port 9093 for
     // SSL connections.
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9093");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, secureBootstrapServers);
     // Specify default (de)serializers for record keys and for record values.
     streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
     streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SessionWindowsExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SessionWindowsExample.java
@@ -103,8 +103,10 @@ public class SessionWindowsExample {
   static final String PLAY_EVENTS_PER_SESSION = "play-events-per-session";
 
   public static void main(String[] args) {
-    final KafkaStreams streams = createStreams("localhost:9092",
-                                               "http://localhost:8081",
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 1 ? args[1] : "http://localhost:8081";
+    final KafkaStreams streams = createStreams(bootstrapServers,
+                                               schemaRegistryUrl,
                                                "/tmp/kafka-streams");
 
     // Always (and unconditionally) clean local state prior to starting the processing topology.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SessionWindowsExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SessionWindowsExample.java
@@ -49,10 +49,10 @@ import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
  * 2) Create the input/intermediate/output topics used by this example.
  * <pre>
  * {@code
- * $ bin/kafka-topics --create --topic play-events --partitions 1 \
- *                    --zookeeper localhost:2181
- * $ bin/kafka-topics --create --topic play-events-per-session --partitions 1 \
- *                    --zookeeper localhost:2181
+ * $ bin/kafka-topics --create --topic play-events \
+ *                    --zookeeper localhost:2181 --partitions 1 --replication-factor 1
+ * $ bin/kafka-topics --create --topic play-events-per-session \
+ *                    --zookeeper localhost:2181 --partitions 1 --replication-factor 1
  * }</pre>
  * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be
  * `bin/kafka-topics.sh ...`.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SessionWindowsExampleDriver.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SessionWindowsExampleDriver.java
@@ -51,8 +51,8 @@ public class SessionWindowsExampleDriver {
   public static final int NUM_RECORDS_SENT = 8;
 
   public static void main(String[] args) {
-    final String bootstrapServers = "localhost:9092";
-    final String schemaRegistryUrl = "http://localhost:8081";
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 1 ? args[1] : "http://localhost:8081";
     producePlayEvents(bootstrapServers, schemaRegistryUrl);
     consumeOutput(bootstrapServers);
   }

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExample.java
@@ -82,12 +82,13 @@ public class SumLambdaExample {
   static final String NUMBERS_TOPIC = "numbers-topic";
 
   public static void main(final String[] args) throws Exception {
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
     final Properties streamsConfiguration = new Properties();
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "sum-lambda-example");
     // Where to find Kafka broker(s).
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Specify default (de)serializers for record keys and for record values.
     streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass().getName());
     streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass().getName());

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExample.java
@@ -65,7 +65,7 @@ import java.util.Properties;
  * <pre>
  * {@code
  * $ bin/kafka-console-consumer --topic sum-of-odd-numbers-topic --from-beginning \
- *                              --zookeeper localhost:2181 \
+ *                              --new-consumer --bootstrap-server localhost:9092 \
  *                              --property value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer
  * }</pre>
  * You should see output data similar to:

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExampleDriver.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExampleDriver.java
@@ -48,13 +48,14 @@ import java.util.stream.IntStream;
 public class SumLambdaExampleDriver {
 
   public static void main(final String[] args) throws Exception {
-    produceInput();
-    consumeOutput();
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    produceInput(bootstrapServers);
+    consumeOutput(bootstrapServers);
   }
 
-  private static void consumeOutput() {
+  private static void consumeOutput(String bootstrapServers) {
     final Properties properties = new Properties();
-    properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
     properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
     properties.put(ConsumerConfig.GROUP_ID_CONFIG, "sum-lambda-example-consumer");
@@ -71,9 +72,9 @@ public class SumLambdaExampleDriver {
     }
   }
 
-  private static void produceInput() {
+  private static void produceInput(String bootstrapServers) {
     final Properties props = new Properties();
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
 

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/TopArticlesExampleDriver.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/TopArticlesExampleDriver.java
@@ -53,23 +53,25 @@ import java.util.stream.IntStream;
 public class TopArticlesExampleDriver {
 
   public static void main(String[] args) throws IOException {
-    produceInputs();
-    consumeOutput();
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 1 ? args[1] : "http://localhost:8081";
+    produceInputs(bootstrapServers, schemaRegistryUrl);
+    consumeOutput(bootstrapServers, schemaRegistryUrl);
   }
 
-  private static void produceInputs() throws IOException {
+  private static void produceInputs(String bootstrapServers, String schemaRegistryUrl) throws IOException {
     final String[] users = {"erica", "bob", "joe", "damian", "tania", "phil", "sam",
         "lauren", "joseph"};
     final String[] industries = {"engineering", "telco", "finance", "health", "science"};
     final String[] pages = {"index.html", "news.html", "contact.html", "about.html", "stuff.html"};
 
     final Properties props = new Properties();
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
         StringSerializer.class);
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
         io.confluent.kafka.serializers.KafkaAvroSerializer.class);
-    props.put("schema.registry.url", "http://localhost:8081");
+    props.put("schema.registry.url", schemaRegistryUrl);
     final KafkaProducer<String, GenericRecord> producer = new KafkaProducer<>(props);
 
     final GenericRecordBuilder pageViewBuilder =
@@ -92,13 +94,13 @@ public class TopArticlesExampleDriver {
     producer.flush();
   }
 
-  private static void consumeOutput() {
+  private static void consumeOutput(String bootstrapServers, String schemaRegistryUrl) {
     final Properties consumerProperties = new Properties();
-    consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
               StringDeserializer.class);
-    consumerProperties.put("schema.registry.url", "http://localhost:8081");
+    consumerProperties.put("schema.registry.url", schemaRegistryUrl);
     consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG,
         "top-articles-lambda-example-consumer");
     consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/TopArticlesLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/TopArticlesLambdaExample.java
@@ -93,7 +93,6 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  */
 public class TopArticlesLambdaExample {
 
-  private static final String SCHEMA_REGISTRY_URL = "http://localhost:8081";
   static final String TOP_NEWS_PER_INDUSTRY_TOPIC = "TopNewsPerIndustry";
   static final String PAGE_VIEWS = "PageViews";
 
@@ -106,8 +105,11 @@ public class TopArticlesLambdaExample {
   }
 
   public static void main(final String[] args) throws Exception {
-    final KafkaStreams streams = buildTopArticlesStream("localhost:9092",
-      SCHEMA_REGISTRY_URL,
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 1 ? args[1] : "http://localhost:8081";
+    final KafkaStreams streams = buildTopArticlesStream(
+        bootstrapServers,
+        schemaRegistryUrl,
       "/tmp/kafka-streams");
     // Always (and unconditionally) clean local state prior to starting the processing topology.
     // We opt for this unconditional call here because this will make it easier for you to play around with the example

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/UserRegionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/UserRegionLambdaExample.java
@@ -81,7 +81,7 @@ import java.util.Properties;
  * <pre>
  * {@code
  * $ bin/kafka-console-consumer --topic LargeRegions --from-beginning \
- *                              --zookeeper localhost:2181 \
+ *                              --new-consumer --bootstrap-server localhost:9092 \
  *                              --property print.key=true \
  *                              --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer
  * }</pre>

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/UserRegionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/UserRegionLambdaExample.java
@@ -98,12 +98,13 @@ import java.util.Properties;
 public class UserRegionLambdaExample {
 
   public static void main(final String[] args) throws Exception {
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
     final Properties streamsConfiguration = new Properties();
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "user-region-lambda-example");
     // Where to find Kafka broker(s).
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Specify default (de)serializers for record keys and for record values.
     streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
     streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/WikipediaFeedAvroExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/WikipediaFeedAvroExample.java
@@ -35,20 +35,14 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 
 
 /**
- * Computes, for every minute the number of new user feeds from the Wikipedia feed irc stream.
- * Same as {@link WikipediaFeedAvroLambdaExample} but does not use lambda expressions and thus works on
- * Java 7+.
- * <p>
- * Note: The specific Avro binding is used for serialization/deserialization, where the {@code WikiFeed}
- * class is auto-generated from its Avro schema by the maven avro plugin. See {@code wikifeed.avsc}
- * under {@code src/main/resources/avro/io/confluent/examples/streams/}.
- * <p>
- * <br>
- * HOW TO RUN THIS EXAMPLE
- * <p>
- * 1) Start Zookeeper, Kafka, and Confluent Schema Registry. Please refer to <a href='http://docs.confluent.io/current/quickstart.html#quickstart'>QuickStart</a>.
- * <p>
- * 2) Create the input/intermediate/output topics used by this example.
+ * Computes, for every minute the number of new user feeds from the Wikipedia feed irc stream. Same
+ * as {@link WikipediaFeedAvroLambdaExample} but does not use lambda expressions and thus works on
+ * Java 7+. <p> Note: The specific Avro binding is used for serialization/deserialization, where the
+ * {@code WikiFeed} class is auto-generated from its Avro schema by the maven avro plugin. See
+ * {@code wikifeed.avsc} under {@code src/main/resources/avro/io/confluent/examples/streams/}. <p>
+ * <br> HOW TO RUN THIS EXAMPLE <p> 1) Start Zookeeper, Kafka, and Confluent Schema Registry. Please
+ * refer to <a href='http://docs.confluent.io/current/quickstart.html#quickstart'>QuickStart</a>.
+ * <p> 2) Create the input/intermediate/output topics used by this example.
  * <pre>
  * {@code
  * $ bin/kafka-topics --create --topic WikipediaFeed \
@@ -56,11 +50,9 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  * $ bin/kafka-topics --create --topic WikipediaStats \
  *                    --zookeeper localhost:2181 --partitions 1 --replication-factor 1
  * }</pre>
- * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be {@code bin/kafka-topics.sh ...}.
- * <p>
- * 3) Start this example application either in your IDE or on the command line.
- * <p>
- * If via the command line please refer to <a href='https://github.com/confluentinc/examples/tree/3.2.x/kafka-streams#packaging-and-running'>Packaging</a>.
+ * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be {@code
+ * bin/kafka-topics.sh ...}. <p> 3) Start this example application either in your IDE or on the
+ * command line. <p> If via the command line please refer to <a href='https://github.com/confluentinc/examples/tree/3.2.x/kafka-streams#packaging-and-running'>Packaging</a>.
  * Once packaged you can then run:
  * <pre>
  * {@code
@@ -80,14 +72,16 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 
 public class WikipediaFeedAvroExample {
 
-  public static final String WIKIPEDIA_FEED = "WikipediaFeed";
-  public static final String WIKIPEDIA_STATS = "WikipediaStats";
+  static final String WIKIPEDIA_FEED = "WikipediaFeed";
+  static final String WIKIPEDIA_STATS = "WikipediaStats";
 
   public static void main(final String[] args) throws Exception {
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 1 ? args[1] : "http://localhost:8081";
     final KafkaStreams streams = buildWikipediaFeed(
-      "localhost:9092",
-      "http://localhost:8081",
-      "/tmp/kafka-streams");
+        bootstrapServers,
+        schemaRegistryUrl,
+        "/tmp/kafka-streams");
     // Always (and unconditionally) clean local state prior to starting the processing topology.
     // We opt for this unconditional call here because this will make it easier for you to play around with the example
     // when resetting the application for doing a re-run (via the Application Reset Tool,
@@ -140,23 +134,23 @@ public class WikipediaFeedAvroExample {
 
     // aggregate the new feed counts of by user
     final KTable<String, Long> aggregated = feeds
-            // filter out old feeds
-            .filter(new Predicate<String, WikiFeed>() {
-              @Override
-              public boolean test(final String dummy, final WikiFeed value) {
-                return value.getIsNew();
-              }
-            })
-            // map the user id as key
-            .map(new KeyValueMapper<String, WikiFeed, KeyValue<String, WikiFeed>>() {
-              @Override
-              public KeyValue<String, WikiFeed> apply(final String key, final WikiFeed value) {
-                return new KeyValue<>(value.getUser(), value);
-              }
-            })
-            // no need to specify explicit serdes because the resulting key and value types match our default serde settings
-            .groupByKey()
-            .count("Counts");
+        // filter out old feeds
+        .filter(new Predicate<String, WikiFeed>() {
+          @Override
+          public boolean test(final String dummy, final WikiFeed value) {
+            return value.getIsNew();
+          }
+        })
+        // map the user id as key
+        .map(new KeyValueMapper<String, WikiFeed, KeyValue<String, WikiFeed>>() {
+          @Override
+          public KeyValue<String, WikiFeed> apply(final String key, final WikiFeed value) {
+            return new KeyValue<>(value.getUser(), value);
+          }
+        })
+        // no need to specify explicit serdes because the resulting key and value types match our default serde settings
+        .groupByKey()
+        .count("Counts");
 
     // write to the result topic, need to override serdes
     aggregated.to(stringSerde, longSerde, WIKIPEDIA_STATS);

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/WikipediaFeedAvroExampleDriver.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/WikipediaFeedAvroExampleDriver.java
@@ -48,21 +48,23 @@ import io.confluent.examples.streams.avro.WikiFeed;
 public class WikipediaFeedAvroExampleDriver {
 
   public static void main(final String[] args) throws IOException {
-    produceInputs();
-    consumeOutput();
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 1 ? args[1] : "http://localhost:8081";
+    produceInputs(bootstrapServers, schemaRegistryUrl);
+    consumeOutput(bootstrapServers, schemaRegistryUrl);
   }
 
-  private static void produceInputs() throws IOException {
+  private static void produceInputs(String bootstrapServers, String schemaRegistryUrl) throws IOException {
     final String[] users = {"erica", "bob", "joe", "damian", "tania", "phil", "sam",
             "lauren", "joseph"};
 
     final Properties props = new Properties();
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
             StringSerializer.class);
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
             io.confluent.kafka.serializers.KafkaAvroSerializer.class);
-    props.put("schema.registry.url", "http://localhost:8081");
+    props.put("schema.registry.url", schemaRegistryUrl);
     final KafkaProducer<String, WikiFeed> producer = new KafkaProducer<>(props);
 
     final Random random = new Random();
@@ -75,12 +77,12 @@ public class WikipediaFeedAvroExampleDriver {
     producer.flush();
   }
 
-  private static void consumeOutput() {
+  private static void consumeOutput(String bootstrapServers, String schemaRegistryUrl) {
     final Properties consumerProperties = new Properties();
-    consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    consumerProperties.put("schema.registry.url", "http://localhost:8081");
+    consumerProperties.put("schema.registry.url", schemaRegistryUrl);
     consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG, "wikipedia-feed-example-consumer");
     consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     final KafkaConsumer<String, Long> consumer = new KafkaConsumer<>(consumerProperties,

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/WikipediaFeedAvroLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/WikipediaFeedAvroLambdaExample.java
@@ -32,19 +32,14 @@ import io.confluent.examples.streams.utils.SpecificAvroSerde;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 
 /**
- * Computes, for every minute the number of new user feeds from the Wikipedia feed irc stream.
- * Same as {@link WikipediaFeedAvroExample} but uses lambda expressions and thus only works on Java 8+.
- * <p>
- * Note: The specific Avro binding is used for serialization/deserialization, where the {@code WikiFeed}
- * class is auto-generated from its Avro schema by the maven avro plugin. See {@code wikifeed.avsc}
- * under {@code src/main/resources/avro/io/confluent/examples/streams/}.
- * <p>
- * <br>
- * HOW TO RUN THIS EXAMPLE
- * <p>
- * 1) Start Zookeeper, Kafka, and Confluent Schema Registry. Please refer to <a href='http://docs.confluent.io/current/quickstart.html#quickstart'>QuickStart</a>.
- * <p>
- * 2) Create the input/intermediate/output topics used by this example.
+ * Computes, for every minute the number of new user feeds from the Wikipedia feed irc stream. Same
+ * as {@link WikipediaFeedAvroExample} but uses lambda expressions and thus only works on Java 8+.
+ * <p> Note: The specific Avro binding is used for serialization/deserialization, where the {@code
+ * WikiFeed} class is auto-generated from its Avro schema by the maven avro plugin. See {@code
+ * wikifeed.avsc} under {@code src/main/resources/avro/io/confluent/examples/streams/}. <p> <br> HOW
+ * TO RUN THIS EXAMPLE <p> 1) Start Zookeeper, Kafka, and Confluent Schema Registry. Please refer to
+ * <a href='http://docs.confluent.io/current/quickstart.html#quickstart'>QuickStart</a>. <p> 2)
+ * Create the input/intermediate/output topics used by this example.
  * <pre>
  * {@code
  * $ bin/kafka-topics --create --topic WikipediaFeed \
@@ -52,11 +47,9 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
  * $ bin/kafka-topics --create --topic WikipediaStats \
  *                    --zookeeper localhost:2181 --partitions 1 --replication-factor 1
  * }</pre>
- * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be {@code bin/kafka-topics.sh ...}.
- * <p>
- * 3) Start this example application either in your IDE or on the command line.
- * <p>
- * If via the command line please refer to <a href='https://github.com/confluentinc/examples/tree/3.2.x/kafka-streams#packaging-and-running'>Packaging</a>.
+ * Note: The above commands are for the Confluent Platform. For Apache Kafka it should be {@code
+ * bin/kafka-topics.sh ...}. <p> 3) Start this example application either in your IDE or on the
+ * command line. <p> If via the command line please refer to <a href='https://github.com/confluentinc/examples/tree/3.2.x/kafka-streams#packaging-and-running'>Packaging</a>.
  * Once packaged you can then run:
  * <pre>
  * {@code
@@ -76,10 +69,12 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 public class WikipediaFeedAvroLambdaExample {
 
   public static void main(final String[] args) throws Exception {
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 1 ? args[1] : "http://localhost:8081";
     final KafkaStreams streams = buildWikipediaFeed(
-      "localhost:9092",
-      "http://localhost:8081",
-      "/tmp/kafka-streams");
+        bootstrapServers,
+        schemaRegistryUrl,
+        "/tmp/kafka-streams");
     // Always (and unconditionally) clean local state prior to starting the processing topology.
     // We opt for this unconditional call here because this will make it easier for you to play around with the example
     // when resetting the application for doing a re-run (via the Application Reset Tool,
@@ -116,7 +111,7 @@ public class WikipediaFeedAvroLambdaExample {
     // Records should be flushed every 10 seconds. This is less than the default
     // in order to keep this example interactive.
     streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10 * 1000);
- 
+
     final Serde<String> stringSerde = Serdes.String();
     final Serde<Long> longSerde = Serdes.Long();
 
@@ -127,13 +122,13 @@ public class WikipediaFeedAvroLambdaExample {
 
     // aggregate the new feed counts of by user
     final KTable<String, Long> aggregated = feeds
-      // filter out old feeds
-      .filter((dummy, value) -> value.getIsNew())
-      // map the user id as key
-      .map((key, value) -> new KeyValue<>(value.getUser(), value))
-      // no need to specify explicit serdes because the resulting key and value types match our default serde settings
-      .groupByKey()
-      .count("Counts");
+        // filter out old feeds
+        .filter((dummy, value) -> value.getIsNew())
+        // map the user id as key
+        .map((key, value) -> new KeyValue<>(value.getUser(), value))
+        // no need to specify explicit serdes because the resulting key and value types match our default serde settings
+        .groupByKey()
+        .count("Counts");
 
     // write to the result topic, need to override serdes
     aggregated.to(stringSerde, longSerde, WikipediaFeedAvroExample.WIKIPEDIA_STATS);

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
@@ -78,7 +78,7 @@ import java.util.regex.Pattern;
  * <pre>
  * {@code
  * $ bin/kafka-console-consumer --topic WordsWithCountsTopic --from-beginning \
- *                              --zookeeper localhost:2181 \
+ *                              --new-consumer --bootstrap-server localhost:9092 \
  *                              --property print.key=true \
  *                              --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer
  * }</pre>

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
@@ -107,12 +107,13 @@ import java.util.regex.Pattern;
 public class WordCountLambdaExample {
 
   public static void main(final String[] args) throws Exception {
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
     final Properties streamsConfiguration = new Properties();
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "wordcount-lambda-example");
     // Where to find Kafka broker(s).
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Specify default (de)serializers for record keys and for record values.
     streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
     streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesDriver.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesDriver.java
@@ -43,6 +43,7 @@ import java.util.Random;
 public class WordCountInteractiveQueriesDriver {
 
   public static void main(String [] args) throws Exception {
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
     final List<String> inputValues = Arrays.asList("hello world",
                                                    "all streams lead to kafka",
                                                    "streams",
@@ -58,7 +59,7 @@ public class WordCountInteractiveQueriesDriver {
                                                    "king of the world");
 
     Properties producerConfig = new Properties();
-    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
     producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
     producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
@@ -137,17 +137,18 @@ public class WordCountInteractiveQueriesExample {
   static final String TEXT_LINES_TOPIC = "TextLinesTopic";
 
   public static void main(String[] args) throws Exception {
-    if (args.length != 1) {
-      throw new IllegalArgumentException("usage ... portForRestEndPoint");
+    if (args.length == 0 || args.length > 2) {
+      throw new IllegalArgumentException("usage: ... <portForRestEndPoint> [<bootstrap.servers> (optional)]");
     }
     final int port = Integer.valueOf(args[0]);
+    final String bootstrapServers = args.length > 1 ? args[1] : "localhost:9092";
 
     Properties streamsConfiguration = new Properties();
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "interactive-queries-example");
     // Where to find Kafka broker(s).
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Provide the details of our embedded http service that we'll use to connect to this streams
     // instance and discover locations of stores.
     streamsConfiguration.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + port);

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExample.java
@@ -173,15 +173,16 @@ public class KafkaMusicExample {
   static final String TOP_FIVE_KEY = "all";
 
   public static void main(String[] args) throws Exception {
-    if (args.length != 1) {
-      throw new IllegalArgumentException("usage ... portForRestEndPoint");
+    if (args.length == 0 || args.length > 3) {
+      throw new IllegalArgumentException("usage: ... <portForRestEndPoint> " +
+          "[<bootstrap.servers> (optional)] [<schema.registry.url> (optional)]");
     }
     final int port = Integer.valueOf(args[0]);
+    final String bootstrapServers = args.length > 1 ? args[1] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 2 ? args[2] : "http://localhost:8081";
 
-
-
-    final KafkaStreams streams = createChartsStreams("localhost:9092",
-                                                     "http://localhost:8081",
+    final KafkaStreams streams = createChartsStreams(bootstrapServers,
+                                                     schemaRegistryUrl,
                                                      port,
                                                      "/tmp/kafka-streams");
 

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleDriver.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleDriver.java
@@ -52,6 +52,8 @@ import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 public class KafkaMusicExampleDriver {
 
   public static void main(String [] args) throws Exception {
+    final String bootstrapServers = args.length > 0 ? args[0] : "localhost:9092";
+    final String schemaRegistryUrl = args.length > 1 ? args[1] : "http://localhost:8081";
     final List<Song> songs = Arrays.asList(new Song(1L,
                                                     "Fresh Fruit For Rotting Vegetables",
                                                     "Dead Kennedys",
@@ -117,9 +119,8 @@ public class KafkaMusicExampleDriver {
     );
 
     final Properties props = new Properties();
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 
-    final String schemaRegistryUrl = "http://localhost:8081";
     final CachedSchemaRegistryClient
         schemaRegistry =
         new CachedSchemaRegistryClient(schemaRegistryUrl, 100);

--- a/kafka-streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
+++ b/kafka-streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
@@ -93,12 +93,13 @@ import org.apache.kafka.streams.kstream.{KStream, KStreamBuilder}
 object MapFunctionScalaExample {
 
   def main(args: Array[String]) {
-    val builder: KStreamBuilder = new KStreamBuilder
+    val bootstrapServers = if (args.length > 0) args(0) else "localhost:9092"
+    val builder = new KStreamBuilder
 
     val streamingConfig = {
       val settings = new Properties
       settings.put(StreamsConfig.APPLICATION_ID_CONFIG, "map-function-scala-example")
-      settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+      settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
       // Specify default (de)serializers for record keys and for record values.
       settings.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray.getClass.getName)
       settings.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)

--- a/kafka-streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
+++ b/kafka-streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
@@ -77,8 +77,8 @@ import org.apache.kafka.streams.kstream.{KStream, KStreamBuilder}
   * 5) Inspect the resulting data in the output topics, e.g. via `kafka-console-consumer`.
   *
   * {{{
-  * $ bin/kafka-console-consumer --zookeeper localhost:2181 --topic UppercasedTextLinesTopic --from-beginning
-  * $ bin/kafka-console-consumer --zookeeper localhost:2181 --topic OriginalAndUppercasedTopic --from-beginning
+  * $ bin/kafka-console-consumer --new-consumer --bootstrap-server localhost:9092 --topic UppercasedTextLinesTopic --from-beginning
+  * $ bin/kafka-console-consumer --new-consumer --bootstrap-server localhost:9092 --topic OriginalAndUppercasedTopic --from-beginning
   * }}}
   *
   * You should see output data similar to:


### PR DESCRIPTION
Plus a few more minor changes.

The purpose of this PR is:

- To allow developers working on Windows OS to use the examples under `src/main/` as-is, because typically these developers won't have Kafka running on their local machine.
- To allow users of our Confluent docker images to run the examples against a containerized Kafka cluster (which requires a different broker port, most notably).