### PR TITLE
REP-463 fix for multidc demo timestamp interceptor location change

### DIFF
--- a/multi-datacenter/read-topics.sh
+++ b/multi-datacenter/read-topics.sh
@@ -12,7 +12,7 @@ docker-compose exec schema-registry-dc1 kafka-avro-console-consumer --topic topi
 echo -e "\n_schemas:"
 docker-compose exec broker-dc1 kafka-console-consumer --topic _schemas --bootstrap-server broker-dc1:29091 --from-beginning --timeout-ms 5000
 echo -e "\nprovenance info (cluster, topic, timestamp):"
-docker-compose exec connect-dc1 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/timestamp-interceptor-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic topic1 --bootstrap-server broker-dc1:29091 --max-messages 10 --formatter=io.confluent.connect.replicator.tools.ProvenanceHeaderFormatter"
+docker-compose exec connect-dc1 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/connect-replicator-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic topic1 --bootstrap-server broker-dc1:29091 --max-messages 10 --formatter=io.confluent.connect.replicator.tools.ProvenanceHeaderFormatter"
 echo -e "\ntimestamp info (group: topic-partition):"
 docker-compose exec connect-dc1 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/timestamp-interceptor-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic __consumer_timestamps --bootstrap-server broker-dc1:29091 --property print.key=true --property key.deserializer=io.confluent.connect.replicator.offsets.GroupTopicPartitionDeserializer --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer --max-messages 2"
 echo -e "\ncluster id:"
@@ -28,7 +28,7 @@ docker-compose exec schema-registry-dc1 kafka-avro-console-consumer --topic topi
 echo -e "\n_schemas:"
 docker-compose exec broker-dc1 kafka-console-consumer --topic _schemas --bootstrap-server broker-dc2:29092 --from-beginning --timeout-ms 5000
 echo -e "\nprovenance info (cluster, topic, timestamp):"
-docker-compose exec connect-dc2 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/timestamp-interceptor-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic topic1 --bootstrap-server broker-dc2:29092 --max-messages 10 --formatter=io.confluent.connect.replicator.tools.ProvenanceHeaderFormatter"
+docker-compose exec connect-dc2 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/connect-replicator-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic topic1 --bootstrap-server broker-dc2:29092 --max-messages 10 --formatter=io.confluent.connect.replicator.tools.ProvenanceHeaderFormatter"
 echo -e "\ntimestamp info (group: topic-partition):"
 docker-compose exec connect-dc2 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/timestamp-interceptor-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic __consumer_timestamps --bootstrap-server broker-dc2:29092 --property print.key=true --property key.deserializer=io.confluent.connect.replicator.offsets.GroupTopicPartitionDeserializer --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer --max-messages 2"
 echo -e "\ncluster id:"

--- a/multi-datacenter/read-topics.sh
+++ b/multi-datacenter/read-topics.sh
@@ -12,9 +12,9 @@ docker-compose exec schema-registry-dc1 kafka-avro-console-consumer --topic topi
 echo -e "\n_schemas:"
 docker-compose exec broker-dc1 kafka-console-consumer --topic _schemas --bootstrap-server broker-dc1:29091 --from-beginning --timeout-ms 5000
 echo -e "\nprovenance info (cluster, topic, timestamp):"
-docker-compose exec connect-dc1 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/kafka-connect-replicator-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic topic1 --bootstrap-server broker-dc1:29091 --max-messages 10 --formatter=io.confluent.connect.replicator.tools.ProvenanceHeaderFormatter"
+docker-compose exec connect-dc1 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/timestamp-interceptor-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic topic1 --bootstrap-server broker-dc1:29091 --max-messages 10 --formatter=io.confluent.connect.replicator.tools.ProvenanceHeaderFormatter"
 echo -e "\ntimestamp info (group: topic-partition):"
-docker-compose exec connect-dc1 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/kafka-connect-replicator-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic __consumer_timestamps --bootstrap-server broker-dc1:29091 --property print.key=true --property key.deserializer=io.confluent.connect.replicator.offsets.GroupTopicPartitionDeserializer --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer --max-messages 2"
+docker-compose exec connect-dc1 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/timestamp-interceptor-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic __consumer_timestamps --bootstrap-server broker-dc1:29091 --property print.key=true --property key.deserializer=io.confluent.connect.replicator.offsets.GroupTopicPartitionDeserializer --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer --max-messages 2"
 echo -e "\ncluster id:"
 docker-compose exec zookeeper-dc1 zookeeper-shell localhost:2181 get /cluster/id | grep version | grep id | jq -r .id
 
@@ -28,9 +28,9 @@ docker-compose exec schema-registry-dc1 kafka-avro-console-consumer --topic topi
 echo -e "\n_schemas:"
 docker-compose exec broker-dc1 kafka-console-consumer --topic _schemas --bootstrap-server broker-dc2:29092 --from-beginning --timeout-ms 5000
 echo -e "\nprovenance info (cluster, topic, timestamp):"
-docker-compose exec connect-dc2 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/kafka-connect-replicator-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic topic1 --bootstrap-server broker-dc2:29092 --max-messages 10 --formatter=io.confluent.connect.replicator.tools.ProvenanceHeaderFormatter"
+docker-compose exec connect-dc2 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/timestamp-interceptor-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic topic1 --bootstrap-server broker-dc2:29092 --max-messages 10 --formatter=io.confluent.connect.replicator.tools.ProvenanceHeaderFormatter"
 echo -e "\ntimestamp info (group: topic-partition):"
-docker-compose exec connect-dc2 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/kafka-connect-replicator-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic __consumer_timestamps --bootstrap-server broker-dc2:29092 --property print.key=true --property key.deserializer=io.confluent.connect.replicator.offsets.GroupTopicPartitionDeserializer --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer --max-messages 2"
+docker-compose exec connect-dc2 bash -c "export CLASSPATH=/usr/share/java/kafka-connect-replicator/timestamp-interceptor-5.4.0-SNAPSHOT.jar && kafka-console-consumer --topic __consumer_timestamps --bootstrap-server broker-dc2:29092 --property print.key=true --property key.deserializer=io.confluent.connect.replicator.offsets.GroupTopicPartitionDeserializer --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer --max-messages 2"
 echo -e "\ncluster id:"
 docker-compose exec zookeeper-dc2 zookeeper-shell localhost:2182 get /cluster/id | grep version | grep id | jq -r .id
 


### PR DESCRIPTION
Replicator was refactored in 5.4 to provide the timestamps interceptor in a separate jar. This PR updates the multi data center demo to use this new artifact. There will need to be a follow on PR for master.