### PR TITLE
DEVX-1276 disables loadBalancer by default in gke-base demo

### DIFF
--- a/kubernetes/gke-base/cfg/values.yaml
+++ b/kubernetes/gke-base/cfg/values.yaml
@@ -69,8 +69,7 @@ connect:
 controlcenter:
   <<: *cpImage
   loadBalancer:
-    enabled: true
-#   domain: specific value for your environment, set with --set or in additional values file passed to helm
+    enabled: false
   dependencies:
     c3KafkaCluster:
       zookeeper:


### PR DESCRIPTION
This is required to run the demo w/ out setting the loadBalancer domain.

Thanks for catching @gemma-singleton 