### PR TITLE
DEVX-1131: Extend timeout in kafka-consumer-perf-test to prevent failures on run…

### DIFF
--- a/multiregion/README.md
+++ b/multiregion/README.md
@@ -260,7 +260,7 @@ Note: On failback from a failover to observers, any data that was not replicated
 
 ## Run end-to-end demo
 
-All the individual steps above can be run in on shot:
+All the individual steps above can be run with this automated script:
 
 ```
 ./scripts/start.sh
@@ -276,7 +276,7 @@ Stop the demo and all Docker containers.
 
 ## Troubleshooting
 
-1. If containers fail to ping each other (e.g., failures seen in running `./scripts/validate_connectivity.sh`), clean up the Docker environment and then run the demo again.
+1. If containers fail to ping each other (e.g., failures seen in running `./scripts/validate_connectivity.sh`), stop the demo, clean up the Docker environment, and then start the demo again:
 
 ```
 ./scripts/stop.sh

--- a/multiregion/README.md
+++ b/multiregion/README.md
@@ -276,7 +276,7 @@ Stop the demo and all Docker containers.
 
 ## Troubleshooting
 
-1. If containers fail to ping each other (failures seen in running `./scripts/validate_connectivity.sh`), clean up the Docker environment before running the demo again.
+1. If containers fail to ping each other (e.g., failures seen in running `./scripts/validate_connectivity.sh`), clean up the Docker environment and then run the demo again.
 
 ```
 ./scripts/stop.sh

--- a/multiregion/scripts/start-consumer.sh
+++ b/multiregion/scripts/start-consumer.sh
@@ -5,7 +5,8 @@ echo -e "\n\n==> Consume from east: Multi-region Async Replication from Leader i
 docker-compose exec broker-east-3 kafka-consumer-perf-test --topic multi-region-async \
     --messages 5000 \
     --threads 1 \
-    --broker-list broker-west-1:19091,broker-east-3:19093
+    --broker-list broker-west-1:19091,broker-east-3:19093 \
+    --timeout 20000
 
 echo -e "\n\n==> Consume from east: Multi-region Async Replication from Follower in east (topic: multi-region-async) \n"
 
@@ -13,4 +14,5 @@ docker-compose exec broker-east-3 kafka-consumer-perf-test --topic multi-region-
     --messages 5000 \
     --threads 1 \
     --broker-list broker-west-1:19091,broker-east-3:19093 \
-    --consumer.config /etc/kafka/demo/consumer-east.config
+    --consumer.config /etc/kafka/demo/consumer-east.config \
+    --timeout 20000


### PR DESCRIPTION
…ning perf test