### PR TITLE
MINOR: minor fixes

### DIFF
--- a/kafka-streams/README.md
+++ b/kafka-streams/README.md
@@ -343,11 +343,11 @@ $ java -cp target/streams-examples-3.3.0-SNAPSHOT-standalone.jar \
   io.confluent.examples.streams.WordCountLambdaExample
 ```
 
-which will then try to read from the specified input topic (in the above example it is ``TextLinesTopic``), 
-execute the processing logic, and finally try to write back to the specified output topic (in the above example it is ``WordsWithCountsTopic``).
-So in order to observe the expected output stream, you will need to also start a console producer to send messages into the input topic
-and start a console consumer to continuously read  from the output topic. More details in how to run the examples can be found
-in the java docs of each example code.
+The application will try to read from the specified input topic (in the above example it is ``TextLinesTopic``), 
+execute the processing logic, and then try to write back to the specified output topic (in the above example it is ``WordsWithCountsTopic``).
+In order to observe the expected output stream, you will need to start a console producer to send messages into the input topic
+and start a console consumer to continuously read from the output topic. More details in how to run the examples can be found
+in the [java docs](src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java#L29) of each example code.
 
 If you want to turn on log4j while running your example application, you can edit the [log4j.properties](src/main/resources/log4j.properties) file 
 and then execute as follows:

--- a/kafka-streams/README.md
+++ b/kafka-streams/README.md
@@ -343,10 +343,28 @@ $ java -cp target/streams-examples-3.3.0-SNAPSHOT-standalone.jar \
   io.confluent.examples.streams.WordCountLambdaExample
 ```
 
+which will then try to read from the specified input topic (in the above example it is ``TextLinesTopic``), 
+execute the processing logic, and finally try to write back to the specified output topic (in the above example it is ``WordsWithCountsTopic``).
+So in order to observe the expected output stream, you will need to also start a console producer to send messages into the input topic
+and start a console consumer to continuously read  from the output topic. More details in how to run the examples can be found
+in the java docs of each example code.
+
+If you want to turn on log4j while running your example application, you can edit the [log4j.properties](src/main/resources/log4j.properties) file 
+and then execute as follows:
+
+```shell
+# Run an example application from the standalone jar.
+# Here: `WordCountLambdaExample`
+$ java -cp target/streams-examples-3.3.0-SNAPSHOT-standalone.jar \
+  -Dlog4j.configuration=file:src/main/resources/log4j.properties \
+  io.confluent.examples.streams.WordCountLambdaExample
+```
+
 Keep in mind that the machine on which you run the command above must have access to the Kafka/ZK clusters you
 configured in the code examples.  By default, the code examples assume the Kafka cluster is accessible via
 `localhost:9092` (aka Kafka's ``bootstrap.servers`` parameter) and the ZooKeeper ensemble via `localhost:2181`.
 You can override the default ``bootstrap.servers`` parameter through a command line argument.
+
 
 
 <a name="development"/>

--- a/kafka-streams/pom.xml
+++ b/kafka-streams/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <kafka.version>0.11.0.0-SNAPSHOT</kafka.version>
+        <kafka.version>0.11.1.0-SNAPSHOT</kafka.version>
         <kafka.scala.version>2.11</kafka.scala.version>
         <scala.version>${kafka.scala.version}.8</scala.version>
         <confluent.version>3.3.0-SNAPSHOT</confluent.version>

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/AnomalyDetectionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/AnomalyDetectionLambdaExample.java
@@ -108,6 +108,7 @@ public class AnomalyDetectionLambdaExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "anomaly-detection-lambda-example");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "anomaly-detection-lambda-example-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Specify default (de)serializers for record keys and for record values.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/ApplicationResetExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/ApplicationResetExample.java
@@ -115,6 +115,7 @@ public class ApplicationResetExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "application-reset-demo");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "interactive-queries-example-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Specify default (de)serializers for record keys and for record values.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/ApplicationResetExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/ApplicationResetExample.java
@@ -115,7 +115,7 @@ public class ApplicationResetExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "application-reset-demo");
-    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "interactive-queries-example-client");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "application-reset-demo-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Specify default (de)serializers for record keys and for record values.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/GlobalKTablesExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/GlobalKTablesExample.java
@@ -122,6 +122,7 @@ public class GlobalKTablesExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "global-tables-example");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "global-tables-example-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDir);

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/MapFunctionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/MapFunctionLambdaExample.java
@@ -96,6 +96,7 @@ public class MapFunctionLambdaExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "map-function-lambda-example");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "map-function-lambda-example-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Specify default (de)serializers for record keys and for record values.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionExample.java
@@ -118,6 +118,7 @@ public class PageViewRegionExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "pageview-region-example");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "pageview-region-example-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Where to find the Confluent schema registry instance(s)

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/PageViewRegionLambdaExample.java
@@ -114,6 +114,7 @@ public class PageViewRegionLambdaExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "pageview-region-lambda-example");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "pageview-region-lambda-example-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Where to find the Confluent schema registry instance(s)

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SecureKafkaStreamsExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SecureKafkaStreamsExample.java
@@ -143,6 +143,7 @@ public class SecureKafkaStreamsExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "secure-kafka-streams-app");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "secure-kafka-streams-app-client");
     // Where to find secure (!) Kafka broker(s).  In the VM, the broker listens on port 9093 for
     // SSL connections.
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, secureBootstrapServers);

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SessionWindowsExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SessionWindowsExample.java
@@ -134,6 +134,7 @@ public class SessionWindowsExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     config.put(StreamsConfig.APPLICATION_ID_CONFIG, "session-windows-example");
+    config.put(StreamsConfig.CLIENT_ID_CONFIG, "session-windows-example-client");
     // Where to find Kafka broker(s).
     config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     config.put(StreamsConfig.STATE_DIR_CONFIG, stateDir);

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/SumLambdaExample.java
@@ -87,6 +87,7 @@ public class SumLambdaExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "sum-lambda-example");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "sum-lambda-example-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Specify default (de)serializers for record keys and for record values.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/TopArticlesLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/TopArticlesLambdaExample.java
@@ -135,6 +135,7 @@ public class TopArticlesLambdaExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "top-articles-lambda-example");
+      streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "top-articles-lambda-example-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Where to find the Confluent schema registry instance(s)

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/UserRegionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/UserRegionLambdaExample.java
@@ -103,6 +103,7 @@ public class UserRegionLambdaExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "user-region-lambda-example");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "user-region-lambda-example-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Specify default (de)serializers for record keys and for record values.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/WikipediaFeedAvroExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/WikipediaFeedAvroExample.java
@@ -113,6 +113,7 @@ public class WikipediaFeedAvroExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "wordcount-avro-example");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "wordcount-avro-example-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Where to find the Confluent schema registry instance(s)

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/WikipediaFeedAvroLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/WikipediaFeedAvroLambdaExample.java
@@ -101,6 +101,7 @@ public class WikipediaFeedAvroLambdaExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "wordcount-avro-lambda-example");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "wordcount-avro-lambda-example-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Where to find the Confluent schema registry instance(s)

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
@@ -113,6 +113,7 @@ public class WordCountLambdaExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "wordcount-lambda-example");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "wordcount-lambda-example-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Specify default (de)serializers for record keys and for record values.

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
@@ -147,6 +147,7 @@ public class WordCountInteractiveQueriesExample {
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "interactive-queries-example");
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "interactive-queries-example-client");
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Provide the details of our embedded http service that we'll use to connect to this streams

--- a/kafka-streams/src/main/resources/log4j.properties
+++ b/kafka-streams/src/main/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=WARN, stdout
+log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
@@ -10,7 +10,8 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p [%t] %m (%c)%n
 
 # Squelch expected error messages like:
 #     java.lang.IllegalStateException: This consumer has already been closed.
-log4j.logger.org.apache.kafka.streams.processor.internals.StreamThread=FATAL, stdout
+log4j.logger.org.apache.kafka.streams.processor.internals.StreamThread=INFO, stdout
+log4j.additivity.org.apache.kafka.streams.processor.internals.StreamThread=false
 
 # Enable for debugging if need be
 #log4j.logger.io.confluent=DEBUG, stdout


### PR DESCRIPTION
0. Bump up the AK version to 0.11.1.0 (will need to create 3.3.x branch that depends on 0.11.0.0 after this is merged).

1. Set the log4j default entry to INFO for users to be able to check the log4j outputs, also update the corresponding README file to indicate console producer / consumer are usually needed.

2. Specify the client-id in all the examples to make the thread-id be more readable.