### PR TITLE
DEVX-989 upgrade kafka-streams-example jar dependency

### DIFF
--- a/music/docker-compose.yml
+++ b/music/docker-compose.yml
@@ -68,7 +68,7 @@ services:
                        cub kafka-ready -b kafka:29092 1 20 && \
                        echo Waiting for Confluent Schema Registry to be ready... && \
                        cub sr-ready schema-registry 8081 20 && \
-                       java -cp /usr/share/java/kafka-streams-examples/kafka-streams-examples-5.2.2-standalone.jar \
+                       java -cp /usr/share/java/kafka-streams-examples/kafka-streams-examples-5.3.0-standalone.jar \
                        io.confluent.examples.streams.interactivequeries.kafkamusic.KafkaMusicExampleDriver \
                        kafka:29092 http://schema-registry:8081'"
     environment:

--- a/music/start.sh
+++ b/music/start.sh
@@ -13,9 +13,9 @@ echo "auto.offset.reset=earliest" >> $CONFLUENT_HOME/etc/ksql/ksql-server.proper
 confluent local start
 
 [[ -d "kafka-streams-examples" ]] || git clone https://github.com/confluentinc/kafka-streams-examples.git
-(cd kafka-streams-examples && git checkout 5.2.2-post)
-[[ -f "kafka-streams-examples/target/kafka-streams-examples-5.2.2-standalone.jar" ]] || (cd kafka-streams-examples && mvn clean package -DskipTests)
-java -cp kafka-streams-examples/target/kafka-streams-examples-5.2.2-standalone.jar io.confluent.examples.streams.interactivequeries.kafkamusic.KafkaMusicExampleDriver &>/dev/null &
+(cd kafka-streams-examples && git checkout 5.3.0-post)
+[[ -f "kafka-streams-examples/target/kafka-streams-examples-5.3.0-standalone.jar" ]] || (cd kafka-streams-examples && mvn clean package -DskipTests)
+java -cp kafka-streams-examples/target/kafka-streams-examples-5.3.0-standalone.jar io.confluent.examples.streams.interactivequeries.kafkamusic.KafkaMusicExampleDriver &>/dev/null &
 
 sleep 5
 


### PR DESCRIPTION
Prior to this change, 5.3.0-post branch would not operate (local or docker-compose)