### PR TITLE
CC-7524: Bump Datagen connector version in cp-quickstart

### DIFF
--- a/cp-quickstart/start.sh
+++ b/cp-quickstart/start.sh
@@ -9,7 +9,7 @@ check_cli_v2 || exit
 
 ./stop.sh
 
-confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.1.6
+confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.1.7
 confluent local start
 sleep 10
 


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CC-7254)

The most recent release of the Datagen connector, 0.1.7, includes a fix that removes the `AvroConverter` class from its dependencies. This prevents that class from being picked up as a converter plugin by the Connect framework, which as of https://github.com/apache/kafka/pull/7315/ is guaranteed to happen on up-to-date versions of the framework. The Datagen connector excludes several transitive dependencies of the Avro converter, so any the version that's packaged with the connector is used as a converter plugin, things break.