### PR TITLE
Fixed incomplete move from 4.1.1 to 5.0.0

### DIFF
--- a/postgres-debezium-ksql-elasticsearch/docker-compose/docker-compose.yml
+++ b/postgres-debezium-ksql-elasticsearch/docker-compose/docker-compose.yml
@@ -2,13 +2,13 @@
 version: '2'
 services:
   zookeeper:
-    image: "confluentinc/cp-zookeeper:4.1.1"
+    image: "confluentinc/cp-zookeeper:5.0.0"
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: "confluentinc/cp-enterprise-kafka:4.1.1"
+    image: "confluentinc/cp-enterprise-kafka:5.0.0"
     ports:
       - '9092:9092'
     depends_on:
@@ -30,10 +30,12 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: "confluentinc/cp-schema-registry:4.1.1"
+    image: "confluentinc/cp-schema-registry:5.0.0"
     depends_on:
       - zookeeper
       - kafka
+    ports:
+      - "8081:8081"
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:2181
@@ -72,7 +74,7 @@ services:
 
   # KSQL
   ksql-server:
-    image: "confluentinc/ksql-cli:5.0.0-beta30"
+    image: "confluentinc/ksql-cli:5.0.0"
     depends_on:
       - kafka
       - schema-registry
@@ -124,7 +126,7 @@ services:
 
   # Runs the Kafka KSQL data generator for ratings
   datagen-ratings:
-    image: "confluentinc/ksql-examples:4.1.0"
+    image: "confluentinc/ksql-examples:5.0.0"
     depends_on:
       - kafka
       - schema-registry
@@ -138,7 +140,7 @@ services:
                        cub sr-ready schema-registry 8081 300 && \
                        echo Waiting a few seconds for topic creation to finish... && \
                        sleep 20 && \
-                       java -jar /usr/share/java/ksql-examples/ksql-examples-4.1.1-SNAPSHOT-standalone.jar quickstart=ratings format=avro topic=ratings maxInterval=500 bootstrap-server=kafka:29092 schemaRegistryUrl=http://schema-registry:8081'"
+		               /usr/bin/ksql-datagen quickstart=ratings format=avro topic=ratings maxInterval=500 bootstrap-server=kafka:29092 schemaRegistryUrl=http://schema-registry:8081'"
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"
       KSQL_LOG4J_OPTS: "-Dlog4j.configuration=file:/etc/ksql/log4j-rolling.properties"
@@ -147,7 +149,7 @@ services:
       STREAMS_SCHEMA_REGISTRY_PORT: 8081
 
   ksql-cli:
-    image: "confluentinc/ksql-cli:5.0.0-beta30"
+    image: "confluentinc/ksql-cli:5.0.0"
     depends_on:
       - kafka
       - schema-registry


### PR DESCRIPTION
Some of the component versions in quickstart-demos/postgres-debezium-ksql-elasticsearch were still 4.1.1 or 5.0.0-beta3.

ksql-datagen is now packaged as an executable.