### PR TITLE
Update control-center-ccloud.delta

### DIFF
--- a/ccloud/ccloud-generate-cp-configs.sh
+++ b/ccloud/ccloud-generate-cp-configs.sh
@@ -272,7 +272,7 @@ while read -r line
     fi
   fi
 done < "$CONFIG_FILE"
-#max.message.bytes is enforced to 8Mb in CCloud
+# max.message.bytes is enforced to 8MB in Confluent Cloud
 echo "confluent.metrics.topic.max.message.bytes=8388608" >> $C3_DELTA
 echo -e "\n# Confluent Schema Registry configuration for Confluent Control Center" >> $C3_DELTA
 while read -r line

--- a/ccloud/ccloud-generate-cp-configs.sh
+++ b/ccloud/ccloud-generate-cp-configs.sh
@@ -272,6 +272,8 @@ while read -r line
     fi
   fi
 done < "$CONFIG_FILE"
+#max.message.bytes is enforced to 8Mb in CCloud
+echo "confluent.metrics.topic.max.message.bytes=8388608" >> $C3_DELTA
 echo -e "\n# Confluent Schema Registry configuration for Confluent Control Center" >> $C3_DELTA
 while read -r line
 do

--- a/ccloud/template_delta_configs/control-center-ccloud.delta
+++ b/ccloud/template_delta_configs/control-center-ccloud.delta
@@ -5,6 +5,7 @@ confluent.controlcenter.streams.sasl.mechanism=PLAIN
 confluent.controlcenter.streams.security.protocol=SASL_SSL
 bootstrap.servers=<CCLOUD_BOOTSTRAP_SERVER>
 confluent.controlcenter.streams.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="<CCLOUD_API_KEY>" password\="<CCLOUD_API_SECRET>";
+confluent.metrics.topic.max.message.bytes=8388608
 
 # Confluent Schema Registry configuration for Confluent Control Center
 confluent.controlcenter.schema.registry.basic.auth.credentials.source=USER_INFO


### PR DESCRIPTION
added confluent.metrics.topic.max.message.bytes=8388608 to be consistent with https://docs.confluent.io/current/cloud/connect/c3-cloud-config.html