### PR TITLE
Fixing build failure on "mvn clean package"

### DIFF
--- a/ccloud/java-clients/pom.xml
+++ b/ccloud/java-clients/pom.xml
@@ -35,9 +35,9 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <kafka.version>1.1.0-SNAPSHOT</kafka.version>
+        <kafka.version>1.1.0</kafka.version>
         <kafka.scala.version>2.11</kafka.scala.version>
-        <confluent.version>4.1.0-SNAPSHOT</confluent.version>
+        <confluent.version>4.1.0</confluent.version>
         <slf4j-api.version>1.7.6</slf4j-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
Fixing build failure (mvn clean package) due to SNAPSHOT tag on versions of Kafka and Confluent. Currently our examples page doesn't work as a result: https://docs.confluent.io/current/quickstart/cloud-quickstart.html#step-5-run-java-examples