### PR TITLE
KSQL workshop: Added Windows Install instructions for JQ 

### DIFF
--- a/ksql-workshop/pre-requisites.adoc
+++ b/ksql-workshop/pre-requisites.adoc
@@ -64,7 +64,7 @@ docker-compose pull
 * Mac: `brew install jq`
 * RHEL-based: `sudo yum install -y jq`
 * Debian-based: `sudo apt install -y jq`
-* Windows: `¯\_(ツ)_/¯` -> send me a PR for these instructions on how to do it :)
+* Windows: `choco install jq` or `Download from https://stedolan.github.io/jq/download/[the official JQ website] and add to Path.`
 
 4. Linux only:
 + 


### PR DESCRIPTION
It was jokingly stated you needed install instructions for Windows.

Kind Regards,
Tom