### PR TITLE
add named C3 services + super user bindings

### DIFF
--- a/security/rbac/rbac-docker/create-role-bindings.sh
+++ b/security/rbac/rbac-docker/create-role-bindings.sh
@@ -17,14 +17,14 @@ KSQL=ksql-cluster
 C3=c3-cluster
 
 SUPER_USER=professor
-SUPER_PASSWORD=professor
+SUPER_USER_PASSWORD=professor
 SUPER_USER_PRINCIPAL="User:$SUPER_USER"
 CONNECT_PRINCIPAL="User:fry"
 SR_PRINCIPAL="User:leela"
 KSQL_PRINCIPAL="User:zoidberg"
 C3_PRINCIPAL="User:hermes"
 
-XX_CONFLUENT_USERNAME=professor XX_CONFLUENT_PASSWORD=professor confluent login --url $MDS_URL
+XX_CONFLUENT_USERNAME=$SUPER_USER XX_CONFLUENT_PASSWORD=$SUPER_USER_PASSWORD confluent login --url $MDS_URL
 
 ################################### SETUP SUPERUSER ###################################
 echo "Creating Super User role bindings"

--- a/security/rbac/rbac-docker/create-role-bindings.sh
+++ b/security/rbac/rbac-docker/create-role-bindings.sh
@@ -152,3 +152,7 @@ echo "    connect service account: $CONNECT_PRINCIPAL"
 echo "    schema registry service account: $SR_PRINCIPAL"
 echo "    KSQL service account: $KSQL_PRINCIPAL"
 echo "    C3 service account: $C3_PRINCIPAL"
+
+echo
+echo "To set service IDs as environment variables paste/run this in your shell:"
+echo "    export KAFKA_ID=$KAFKA_CLUSTER_ID ; export CONNECT_ID=$CONNECT ; export SR_ID=$SR ; export KSQL_ID=$KSQL"

--- a/security/rbac/rbac-docker/create-role-bindings.sh
+++ b/security/rbac/rbac-docker/create-role-bindings.sh
@@ -18,12 +18,39 @@ C3=c3-cluster
 
 SUPER_USER=professor
 SUPER_PASSWORD=professor
+SUPER_USER_PRINCIPAL="User:$SUPER_USER"
 CONNECT_PRINCIPAL="User:fry"
 SR_PRINCIPAL="User:leela"
 KSQL_PRINCIPAL="User:zoidberg"
 C3_PRINCIPAL="User:hermes"
 
 XX_CONFLUENT_USERNAME=professor XX_CONFLUENT_PASSWORD=professor confluent login --url $MDS_URL
+
+################################### SETUP SUPERUSER ###################################
+echo "Creating Super User role bindings"
+
+confluent iam rolebinding create \
+    --principal $SUPER_USER_PRINCIPAL  \
+    --role SystemAdmin \
+    --kafka-cluster-id $KAFKA_CLUSTER_ID
+
+confluent iam rolebinding create \
+    --principal $SUPER_USER_PRINCIPAL \
+    --role SystemAdmin \
+    --kafka-cluster-id $KAFKA_CLUSTER_ID \
+    --schema-registry-cluster-id $SR
+
+confluent iam rolebinding create \
+    --principal $SUPER_USER_PRINCIPAL \
+    --role SystemAdmin \
+    --kafka-cluster-id $KAFKA_CLUSTER_ID \
+    --connect-cluster-id $CONNECT
+
+confluent iam rolebinding create \
+    --principal $SUPER_USER_PRINCIPAL \
+    --role SystemAdmin \
+    --kafka-cluster-id $KAFKA_CLUSTER_ID \
+    --ksql-cluster-id $KSQL
 
 ################################### SCHEMA REGISTRY ###################################
 echo "Creating Schema Registry role bindings"
@@ -120,6 +147,7 @@ echo "    connect cluster id: $CONNECT"
 echo "    schema registry cluster id: $SR"
 echo "    ksql cluster id: $KSQL"
 echo
+echo "    super user account: $SUPER_USER_PRINCIPAL"
 echo "    connect service account: $CONNECT_PRINCIPAL"
 echo "    schema registry service account: $SR_PRINCIPAL"
 echo "    KSQL service account: $KSQL_PRINCIPAL"

--- a/security/rbac/rbac-docker/docker-compose.yml
+++ b/security/rbac/rbac-docker/docker-compose.yml
@@ -477,15 +477,21 @@ services:
       # general settings
       CONTROL_CENTER_BOOTSTRAP_SERVERS: 'broker:9092'
       CONTROL_CENTER_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      CONTROL_CENTER_CONNECT_CLUSTER: 'http://connect:8083'
-      CONTROL_CENTER_KSQL_URL: "http://ksql-server:8088"
-      # CONTROL_CENTER_KSQL_ADVERTISED_URL: "http://localhost:8088"
-      CONTROL_CENTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
       CONTROL_CENTER_REPLICATION_FACTOR: 1
       CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
       CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
       CONFLUENT_METRICS_TOPIC_REPLICATION: 1
       PORT: 9021
+
+      # ========================= other services ==============================
+      # connect
+      CONTROL_CENTER_CONNECT_CONNECT1_CLUSTER: http://connect:8083
+      # ksql
+      CONTROL_CENTER_KSQL_KSQL1_URL: http://ksql-server:8088
+      CONTROL_CENTER_KSQL_KSQL1_ADVERTISED_URL: http://localhost:8088
+      # schema-registry
+      CONTROL_CENTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+
       # ========================= RBAC =================================
       CONTROL_CENTER_REST_AUTHENTICATION_METHOD: BEARER
       CONTROL_CENTER_AUTH_BEARER_PUBLIC_KEY_PATH: /tmp/conf/public.pem

--- a/security/rbac/rbac-docker/docker-compose.yml
+++ b/security/rbac/rbac-docker/docker-compose.yml
@@ -486,9 +486,11 @@ services:
       # ========================= other services ==============================
       # connect
       CONTROL_CENTER_CONNECT_CONNECT1_CLUSTER: http://connect:8083
+
       # ksql
       CONTROL_CENTER_KSQL_KSQL1_URL: http://ksql-server:8088
-      CONTROL_CENTER_KSQL_KSQL1_ADVERTISED_URL: http://localhost:8088
+      CONTROL_CENTER_KSQL_KSQL1_ADVERTISED_URL: http://localhost:8088 # access KSQL from the browser
+
       # schema-registry
       CONTROL_CENTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
 


### PR DESCRIPTION
### what
1. used C3 named services
2. bind super user to clusters 

### why
1. now we support multiple KSQLs/Connects in C3
2. be able to use the super-user for testing