### PR TITLE
Upgrade Jersey version to fix Jersey warning about existing previous registration

### DIFF
--- a/kafka-streams/pom.xml
+++ b/kafka-streams/pom.xml
@@ -45,7 +45,7 @@
         <chill.version>0.9.2</chill.version>
         <jetty.version>9.2.12.v20150709</jetty.version>
         <jackson.version>2.8.8</jackson.version>
-        <jersey.version>2.19</jersey.version>
+        <jersey.version>2.25</jersey.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Warning message was similar to:

    org.glassfish.jersey.internal.Errors logErrors
    WARNING: The following warnings have been detected: WARNING: Cannot create new registration for component type class com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper: Existing previous registration found for the type.