### PR TITLE
DEVX-1284: For pre-5.4 GA demos, pull in specific version of kafka-co…

### DIFF
--- a/ccloud/beginner-cloud/Dockerfile
+++ b/ccloud/beginner-cloud/Dockerfile
@@ -17,4 +17,4 @@ FROM confluentinc/cp-kafka-connect:5.3.1
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 
-RUN confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:latest
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.1.6

--- a/ccloud/start.sh
+++ b/ccloud/start.sh
@@ -17,7 +17,7 @@ fi
 
 ./stop.sh
 
-confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:latest
+confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.1.6
 confluent local start connect
 CONFLUENT_CURRENT=`confluent local current | tail -1`
 

--- a/cp-quickstart/start.sh
+++ b/cp-quickstart/start.sh
@@ -9,7 +9,7 @@ check_cli_v2 || exit
 
 ./stop.sh
 
-confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:latest
+confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.1.6
 confluent local start
 sleep 10
 

--- a/security/rbac/scripts/enable-rbac-connect.sh
+++ b/security/rbac/scripts/enable-rbac-connect.sh
@@ -73,8 +73,8 @@ echo "confluent iam rolebinding list --principal User:$USER_ADMIN_CONNECT --kafk
 confluent iam rolebinding list --principal User:$USER_ADMIN_CONNECT --kafka-cluster-id $KAFKA_CLUSTER_ID
 
 echo -e "\n# Install kafka-connect-datagen"
-echo "confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:latest"
-confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:latest
+echo "confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.1.6"
+confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.1.6
 
 echo -e "\n# Bring up Connect"
 confluent local start connect


### PR DESCRIPTION
…nnect-datagen

I have validated one of the demos with this PR, specifically `cp-quickstart/start.sh`.

Related to future change: https://github.com/confluentinc/kafka-connect-datagen/pull/44 