### PR TITLE
Upgrade Avro in examples to 1.9.1

### DIFF
--- a/clients/avro/pom.xml
+++ b/clients/avro/pom.xml
@@ -16,7 +16,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <packaging>jar</packaging>
   <properties>
     <!-- Keep versions as properties to allow easy modification -->
-    <avro.version>1.8.2</avro.version>
+    <avro.version>1.9.1</avro.version>
     <!-- Maven properties for compilation -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/clients/cloud/java/pom.xml
+++ b/clients/cloud/java/pom.xml
@@ -48,7 +48,7 @@
         <java.version>1.8</java.version>
         <slf4j-api.version>1.7.6</slf4j-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <avro.version>1.8.2</avro.version>
+        <avro.version>1.9.1</avro.version>
     </properties>
 
     <dependencies>

--- a/connect-streams-pipeline/pom.xml
+++ b/connect-streams-pipeline/pom.xml
@@ -22,7 +22,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <properties>
     <!-- Keep versions as properties to allow easy modification -->
     <licenses.version>5.4.0-SNAPSHOT</licenses.version>
-    <avro.version>1.8.2</avro.version>
+    <avro.version>1.9.1</avro.version>
     <!-- Maven properties for compilation -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/multi-datacenter/pom.xml
+++ b/multi-datacenter/pom.xml
@@ -16,7 +16,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <packaging>jar</packaging>
   <properties>
     <!-- Keep versions as properties to allow easy modification -->
-    <avro.version>1.8.2</avro.version>
+    <avro.version>1.9.1</avro.version>
     <!-- Maven properties for compilation -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Upgrade Avro to 1.9.1 to be consistent with the rest of the platform, which was also recently upgraded.