### PR TITLE
DOCS-1771: Remove extraneous call to check_env in stop-docker.sh script

### DIFF
--- a/ccloud/stop-docker.sh
+++ b/ccloud/stop-docker.sh
@@ -3,7 +3,6 @@
 # Source library
 . ../utils/helper.sh
 
-check_env || exit 1
 check_ccloud || exit
 
 ./ccloud-generate-cp-configs.sh


### PR DESCRIPTION
Fixes DOCS-1771 and customer-reported [issue](https://groups.google.com/a/confluent.io/forum/#!msg/docs/UUQ8P23JoFQ/3RL-oM0NBAAJ).