### PR TITLE
Fixing build failure

### DIFF
--- a/ccloud/java-clients/pom.xml
+++ b/ccloud/java-clients/pom.xml
@@ -35,9 +35,9 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <kafka.version>1.0.0-SNAPSHOT</kafka.version>
+        <kafka.version>1.0.0</kafka.version>
         <kafka.scala.version>2.11</kafka.scala.version>
-        <confluent.version>4.0.0-SNAPSHOT</confluent.version>
+        <confluent.version>4.0.0</confluent.version>
         <slf4j-api.version>1.7.6</slf4j-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
Fixes build failure (mvn clean package) by removing SNAPSHOT tags which breaks the current examples page here: https://docs.confluent.io/current/quickstart/cloud-quickstart.html#step-4-create-topics-and-produce-and-consume-to-kafka