### PR TITLE
use metrics reporter in RBAC docker example

### DIFF
--- a/security/rbac/delta_configs/server.properties.delta
+++ b/security/rbac/delta_configs/server.properties.delta
@@ -45,6 +45,4 @@ listener.name.rbac.oauthbearer.sasl.server.callback.handler.class=io.confluent.k
 listener.name.rbac.oauthbearer.sasl.login.callback.handler.class=io.confluent.kafka.server.plugins.auth.token.TokenBearerServerLoginCallbackHandler
 
 # Setup MetricsReporter (point at PLAINTEXT port)
-metric.reporters=io.confluent.metrics.reporter.ConfluentMetricsReporter
 confluent.metrics.reporter.bootstrap.servers=localhost:9093
-confluent.metrics.reporter.topic.replicas=1

--- a/security/rbac/delta_configs/server.properties.delta
+++ b/security/rbac/delta_configs/server.properties.delta
@@ -43,3 +43,8 @@ listener.name.rbac.oauthbearer.sasl.jaas.config= \
 listener.name.rbac.oauthbearer.sasl.server.callback.handler.class=io.confluent.kafka.server.plugins.auth.token.TokenBearerValidatorCallbackHandler
 # Set SASL callback handler for handling tokens on login. This is essentially a noop if not used for inter-broker communication.
 listener.name.rbac.oauthbearer.sasl.login.callback.handler.class=io.confluent.kafka.server.plugins.auth.token.TokenBearerServerLoginCallbackHandler
+
+# Setup MetricsReporter (point at PLAINTEXT port)
+metric.reporters=io.confluent.metrics.reporter.ConfluentMetricsReporter
+confluent.metrics.reporter.bootstrap.servers=localhost:9093
+confluent.metrics.reporter.topic.replicas=1

--- a/security/rbac/delta_configs/server.properties.delta
+++ b/security/rbac/delta_configs/server.properties.delta
@@ -43,6 +43,3 @@ listener.name.rbac.oauthbearer.sasl.jaas.config= \
 listener.name.rbac.oauthbearer.sasl.server.callback.handler.class=io.confluent.kafka.server.plugins.auth.token.TokenBearerValidatorCallbackHandler
 # Set SASL callback handler for handling tokens on login. This is essentially a noop if not used for inter-broker communication.
 listener.name.rbac.oauthbearer.sasl.login.callback.handler.class=io.confluent.kafka.server.plugins.auth.token.TokenBearerServerLoginCallbackHandler
-
-# Setup MetricsReporter (point at PLAINTEXT port)
-confluent.metrics.reporter.bootstrap.servers=localhost:9093

--- a/security/rbac/rbac-docker/docker-compose.yml
+++ b/security/rbac/rbac-docker/docker-compose.yml
@@ -170,9 +170,7 @@ services:
                                                     \
                                                     org.apache.kafka.common.security.plain.PlainLoginModule required \
                                                     username="admin" \
-                                                    password="admin-secret" \
-                                                    user_admin="admin-secret" \
-                                                    user_mds="mds-secret";
+                                                    password="admin-secret";
 
       # ======================= OTHER BROKER STUFF =================================
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

--- a/security/rbac/rbac-docker/docker-compose.yml
+++ b/security/rbac/rbac-docker/docker-compose.yml
@@ -156,14 +156,27 @@ services:
       KAFKA_LDAP_USER_MEMBEROF_ATTRIBUTE: ou
       KAFKA_LDAP_GROUP_NAME_ATTRIBUTE: cn
       KAFKA_LDAP_GROUP_OBJECT_CLASS: group
+
+      # ======================= CONFIGURE METRICS REPORTER =========================
+      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
+      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
+
+      # point at our 'INTERNAL' listener
+      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:9093
+      # CONFLUENT_METRICS_REPORTER_ZOOKEEPER_CONNECT: zookeeper:2181
+      CONFLUENT_METRICS_REPORTER_SECURITY_PROTOCOL: SASL_PLAINTEXT
+      CONFLUENT_METRICS_REPORTER_SASL_MECHANISM: PLAIN
+      CONFLUENT_METRICS_REPORTER_SASL_JAAS_CONFIG: |
+                                                    \
+                                                    org.apache.kafka.common.security.plain.PlainLoginModule required \
+                                                    username="admin" \
+                                                    password="admin-secret" \
+                                                    user_admin="admin-secret" \
+                                                    user_mds="mds-secret";
+
       # ======================= OTHER BROKER STUFF =================================
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      # KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
       # KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-
-      # CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:9093
-      # CONFLUENT_METRICS_REPORTER_ZOOKEEPER_CONNECT: zookeeper:2181
-      # CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
       # CONFLUENT_METRICS_ENABLE: 'true'
       # CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 


### PR DESCRIPTION
### what
enable the metrics reporter in rbac docker demo

### tested
1. tested docker setup via `security/rbac/rbac-docker/confluent-start.sh` 

