### PR TITLE
CONNECT_INTERNAL_KEY_CONVERTER: unbound variable

### DIFF
--- a/microservices-orders/docker-compose.yml
+++ b/microservices-orders/docker-compose.yml
@@ -82,6 +82,8 @@ services:
       CONNECT_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
       CONNECT_PLUGIN_PATH: /usr/share/java
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
+      CONNECT_INTERNAL_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+      CONNECT_INTERNAL_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
 
   control-center:
     image: confluentinc/cp-enterprise-control-center:5.3.1


### PR DESCRIPTION
Fixed
Bug
connect              | /etc/confluent/docker/configure: line 36: CONNECT_INTERNAL_KEY_CONVERTER: unbound variable