### PR TITLE
Fix doc: proper main class in the start instance command

### DIFF
--- a/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
@@ -74,7 +74,7 @@ import java.util.Properties;
  * <pre>
  * {@code
  * $ java -cp target/streams-examples-3.3.0-standalone.jar \
- *      io.confluent.examples.streams.interactivequeries.InteractiveQueriesExample 7070
+ *      io.confluent.examples.streams.interactivequeries.WordCountInteractiveQueriesExample 7070
  * }
  * </pre>
  *
@@ -85,7 +85,7 @@ import java.util.Properties;
  * <pre>
  * {@code
  * $ java -cp target/streams-examples-3.3.0-standalone.jar \
- *      io.confluent.examples.streams.interactivequeries.InteractiveQueriesExample 7071
+ *      io.confluent.examples.streams.interactivequeries.WordCountInteractiveQueriesExample 7071
  * }
  * </pre>
  *


### PR DESCRIPTION
This PR fixes the following issue: the starting application command within the documentation of the WordCountInteractive queries example was not pointing to the proper main class.