### PR TITLE
DEVX-435: Update demos for fix for KSQL 5.0 regression to WindowStart()

### DIFF
--- a/clickstream/ksql/ksql-clickstream-demo/demo/clickstream-schema.sql
+++ b/clickstream/ksql/ksql-clickstream-demo/demo/clickstream-schema.sql
@@ -1,8 +1,7 @@
-set 'commit.interval.ms'='2000';
-set 'cache.max.bytes.buffering'='10000000';
-set 'auto.offset.reset'='earliest';
+
 
 -- 1. SOURCE of ClickStream
+--DROP STREAM IF EXISTS clickstream;
 CREATE STREAM clickstream (_time bigint,time varchar, ip varchar, request varchar, status int, userid int, bytes bigint, agent varchar) with (kafka_topic = 'clickstream', value_format = 'json');
 
 
@@ -13,14 +12,17 @@ CREATE STREAM clickstream (_time bigint,time varchar, ip varchar, request varcha
 ----------------------------------------------------------------------------------------------------------------------------
 
  -- number of events per minute - think about key-for-distribution-purpose - shuffling etc - shouldnt use 'userid'
-CREATE table events_per_min AS SELECT userid, count(*) AS events FROM clickstream window TUMBLING (size 60 second) GROUP BY userid;
+--DROP TABLE IF EXISTS events_per_min;
+CREATE table events_per_min AS SELECT userid, WindowStart() AS EVENT_TS, count(*) AS events FROM clickstream window TUMBLING (size 60 second) GROUP BY userid;
 
 -- 3. BUILD STATUS_CODES
 -- static table
+--DROP TABLE IF EXISTS clickstream_codes;
 CREATE TABLE clickstream_codes (code int, definition varchar) with (key='code', kafka_topic = 'clickstream_codes', value_format = 'json');
 
 -- 4. BUILD PAGE_VIEWS
-CREATE TABLE pages_per_min AS SELECT userid, count(*) AS pages FROM clickstream WINDOW HOPPING (size 60 second, advance by 5 second) WHERE request like '%html%' GROUP BY userid ;
+--DROP TABLE IF EXISTS pages_per_min;
+CREATE TABLE pages_per_min AS SELECT userid, WindowStart() AS EVENT_TS, count(*) AS pages FROM clickstream WINDOW HOPPING (size 60 second, advance by 5 second) WHERE request like '%html%' GROUP BY userid ;
 
 ----------------------------------------------------------------------------------------------------------------------------
 -- URL STATUS CODES (Join AND Alert)
@@ -29,14 +31,20 @@ CREATE TABLE pages_per_min AS SELECT userid, count(*) AS pages FROM clickstream 
 ----------------------------------------------------------------------------------------------------------------------------
 
 -- Use 'HAVING' Filter to show ERROR codes > 400 where count > 5
-CREATE TABLE ERRORS_PER_MIN_ALERT AS SELECT status, count(*) AS errors FROM clickstream window HOPPING ( size 30 second, advance by 20 second) WHERE status > 400 GROUP BY status HAVING count(*) > 5 AND count(*) is not NULL;
+--DROP TABLE IF EXISTS ERRORS_PER_MIN_ALERT;
+CREATE TABLE ERRORS_PER_MIN_ALERT AS SELECT status, WindowStart() AS EVENT_TS, count(*) AS errors FROM clickstream window HOPPING ( size 30 second, advance by 20 second) WHERE status > 400 GROUP BY status HAVING count(*) > 5 AND count(*) is not NULL;
 
-CREATE table ERRORS_PER_MIN AS SELECT status, count(*) AS errors FROM clickstream window HOPPING ( size 60 second, advance by 5  second) WHERE status > 400 GROUP BY status;
+--DROP TABLE IF EXISTS ERRORS_PER_MIN;
+CREATE table ERRORS_PER_MIN AS SELECT status, WindowStart() AS EVENT_TS, count(*) AS errors FROM clickstream window HOPPING ( size 60 second, advance by 5  second) WHERE status > 400 GROUP BY status;
+
+-- VIEW - Enrich Codes with errors with Join to Status-Code definition
+--DROP STREAM IF EXISTS ENRICHED_ERROR_CODES;
+--DROP TABLE IF EXISTS ENRICHED_ERROR_CODES_COUNT;
 
 --Join using a STREAM
 CREATE STREAM ENRICHED_ERROR_CODES AS SELECT code, definition FROM clickstream LEFT JOIN clickstream_codes ON clickstream.status = clickstream_codes.code;
 -- Aggregate (count&groupBy) using a TABLE-Window
-CREATE TABLE ENRICHED_ERROR_CODES_COUNT AS SELECT code, definition, COUNT(*) AS count FROM ENRICHED_ERROR_CODES WINDOW TUMBLING (size 30 second) GROUP BY code, definition HAVING COUNT(*) > 1;
+CREATE TABLE ENRICHED_ERROR_CODES_COUNT AS SELECT code, WindowStart() AS EVENT_TS, definition, COUNT(*) AS count FROM ENRICHED_ERROR_CODES WINDOW TUMBLING (size 30 second) GROUP BY code, definition HAVING COUNT(*) > 1;
 
 
 ----------------------------------------------------------------------------------------------------------------------------
@@ -46,17 +54,37 @@ CREATE TABLE ENRICHED_ERROR_CODES_COUNT AS SELECT code, definition, COUNT(*) AS 
 ----------------------------------------------------------------------------------------------------------------------------
 
 -- users lookup table
+--DROP TABLE IF EXISTS WEB_USERS;
 CREATE TABLE WEB_USERS (user_id int, registered_At BIGINT, username varchar, first_name varchar, last_name varchar, city varchar, level varchar) with (key='user_id', kafka_topic = 'clickstream_users', value_format = 'json');
+
+-- Clickstream enriched with user account data
+--DROP STREAM IF EXISTS customer_clickstream;
+CREATE STREAM customer_clickstream WITH (PARTITIONS=2) AS SELECT userid, u.first_name, u.last_name, u.level, time, ip, request, status, agent FROM clickstream c LEFT JOIN web_users u ON c.userid = u.user_id;
+
+-- Find error views by important users
+----DROP STREAM IF EXISTS platinum_customers_with_errors
+--CREATE stream platinum_customers_with_errors WITH (PARTITIONS=2) AS seLECT * FROM customer_clickstream WHERE status > 400 AND level = 'Platinum';
+
+-- Find error views by important users in one shot
+----DROP STREAM IF EXISTS platinum_errors;
+--CREATE STREAM platinum_errors WITH (PARTITIONS=2) AS SELECT userid, u.first_name, u.last_name, u.city, u.level, time, ip, request, status, agent FROM clickstream c LEFT JOIN web_users u ON c.userid = u.user_id WHERE status > 400 AND level = 'Platinum';
+--
+---- Trend of errors from important users
+----DROP TABLE IF EXISTS platinum_page_errors_per_5_min;
+--CREATE TABLE platinum_errors_per_5_min AS SELECT userid, first_name, last_name, city, count(*) AS running_count FROM platinum_errors WINDOW TUMBLING (SIZE 5 MINUTE) WHERE request LIKE '%html%' GROUP BY userid, first_name, last_name, city;
+
 
 ----------------------------------------------------------------------------------------------------------------------------
 -- User experience monitoring
 --
 -- View IP, username and City Versus web-site-activity (hits)
 ----------------------------------------------------------------------------------------------------------------------------
+--DROP STREAM IF EXISTS USER_CLICKSTREAM;
 CREATE STREAM USER_CLICKSTREAM AS SELECT userid, u.username, ip, u.city, request, status, bytes FROM clickstream c LEFT JOIN web_users u ON c.userid = u.user_id;
 
 -- Aggregate (count&groupBy) using a TABLE-Window
-CREATE TABLE USER_IP_ACTIVITY AS SELECT username, ip, city, COUNT(*) AS count FROM USER_CLICKSTREAM WINDOW TUMBLING (size 60 second) GROUP BY username, ip, city HAVING COUNT(*) > 1;
+--DROP TABLE IF EXISTS USER_IP_ACTIVITY;
+CREATE TABLE USER_IP_ACTIVITY AS SELECT username, WindowStart() AS EVENT_TS, ip, city, COUNT(*) AS count FROM USER_CLICKSTREAM WINDOW TUMBLING (size 60 second) GROUP BY username, ip, city HAVING COUNT(*) > 1;
 
 ----------------------------------------------------------------------------------------------------------------------------
 -- User session monitoring
@@ -65,4 +93,18 @@ CREATE TABLE USER_IP_ACTIVITY AS SELECT username, ip, city, COUNT(*) AS count FR
 --
 ----------------------------------------------------------------------------------------------------------------------------
 
-CREATE TABLE CLICK_USER_SESSIONS AS SELECT username, count(*) AS events FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username;
+--DROP TABLE IF EXISTS CLICK_USER_SESSIONS;
+CREATE TABLE CLICK_USER_SESSIONS AS SELECT username, WindowStart() AS EVENT_TS, count(*) AS events FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username;
+
+----------------------------------------------------------------------------------------------------------------------------
+-- Blog Article tracking user-session and bandwidth
+--
+-- Sessionisation using IP addresses - 300 seconds of inactivity expires the session
+--
+----------------------------------------------------------------------------------------------------------------------------
+
+----DROP TABLE IF EXISTS PER_USER_KBYTES;
+--CREATE TABLE PER_USER_KBYTES AS SELECT username, sum(bytes)/1024 AS kbytes FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username;
+
+----DROP TABLE IF EXISTS MALICIOUS_USER_SESSIONS;
+--CREATE TABLE MALICIOUS_USER_SESSIONS AS SELECT username, ip,  sum(bytes)/1024 AS kbytes FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username, ip  HAVING sum(bytes)/1024 > 50;

--- a/clickstream/ksql/ksql-clickstream-demo/demo/clickstream-schema.sql
+++ b/clickstream/ksql/ksql-clickstream-demo/demo/clickstream-schema.sql
@@ -1,7 +1,8 @@
-
+set 'commit.interval.ms'='2000';
+set 'cache.max.bytes.buffering'='10000000';
+set 'auto.offset.reset'='earliest';
 
 -- 1. SOURCE of ClickStream
---DROP STREAM IF EXISTS clickstream;
 CREATE STREAM clickstream (_time bigint,time varchar, ip varchar, request varchar, status int, userid int, bytes bigint, agent varchar) with (kafka_topic = 'clickstream', value_format = 'json');
 
 
@@ -12,16 +13,13 @@ CREATE STREAM clickstream (_time bigint,time varchar, ip varchar, request varcha
 ----------------------------------------------------------------------------------------------------------------------------
 
  -- number of events per minute - think about key-for-distribution-purpose - shuffling etc - shouldnt use 'userid'
---DROP TABLE IF EXISTS events_per_min;
 CREATE table events_per_min AS SELECT userid, WindowStart() AS EVENT_TS, count(*) AS events FROM clickstream window TUMBLING (size 60 second) GROUP BY userid;
 
 -- 3. BUILD STATUS_CODES
 -- static table
---DROP TABLE IF EXISTS clickstream_codes;
 CREATE TABLE clickstream_codes (code int, definition varchar) with (key='code', kafka_topic = 'clickstream_codes', value_format = 'json');
 
 -- 4. BUILD PAGE_VIEWS
---DROP TABLE IF EXISTS pages_per_min;
 CREATE TABLE pages_per_min AS SELECT userid, WindowStart() AS EVENT_TS, count(*) AS pages FROM clickstream WINDOW HOPPING (size 60 second, advance by 5 second) WHERE request like '%html%' GROUP BY userid ;
 
 ----------------------------------------------------------------------------------------------------------------------------
@@ -31,21 +29,14 @@ CREATE TABLE pages_per_min AS SELECT userid, WindowStart() AS EVENT_TS, count(*)
 ----------------------------------------------------------------------------------------------------------------------------
 
 -- Use 'HAVING' Filter to show ERROR codes > 400 where count > 5
---DROP TABLE IF EXISTS ERRORS_PER_MIN_ALERT;
 CREATE TABLE ERRORS_PER_MIN_ALERT AS SELECT status, WindowStart() AS EVENT_TS, count(*) AS errors FROM clickstream window HOPPING ( size 30 second, advance by 20 second) WHERE status > 400 GROUP BY status HAVING count(*) > 5 AND count(*) is not NULL;
 
---DROP TABLE IF EXISTS ERRORS_PER_MIN;
 CREATE table ERRORS_PER_MIN AS SELECT status, WindowStart() AS EVENT_TS, count(*) AS errors FROM clickstream window HOPPING ( size 60 second, advance by 5  second) WHERE status > 400 GROUP BY status;
-
--- VIEW - Enrich Codes with errors with Join to Status-Code definition
---DROP STREAM IF EXISTS ENRICHED_ERROR_CODES;
---DROP TABLE IF EXISTS ENRICHED_ERROR_CODES_COUNT;
 
 --Join using a STREAM
 CREATE STREAM ENRICHED_ERROR_CODES AS SELECT code, definition FROM clickstream LEFT JOIN clickstream_codes ON clickstream.status = clickstream_codes.code;
 -- Aggregate (count&groupBy) using a TABLE-Window
 CREATE TABLE ENRICHED_ERROR_CODES_COUNT AS SELECT code, WindowStart() AS EVENT_TS, definition, COUNT(*) AS count FROM ENRICHED_ERROR_CODES WINDOW TUMBLING (size 30 second) GROUP BY code, definition HAVING COUNT(*) > 1;
-
 
 ----------------------------------------------------------------------------------------------------------------------------
 -- Clickstream users for enrichment and exception monitoring
@@ -54,36 +45,16 @@ CREATE TABLE ENRICHED_ERROR_CODES_COUNT AS SELECT code, WindowStart() AS EVENT_T
 ----------------------------------------------------------------------------------------------------------------------------
 
 -- users lookup table
---DROP TABLE IF EXISTS WEB_USERS;
 CREATE TABLE WEB_USERS (user_id int, registered_At BIGINT, username varchar, first_name varchar, last_name varchar, city varchar, level varchar) with (key='user_id', kafka_topic = 'clickstream_users', value_format = 'json');
-
--- Clickstream enriched with user account data
---DROP STREAM IF EXISTS customer_clickstream;
-CREATE STREAM customer_clickstream WITH (PARTITIONS=2) AS SELECT userid, u.first_name, u.last_name, u.level, time, ip, request, status, agent FROM clickstream c LEFT JOIN web_users u ON c.userid = u.user_id;
-
--- Find error views by important users
-----DROP STREAM IF EXISTS platinum_customers_with_errors
---CREATE stream platinum_customers_with_errors WITH (PARTITIONS=2) AS seLECT * FROM customer_clickstream WHERE status > 400 AND level = 'Platinum';
-
--- Find error views by important users in one shot
-----DROP STREAM IF EXISTS platinum_errors;
---CREATE STREAM platinum_errors WITH (PARTITIONS=2) AS SELECT userid, u.first_name, u.last_name, u.city, u.level, time, ip, request, status, agent FROM clickstream c LEFT JOIN web_users u ON c.userid = u.user_id WHERE status > 400 AND level = 'Platinum';
---
----- Trend of errors from important users
-----DROP TABLE IF EXISTS platinum_page_errors_per_5_min;
---CREATE TABLE platinum_errors_per_5_min AS SELECT userid, first_name, last_name, city, count(*) AS running_count FROM platinum_errors WINDOW TUMBLING (SIZE 5 MINUTE) WHERE request LIKE '%html%' GROUP BY userid, first_name, last_name, city;
-
 
 ----------------------------------------------------------------------------------------------------------------------------
 -- User experience monitoring
 --
 -- View IP, username and City Versus web-site-activity (hits)
 ----------------------------------------------------------------------------------------------------------------------------
---DROP STREAM IF EXISTS USER_CLICKSTREAM;
 CREATE STREAM USER_CLICKSTREAM AS SELECT userid, u.username, ip, u.city, request, status, bytes FROM clickstream c LEFT JOIN web_users u ON c.userid = u.user_id;
 
 -- Aggregate (count&groupBy) using a TABLE-Window
---DROP TABLE IF EXISTS USER_IP_ACTIVITY;
 CREATE TABLE USER_IP_ACTIVITY AS SELECT username, WindowStart() AS EVENT_TS, ip, city, COUNT(*) AS count FROM USER_CLICKSTREAM WINDOW TUMBLING (size 60 second) GROUP BY username, ip, city HAVING COUNT(*) > 1;
 
 ----------------------------------------------------------------------------------------------------------------------------
@@ -93,18 +64,4 @@ CREATE TABLE USER_IP_ACTIVITY AS SELECT username, WindowStart() AS EVENT_TS, ip,
 --
 ----------------------------------------------------------------------------------------------------------------------------
 
---DROP TABLE IF EXISTS CLICK_USER_SESSIONS;
 CREATE TABLE CLICK_USER_SESSIONS AS SELECT username, WindowStart() AS EVENT_TS, count(*) AS events FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username;
-
-----------------------------------------------------------------------------------------------------------------------------
--- Blog Article tracking user-session and bandwidth
---
--- Sessionisation using IP addresses - 300 seconds of inactivity expires the session
---
-----------------------------------------------------------------------------------------------------------------------------
-
-----DROP TABLE IF EXISTS PER_USER_KBYTES;
---CREATE TABLE PER_USER_KBYTES AS SELECT username, sum(bytes)/1024 AS kbytes FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username;
-
-----DROP TABLE IF EXISTS MALICIOUS_USER_SESSIONS;
---CREATE TABLE MALICIOUS_USER_SESSIONS AS SELECT username, ip,  sum(bytes)/1024 AS kbytes FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username, ip  HAVING sum(bytes)/1024 > 50;

--- a/clickstream/ksql/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
+++ b/clickstream/ksql/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
@@ -3,19 +3,6 @@
 ## An "all-in-one script" to load up a new table and connect all of the relevant parts to allow data to pipe through from KSQL.KafkaTopic->Connect->Elastic->Grafana[DataSource]
 ## Accepts a KSQL TABLE_NAME where the data is to be sourced from.
 
-if [[ -z "${CONNECT_HOST}" ]]; then
-  echo -e "CONNECT_HOST not set, defaulting to localhost"
-  CONNECT_HOST="localhost"
-fi
-if [[ -z "${GRAFANA_HOST}" ]]; then
-  echo -e "GRAFANA_HOST not set, defaulting to localhost"
-  GRAFANA_HOST="localhost"
-fi
-if [[ -z "${ELASTIC_HOST}" ]]; then
-  echo -e "ELASTIC_HOST not set, defaulting to localhost"
-  ELASTIC_HOST="localhost"
-fi
-
 
 if [ "$#" -ne 1 ]; then
     echo "Usage: ksql-connect-es-grafana.sh <TABLENAME>"
@@ -30,10 +17,9 @@ echo -e "\t-> Connecting:" $table_name
 
 # Tell Kafka to send this Table-Topic to Elastic
 # Note the addition of the FilterNulls transform, which converts null values to null records, which Connect ignores.
-# Note the addition of the ExtractTimestamp transform, which exposes the Kafka record's timestamp to Elastic in a field called EVENT_TS.
 echo -e "\t\t-> Adding Kafka Connect Elastic Source es_sink_$TABLE_NAME"
 
-curl -s -X "POST" "http://$CONNECT_HOST:8083/connectors/" \
+curl -s -X "POST" "http://localhost:8083/connectors/" \
      -H "Content-Type: application/json" \
      -d $'{
   "name": "es_sink_'$TABLE_NAME'",
@@ -47,11 +33,9 @@ curl -s -X "POST" "http://$CONNECT_HOST:8083/connectors/" \
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "type.name": "type.name=kafkaconnect",
     "topic.index.map": "'$TABLE_NAME':'$table_name'",
-    "connection.url": "http://'$ELASTIC_HOST':9200",
-    "transforms": "FilterNulls,ExtractTimestamp",
-    "transforms.FilterNulls.type": "io.confluent.transforms.NullFilter",
-    "transforms.ExtractTimestamp.type": "org.apache.kafka.connect.transforms.InsertField$Value",
-    "transforms.ExtractTimestamp.timestamp.field" : "EVENT_TS"
+    "connection.url": "http://elasticsearch:9200",
+    "transforms": "FilterNulls",
+    "transforms.FilterNulls.type": "io.confluent.transforms.NullFilter"
   }
 }' >>/tmp/log.txt 2>&1
 
@@ -59,9 +43,8 @@ curl -s -X "POST" "http://$CONNECT_HOST:8083/connectors/" \
 echo -e "\t\t-> Adding Grafana Source"
 
 ## Add the Elastic DataSource into Grafana
-curl -s -X "POST" "http://$GRAFANA_HOST:3000/api/datasources" \
+curl -s -X "POST" "http://grafana:3000/api/datasources" \
 	    -H "Content-Type: application/json" \
 	     --user admin:admin \
-	     -d $'{"id":1,"orgId":1,"name":"'$table_name'","type":"elasticsearch","typeLogoUrl":"public/app/plugins/datasource/elasticsearch/img/elasticsearch.svg","access":"proxy","url":"http://'$ELASTIC_HOST':9200","password":"","user":"","database":"'$table_name'","basicAuth":false,"isDefault":false,"jsonData":{"timeField":"EVENT_TS"}}' \
+	     -d $'{"id":1,"orgId":1,"name":"'$table_name'","type":"elasticsearch","typeLogoUrl":"public/app/plugins/datasource/elasticsearch/img/elasticsearch.svg","access":"proxy","url":"http://elasticsearch:9200","password":"","user":"","database":"'$table_name'","basicAuth":false,"isDefault":false,"jsonData":{"timeField":"EVENT_TS"}}' \
        >>/tmp/log.txt 2>&1
-

--- a/clickstream/ksql/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
+++ b/clickstream/ksql/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
@@ -3,6 +3,19 @@
 ## An "all-in-one script" to load up a new table and connect all of the relevant parts to allow data to pipe through from KSQL.KafkaTopic->Connect->Elastic->Grafana[DataSource]
 ## Accepts a KSQL TABLE_NAME where the data is to be sourced from.
 
+if [[ -z "${CONNECT_HOST}" ]]; then
+  echo -e "CONNECT_HOST not set, defaulting to localhost"
+  CONNECT_HOST="localhost"
+fi
+if [[ -z "${GRAFANA_HOST}" ]]; then
+  echo -e "GRAFANA_HOST not set, defaulting to localhost"
+  GRAFANA_HOST="localhost"
+fi
+if [[ -z "${ELASTIC_HOST}" ]]; then
+  echo -e "ELASTIC_HOST not set, defaulting to localhost"
+  ELASTIC_HOST="localhost"
+fi
+
 
 if [ "$#" -ne 1 ]; then
     echo "Usage: ksql-connect-es-grafana.sh <TABLENAME>"
@@ -19,7 +32,7 @@ echo -e "\t-> Connecting:" $table_name
 # Note the addition of the FilterNulls transform, which converts null values to null records, which Connect ignores.
 echo -e "\t\t-> Adding Kafka Connect Elastic Source es_sink_$TABLE_NAME"
 
-curl -s -X "POST" "http://localhost:8083/connectors/" \
+curl -s -X "POST" "http://$CONNECT_HOST:8083/connectors/" \
      -H "Content-Type: application/json" \
      -d $'{
   "name": "es_sink_'$TABLE_NAME'",
@@ -33,7 +46,7 @@ curl -s -X "POST" "http://localhost:8083/connectors/" \
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "type.name": "type.name=kafkaconnect",
     "topic.index.map": "'$TABLE_NAME':'$table_name'",
-    "connection.url": "http://elasticsearch:9200",
+    "connection.url": "http://'$ELASTIC_HOST':9200",
     "transforms": "FilterNulls",
     "transforms.FilterNulls.type": "io.confluent.transforms.NullFilter"
   }
@@ -43,8 +56,8 @@ curl -s -X "POST" "http://localhost:8083/connectors/" \
 echo -e "\t\t-> Adding Grafana Source"
 
 ## Add the Elastic DataSource into Grafana
-curl -s -X "POST" "http://grafana:3000/api/datasources" \
+curl -s -X "POST" "http://$GRAFANA_HOST:3000/api/datasources" \
 	    -H "Content-Type: application/json" \
 	     --user admin:admin \
-	     -d $'{"id":1,"orgId":1,"name":"'$table_name'","type":"elasticsearch","typeLogoUrl":"public/app/plugins/datasource/elasticsearch/img/elasticsearch.svg","access":"proxy","url":"http://elasticsearch:9200","password":"","user":"","database":"'$table_name'","basicAuth":false,"isDefault":false,"jsonData":{"timeField":"EVENT_TS"}}' \
+	     -d $'{"id":1,"orgId":1,"name":"'$table_name'","type":"elasticsearch","typeLogoUrl":"public/app/plugins/datasource/elasticsearch/img/elasticsearch.svg","access":"proxy","url":"http://'$ELASTIC_HOST':9200","password":"","user":"","database":"'$table_name'","basicAuth":false,"isDefault":false,"jsonData":{"timeField":"EVENT_TS"}}' \
        >>/tmp/log.txt 2>&1


### PR DESCRIPTION
In 5.0 there was a regression in KSQL, whereby ROWTIME no longer reflected the start of an aggregate window. An alternative method has been provided by #1993 and we should update blogs (e.g. https://www.confluent.io/blog/ksql-in-action-real-time-streaming-etl-from-oracle-transactional-data) and demos (need to check e.g. https://github.com/confluentinc/ksql/tree/master/ksql-clickstream-demo/demo)