### PR TITLE
DEVX-1282 Upgrade clients/avro to Avro 1.9.1

### DIFF
--- a/clients/avro/checkstyle/suppressions.xml
+++ b/clients/avro/checkstyle/suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+</suppressions>

--- a/clients/avro/pom.xml
+++ b/clients/avro/pom.xml
@@ -7,20 +7,31 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
       <groupId>io.confluent</groupId>
       <artifactId>rest-utils-parent</artifactId>
-      <version>5.3.0</version>
+      <version>5.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-client-avro-examples</artifactId>
-  <version>5.3.0</version>
-
   <packaging>jar</packaging>
+
+  <organization>
+      <name>Confluent, Inc.</name>
+      <url>http://confluent.io</url>
+  </organization>
+  <url>http://confluent.io</url>
+  <description>
+     Avro Client Example
+  </description>
+
   <properties>
     <!-- Keep versions as properties to allow easy modification -->
-    <avro.version>1.8.2</avro.version>
+    <avro.version>1.9.1</avro.version>
     <!-- Maven properties for compilation -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <log4j.version>1.7.25</log4j.version>
+    <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
   </properties>
+
   <repositories>
     <repository>
       <id>confluent</id>
@@ -28,12 +39,14 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       <url>https://packages.confluent.io/maven/</url>
     </repository>
   </repositories>
+
   <pluginRepositories>
     <pluginRepository>
       <id>confluent</id>
       <url>https://packages.confluent.io/maven/</url>
     </pluginRepository>
   </pluginRepositories>
+
   <dependencies>  
     <!-- Add the Kafka dependencies -->
     <dependency>
@@ -57,12 +70,13 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       <version>2.2.4</version>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>
       	<!-- Set the Java target version to 1.8 -->
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.8.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>


### PR DESCRIPTION
This is one PR in an eventual series of them to upgrade Avro versions throughout the repository.

This PR:

- Upgrades Avro to 1.9.1 for the clients/avro example.
- Was tested against the nightly build from 12/4/2019 (build 91)
- Brings the pom.xml into line w/ other CP projects, specificially removes the explict version allowing the project to inherit the version from the parent (rest-utils-parent).
- Upgrades the maven complier plugin to the latest
- Adds a checkstyle suppression file which was required to get the test phase to pass (even though there are no tests here).  I'm not certain what made this required, but possibly something from the upstream parent.  There are no supressions defined here, so this seems like a harmless addition.
- Added some Confluent metadata to pom to bring into line w/ other CP projects.