### PR TITLE
DEVX-1326 Add security files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,12 @@ img_data
 *.tar.gz
 kubernetes/common/cp/
 log.*
+*.crt
+*.p12
+*.der
+*.key
+*.pem
+*.jks
+*.csr
+*.srl
+*_creds


### PR DESCRIPTION
No files matching these patterns currently live in this repo, so I've added them to ignore.  Generally no security files should be checked in regardless.

The one pattern added here that might be troublesome is `_creds`, which matches some files generated in `replicator-security` but the pattern is not an extension so it's possible this we might have a file matching this we want in the repo in the future.