### PR TITLE
Added general rolebinding syntax

### DIFF
--- a/security/rbac/README.md
+++ b/security/rbac/README.md
@@ -193,7 +193,26 @@ confluent iam rolebinding create --principal User:${USER_KSQL} --role ResourceOw
 confluent iam rolebinding create --principal User:${USER_ADMIN_KSQL} --role ResourceOwner --resource Topic:_confluent-ksql-${KSQL_SERVICE_ID}transient --prefix --kafka-cluster-id $KAFKA_CLUSTER_ID
 ```
 
+### Control Center
+
+* [delta_configs/control-center-dev.properties.delta](delta_configs/control-center-dev.properties.delta)
+* Role bindings:
+
+```bash
+# Control Center Admin
+confluent iam rolebinding create --principal User:$USER_ADMIN_C3 --role SystemAdmin --kafka-cluster-id $KAFKA_CLUSTER_ID
+
+# Control Center user
+confluent iam rolebinding create --principal User:$USER_CLIENT_C --role DeveloperRead --resource Topic:$TOPIC1 --kafka-cluster-id $KAFKA_CLUSTER_ID
+confluent iam rolebinding create --principal User:$USER_CLIENT_C --role DeveloperRead --resource Topic:$TOPIC2_AVRO --kafka-cluster-id $KAFKA_CLUSTER_ID
+confluent iam rolebinding create --principal User:$USER_CLIENT_C --role DeveloperRead --resource Subject:${TOPIC2_AVRO}-value --kafka-cluster-id $KAFKA_CLUSTER_ID --schema-registry-cluster-id $SCHEMA_REGISTRY_CLUSTER_ID
+confluent iam rolebinding create --principal User:$USER_ADMIN_C3 --role ClusterAdmin --kafka-cluster-id $KAFKA_CLUSTER_ID --schema-registry-cluster-id $SCHEMA_REGISTRY_CLUSTER_ID
+confluent iam rolebinding create --principal User:$USER_CLIENT_C --role DeveloperRead --resource Connector:$CONNECTOR_NAME --kafka-cluster-id $KAFKA_CLUSTER_ID --connect-cluster-id $CONNECT_CLUSTER_ID
+```
+
+
 ### General Rolebinding Syntax
+
 General rolebinding syntax
 ```
 confluent iam rolebinding create --role [role name] --principal User:[username] --resource [resource type]:[resource name] --[cluster type]-cluster-id [insert cluster id] 
@@ -212,24 +231,7 @@ example, list the roles of `User:bender` on Kafka cluster `KAFKA_CLUSTER_ID`
 confluent iam rolebinding list --principal User:bender --kafka-cluster-id $KAFKA_CLUSTER_ID 
 ```
 
-### Control Center
-
-* [delta_configs/control-center-dev.properties.delta](delta_configs/control-center-dev.properties.delta)
-* Role bindings:
-
-```bash
-# Control Center Admin
-confluent iam rolebinding create --principal User:$USER_ADMIN_C3 --role SystemAdmin --kafka-cluster-id $KAFKA_CLUSTER_ID
-
-# Control Center user
-confluent iam rolebinding create --principal User:$USER_CLIENT_C --role DeveloperRead --resource Topic:$TOPIC1 --kafka-cluster-id $KAFKA_CLUSTER_ID
-confluent iam rolebinding create --principal User:$USER_CLIENT_C --role DeveloperRead --resource Topic:$TOPIC2_AVRO --kafka-cluster-id $KAFKA_CLUSTER_ID
-confluent iam rolebinding create --principal User:$USER_CLIENT_C --role DeveloperRead --resource Subject:${TOPIC2_AVRO}-value --kafka-cluster-id $KAFKA_CLUSTER_ID --schema-registry-cluster-id $SCHEMA_REGISTRY_CLUSTER_ID
-confluent iam rolebinding create --principal User:$USER_ADMIN_C3 --role ClusterAdmin --kafka-cluster-id $KAFKA_CLUSTER_ID --schema-registry-cluster-id $SCHEMA_REGISTRY_CLUSTER_ID
-confluent iam rolebinding create --principal User:$USER_CLIENT_C --role DeveloperRead --resource Connector:$CONNECTOR_NAME --kafka-cluster-id $KAFKA_CLUSTER_ID --connect-cluster-id $CONNECT_CLUSTER_ID
-```
 
 # Demo 2: Docker
 
 Follow directions in [rbac-docker/README.md](rbac-docker/README.md).
-

--- a/security/rbac/README.md
+++ b/security/rbac/README.md
@@ -193,6 +193,24 @@ confluent iam rolebinding create --principal User:${USER_KSQL} --role ResourceOw
 confluent iam rolebinding create --principal User:${USER_ADMIN_KSQL} --role ResourceOwner --resource Topic:_confluent-ksql-${KSQL_SERVICE_ID}transient --prefix --kafka-cluster-id $KAFKA_CLUSTER_ID
 ```
 
+### General Rolebinding Syntax
+General rolebinding syntax
+```
+confluent iam rolebinding create --role [role name] --principal User:[username] --resource [resource type]:[resource name] --[cluster type]-cluster-id [insert cluster id] 
+```
+available role types and permissions can be found [Here](https://docs.confluent.io/current/security/rbac/rbac-predefined-roles.html)
+
+resource types include: Cluster, Group, Subject, Connector, TransactionalId, Topic
+
+### Listing a Users roles
+General Listing syntax
+``` 
+confluent iam rolebinding list User:[username] [clusters and resources you want to view their roles on]
+```
+example, list the roles of `User:bender` on Kafka cluster `KAFKA_CLUSTER_ID`
+```
+confluent iam rolebinding list --principal User:bender --kafka-cluster-id $KAFKA_CLUSTER_ID 
+```
 
 ### Control Center
 


### PR DESCRIPTION
Added some changes that would have been helpful to me when I started working with RBAC in the beginning, clarifying on the general syntax of defining and listing roles, as well as clarifying what roles and resources are available for ease of use.