### PR TITLE
Added docs for python client on setting up CentOS trust store

### DIFF
--- a/clients/cloud/python/README.md
+++ b/clients/cloud/python/README.md
@@ -19,7 +19,14 @@ sasl.password=<secret-access-key>
 
 ## Configure SSL trust store
 
-Depending on your operating system or Linux distro you may need to take extra steps to set up the SSL CA root certificates.
+Depending on your operating system or Linux distro you may need to take extra steps to set up the SSL CA root certificates. If your systems does not have the SSL CA root certificates properly set up, here is an example of an error message you may see.
+
+```
+$ ./producer.py -f ~/.ccloud/config -t hello
+%3|1554125834.196|FAIL|rdkafka#producer-2| [thrd:sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/boot]: sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/bootstrap: Failed to verify broker certificate: unable to get issuer certificate (after 626ms in state CONNECT)
+%3|1554125834.197|ERROR|rdkafka#producer-2| [thrd:sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/boot]: sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/bootstrap: Failed to verify broker certificate: unable to get issuer certificate (after 626ms in state CONNECT)
+%3|1554125834.197|ERROR|rdkafka#producer-2| [thrd:sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/boot]: 1/1 brokers are down
+```
 
 ### CentOS
 

--- a/clients/cloud/python/README.md
+++ b/clients/cloud/python/README.md
@@ -21,7 +21,7 @@ sasl.password=<secret-access-key>
 
 In order for the producer to verify the certificate of the brokers make sure the trust store is set up correctly on your system. 
 
-** CentOS
+### CentOS
 
 ```bash
 $ sudo yum reinstall ca-certificates

--- a/clients/cloud/python/README.md
+++ b/clients/cloud/python/README.md
@@ -17,6 +17,24 @@ sasl.username=<api-key-id>
 sasl.password=<secret-access-key>
 ```
 
+* Properly configured trust store on client system
+
+In order for the producer to verify the certificate of the brokers make the trust store is set up correctly on your system. 
+
+** CentOS
+
+```bash
+$ sudo reinstall ca-certificates
+```
+
+Add the following property to the `Producer` and `AdminClient` constructors in `producer.py`:
+
+```
+ssl.ca.location='/etc/pki/tls/cert.pem'
+```
+
+or symlink or copy `/usr/ssl/cert.pem` to `/etc/pki/tls/cert.pem`. This is the default location used by the python producer. For more information see the librdkafka docs on which this python producer is built: https://github.com/edenhill/librdkafka/wiki/Using-SSL-with-librdkafka
+
 # Example 1: Hello World!
 
 In this example, the producer writes Kafka data to a topic in Confluent Cloud. 

--- a/clients/cloud/python/README.md
+++ b/clients/cloud/python/README.md
@@ -19,12 +19,12 @@ sasl.password=<secret-access-key>
 
 * Properly configured trust store on client system
 
-In order for the producer to verify the certificate of the brokers make the trust store is set up correctly on your system. 
+In order for the producer to verify the certificate of the brokers make sure the trust store is set up correctly on your system. 
 
 ** CentOS
 
 ```bash
-$ sudo reinstall ca-certificates
+$ sudo yum reinstall ca-certificates
 ```
 
 Add the following property to the `Producer` and `AdminClient` constructors in `producer.py`:

--- a/clients/cloud/python/README.md
+++ b/clients/cloud/python/README.md
@@ -27,13 +27,13 @@ Depending on your operating system or Linux distro you may need to take extra st
 $ sudo yum reinstall ca-certificates
 ```
 
-Add the following property to the `Producer` and `AdminClient` constructors in `producer.py`:
+Add the following property to the config dict in the `Producer` and `AdminClient` objects in `producer.py`:
 
 ```
-ssl.ca.location='/etc/pki/tls/cert.pem'
+ssl.ca.location='/etc/ssl/certs/ca-bundle.crt'
 ```
 
-or symlink or copy `/usr/ssl/cert.pem` to `/etc/pki/tls/cert.pem`. This is the default location used by the python producer. For more information see the librdkafka docs on which this python producer is built: https://github.com/edenhill/librdkafka/wiki/Using-SSL-with-librdkafka
+For more information see the librdkafka docs on which this python producer is built: https://github.com/edenhill/librdkafka/wiki/Using-SSL-with-librdkafka
 
 # Example 1: Hello World!
 

--- a/clients/cloud/python/README.md
+++ b/clients/cloud/python/README.md
@@ -30,7 +30,7 @@ $ sudo yum reinstall ca-certificates
 Add the following property to the config dict in the `Producer` and `AdminClient` objects in `producer.py`:
 
 ```
-ssl.ca.location='/etc/ssl/certs/ca-bundle.crt'
+ssl.ca.location: '/etc/ssl/certs/ca-bundle.crt'
 ```
 
 For more information see the librdkafka docs on which this python producer is built: https://github.com/edenhill/librdkafka/wiki/Using-SSL-with-librdkafka

--- a/clients/cloud/python/README.md
+++ b/clients/cloud/python/README.md
@@ -27,7 +27,7 @@ Depending on your operating system or Linux distro you may need to take extra st
 $ sudo yum reinstall ca-certificates
 ```
 
-Add the following property to the config dict in the `Producer` and `AdminClient` objects in `producer.py`:
+Add the following property to the config dict objects in `producer.py` and `consumer.py`:
 
 ```
 ssl.ca.location: '/etc/ssl/certs/ca-bundle.crt'

--- a/clients/cloud/python/README.md
+++ b/clients/cloud/python/README.md
@@ -17,9 +17,9 @@ sasl.username=<api-key-id>
 sasl.password=<secret-access-key>
 ```
 
-* Properly configured trust store on client system
+## Configure SSL trust store
 
-In order for the producer to verify the certificate of the brokers make sure the trust store is set up correctly on your system. 
+Depending on your operating system or Linux distro you may need to take extra steps to set up the SSL CA root certificates.
 
 ### CentOS
 


### PR DESCRIPTION
Added docs for the following problem:

I created a cluster but got this error when running the python producer.

```
$ ./producer.py -f ~/.ccloud/config -t hello
%3|1554125834.196|FAIL|rdkafka#producer-2| [thrd:sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/boot]: sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/bootstrap: Failed to verify broker certificate: unable to get issuer certificate (after 626ms in state CONNECT)
%3|1554125834.197|ERROR|rdkafka#producer-2| [thrd:sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/boot]: sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/bootstrap: Failed to verify broker certificate: unable to get issuer certificate (after 626ms in state CONNECT)
%3|1554125834.197|ERROR|rdkafka#producer-2| [thrd:sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/boot]: 1/1 brokers are down
%3|1554125834.196|FAIL|rdkafka#producer-1| [thrd:sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/boot]: sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/bootstrap: Failed to verify broker certificate: unable to get issuer certificate (after 628ms in state CONNECT)
%3|1554125834.197|ERROR|rdkafka#producer-1| [thrd:sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/boot]: sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/bootstrap: Failed to verify broker certificate: unable to get issuer certificate (after 628ms in state CONNECT)
%3|1554125834.197|ERROR|rdkafka#producer-1| [thrd:sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/boot]: 1/1 brokers are down
```

I fixed it after updating the trust store on my CentOS system and setting the `ssl.ca.location` property to `/etc/pki/tls/cert.pem`