### PR TITLE
Demo output text and minor doc-formatting changes

### DIFF
--- a/multiregion/README.md
+++ b/multiregion/README.md
@@ -209,7 +209,7 @@ start.time, end.time, data.consumed.in.MB, MB.sec, data.consumed.in.nMsg, nMsg.s
 2019-09-25 17:10:27:266, 2019-09-25 17:10:53:683, 23.8419, 0.9025, 5000, 189.2721, 1569431435702, -1569431409285, -0.0000, -0.0000
 
 
-==> Consume from east: Multi-region Async Replication reading from Follower in east (topic: multi-region-async)
+==> Consume from east: Multi-region Async Replication reading from Observer in east (topic: multi-region-async)
 
 start.time, end.time, data.consumed.in.MB, MB.sec, data.consumed.in.nMsg, nMsg.sec, rebalance.time.ms, fetch.time.ms, fetch.MB.sec, fetch.nMsg.sec
 2019-09-25 17:10:56:844, 2019-09-25 17:11:02:902, 23.8419, 3.9356, 5000, 825.3549, 1569431461383, -1569431455325, -0.0000, -0.0000

--- a/multiregion/README.md
+++ b/multiregion/README.md
@@ -36,15 +36,15 @@ The full broker configurations are in the [docker-compose.yml](docker-compose.ym
 
 ## Concepts
 
-`Replicas` are brokers assigned to a topic-partition, and they can be a leader, follower, or observer.
-A `leader` is the broker/replica accepting produce messages.
-A `follower` is a broker/replica that can join an ISR list and participate in the calculation of the high watermark (used by the leader when acknowledging messages back to the producer).
+_Replicas_ are brokers assigned to a topic-partition, and they can be a _Leader_, _Follower_, or _Observer_.
+A _Leader_ is the broker/replica accepting produce messages.
+A _Follower_ is a broker/replica that can join an ISR list and participate in the calculation of the high watermark (used by the leader when acknowledging messages back to the producer).
 
-An `ISR` list (in-sync replicas) includes brokers that have a given topic-partition.
+An _ISR_ list (in-sync replicas) includes brokers that have a given topic-partition.
 The data is copied from the leader to every member of the ISR before the producer gets an acknowledgement.
 The followers in an ISR can become the leader if the current leader fails.
 
-An `observer` is a broker/replica that also has a copy of data for a given topic-partition, and consumers are allowed to read from them even though it is not the leader (known as "Follower Fetching").
+An _Observer_ is a broker/replica that also has a copy of data for a given topic-partition, and consumers are allowed to read from them even though it is not the leader (known as "Follower Fetching").
 However, the data is copied asynchronously from the leader such that a producer does not wait on observers to get back an acknowledgement.
 Observers can never participate in the ISR list and cannot become the leader if the current leader fails.
 

--- a/multiregion/scripts/run-consumer.sh
+++ b/multiregion/scripts/run-consumer.sh
@@ -8,7 +8,7 @@ docker-compose exec broker-east-3 kafka-consumer-perf-test --topic multi-region-
     --broker-list broker-west-1:19091,broker-east-3:19093 \
     --timeout 20000
 
-echo -e "\n\n==> Consume from east: Multi-region Async Replication reading from Follower in east (topic: multi-region-async) \n"
+echo -e "\n\n==> Consume from east: Multi-region Async Replication reading from Observer in east (topic: multi-region-async) \n"
 
 docker-compose exec broker-east-3 kafka-consumer-perf-test --topic multi-region-async \
     --messages 5000 \


### PR DESCRIPTION
Consumer demo outputs a banner which should say it is reading from an _Observer_ not a _Follower_ : for `multi-region-async` there are only observers in `east`.

Second commit - prefer italics and capitalisation for concept, non-code/keyword terms _Replicas_, _Followers_ and _Observers_ in this context.