### PR TITLE
error on missing dependencies & use docker ZK-shell

### DIFF
--- a/security/rbac/rbac-docker/confluent-start.sh
+++ b/security/rbac/rbac-docker/confluent-start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # make sure dependencies are installed
-depends="docker confluent jq"
+depends="openssl docker-compose docker confluent jq"
 for value in $depends
 do
     if ! check="$(type -p "$value")" || [[ -z check ]]; then

--- a/security/rbac/rbac-docker/confluent-start.sh
+++ b/security/rbac/rbac-docker/confluent-start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # make sure dependencies are installed
-depends="confluent jq"
+depends="docker confluent jq"
 for value in $depends
 do
     if ! check="$(type -p "$value")" || [[ -z check ]]; then

--- a/security/rbac/rbac-docker/confluent-start.sh
+++ b/security/rbac/rbac-docker/confluent-start.sh
@@ -1,11 +1,14 @@
 #!/bin/bash -e
 
-# make sure confluent command is installed
-CONFLUENT_CMD="confluent"
-if ! check="$(type -p "$CONFLUENT_CMD")" || [[ -z check ]]; then
-    echo "error: please install '$CONFLUENT_CMD' and retry"
-    exit 1
-fi
+# make sure dependencies are installed
+depends="confluent jq"
+for value in $depends
+do
+    if ! check="$(type -p "$value")" || [[ -z check ]]; then
+        echo "error: please install '$value' and retry"
+        exit 1
+    fi
+done
 
 if [ -z "$1" ]; then
     PROJECT=rbac

--- a/security/rbac/rbac-docker/confluent-start.sh
+++ b/security/rbac/rbac-docker/confluent-start.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -e
 
+# make sure confluent command is installed
+CONFLUENT_CMD="confluent"
+if ! check="$(type -p "$CONFLUENT_CMD")" || [[ -z check ]]; then
+    echo "error: please install '$CONFLUENT_CMD' and retry"
+    exit 1
+fi
+
 if [ -z "$1" ]; then
     PROJECT=rbac
 else

--- a/security/rbac/rbac-docker/create-role-bindings.sh
+++ b/security/rbac/rbac-docker/create-role-bindings.sh
@@ -3,7 +3,7 @@
 ################################## GET KAFKA CLUSTER ID ########################
 ZK_CONTAINER=zookeeper
 ZK_PORT=2181
-echo "Retrieving Kafka cluster id from docker-container $ZK_CONTAINER port $ZK_PORT"
+echo "Retrieving Kafka cluster id from docker-container '$ZK_CONTAINER' port '$ZK_PORT'"
 KAFKA_CLUSTER_ID=$(docker exec -it $ZK_CONTAINER zookeeper-shell localhost:$ZK_PORT get /cluster/id 2> /dev/null | grep \"version\" | jq -r .id)
 if [ -z "$KAFKA_CLUSTER_ID" ]; then 
     echo "Failed to retrieve kafka cluster id from zookeeper"

--- a/security/rbac/rbac-docker/create-role-bindings.sh
+++ b/security/rbac/rbac-docker/create-role-bindings.sh
@@ -1,9 +1,10 @@
 #!/bin/bash -e
 
 ################################## GET KAFKA CLUSTER ID ########################
-ZK_HOST=localhost:2181
-echo "Retrieving Kafka cluster id from zookeeper"
-KAFKA_CLUSTER_ID=$(zookeeper-shell $ZK_HOST get /cluster/id 2> /dev/null | grep version | jq -r .id)
+ZK_CONTAINER=zookeeper
+ZK_PORT=2181
+echo "Retrieving Kafka cluster id from docker-container $ZK_CONTAINER port $ZK_PORT"
+KAFKA_CLUSTER_ID=$(docker exec -it $ZK_CONTAINER zookeeper-shell localhost:$ZK_PORT get /cluster/id 2> /dev/null | grep \"version\" | jq -r .id)
 if [ -z "$KAFKA_CLUSTER_ID" ]; then 
     echo "Failed to retrieve kafka cluster id from zookeeper"
     exit 1


### PR DESCRIPTION
### what
1. check dependencies before starting `openssl docker-compose docker confluent jq`
2. use docker zk-shell command

### why
1. fail fast 🙂 
2. don't require users to modify their path variable to include `zookeeper-shell`