### PR TITLE
Remove extraneous port exposure

### DIFF
--- a/cp-all-in-one/docker-compose.yml
+++ b/cp-all-in-one/docker-compose.yml
@@ -18,7 +18,6 @@ services:
     depends_on:
       - zookeeper
     ports:
-      - "29092:29092"
       - "9092:9092"
     environment:
       KAFKA_BROKER_ID: 1


### PR DESCRIPTION
29092 is for internal (`broker`) access, and does not need to be exposed by Docker. Including it makes the Docker Compose less easy for people to understand.