### PR TITLE
Bumps for 5.4.x branch

### DIFF
--- a/ccloud/beginner-cloud/docker-compose.yml
+++ b/ccloud/beginner-cloud/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   connect-cloud:
-    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.0-SNAPSHOT
+    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.x-latest
     hostname: connect-cloud
     container_name: connect-cloud
     ports:

--- a/ccloud/docker-compose.yml
+++ b/ccloud/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -12,7 +12,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-kafka:5.4.x-latest
     hostname: kafka
     container_name: kafka
     ports:
@@ -36,7 +36,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -54,7 +54,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_SASL_MECHANISM: "PLAIN"
 
   ksql-server:
-    image: confluentinc/cp-ksql-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-server:5.4.x-latest
     hostname: ksql-server
     container_name: ksql-server
     depends_on:
@@ -105,7 +105,7 @@ services:
       #KSQL_CONSUMER_CONFLUENT_MONITORING_INTERCEPTOR_SASL_JAAS_CONFIG: $SASL_JAAS_CONFIG
 
   ksql-cli:
-    image: confluentinc/cp-ksql-cli:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-cli:5.4.x-latest
     container_name: ksql-cli
     volumes:
       - $PWD/ksql.commands:/tmp/ksql.commands
@@ -116,7 +116,7 @@ services:
     tty: true
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-control-center:5.4.x-latest
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -151,7 +151,7 @@ services:
 
   # This "container" is a workaround to pre-create topics
   kafka-create-topics:
-    image: confluentinc/cp-kafka:5.4.0-SNAPSHOT
+    image: confluentinc/cp-kafka:5.4.x-latest
     hostname: kafka-create-topics
     container_name: kafka-create-topics
     depends_on:
@@ -172,7 +172,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: ignored
 
   connect-local:
-    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.0-SNAPSHOT
+    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.x-latest
     hostname: connect-local
     container_name: connect-local
     depends_on:
@@ -222,7 +222,7 @@ services:
       CONNECT_CONSUMER_CONFLUENT_MONITORING_INTERCEPTOR_SASL_MECHANISM: PLAIN
 
   connect-cloud:
-    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.0-SNAPSHOT
+    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.x-latest
     hostname: connect-cloud
     container_name: connect-cloud
     depends_on:
@@ -286,7 +286,7 @@ services:
   # This container is just to transfer Replicator jars to the Connect worker
   # It is not used as a Connect worker
   replicator-for-jar-transfer:
-    image: confluentinc/cp-enterprise-replicator:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-replicator:5.4.x-latest
     hostname: replicator
     container_name: replicator
     volumes:

--- a/clickstream/docker-compose.yml
+++ b/clickstream/docker-compose.yml
@@ -3,14 +3,14 @@ version: '2'
 services:
   zookeeper:
     container_name: zookeeper
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
     container_name: kafka
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     depends_on:
       - zookeeper
     #ports:
@@ -37,7 +37,7 @@ services:
 
   schema-registry:
     container_name: schema-registry
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     depends_on:
       - zookeeper
       - kafka
@@ -47,7 +47,7 @@ services:
 
   kafka-connect:
     container_name: kafka-connect
-    image: confluentinc/cp-server-connect:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server-connect:5.4.x-latest
     ports:
       - 8083:8083
     depends_on:
@@ -83,7 +83,7 @@ services:
 
   ksql-server:
     container_name: ksql-server
-    image: confluentinc/cp-ksql-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-server:5.4.x-latest
     ports: 
       - 8088:8088
     depends_on:
@@ -97,7 +97,7 @@ services:
 
   ksql-cli:
     container_name: ksql-cli
-    image: confluentinc/cp-ksql-cli:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-cli:5.4.x-latest
     depends_on:
       - ksql-server
     entrypoint: /bin/sh
@@ -141,7 +141,7 @@ services:
   datagen:
     container_name: datagen
     # Downrev ksql-examples to 5.1.2 due to DEVX-798 (work around issues in 5.2.0)
-    image: confluentinc/ksql-examples:5.4.0-SNAPSHOT
+    image: confluentinc/ksql-examples:5.4.x-latest
     depends_on:
       - kafka
       - schema-registry

--- a/clients/cloud/kafka-connect-datagen/docker-compose.yml
+++ b/clients/cloud/kafka-connect-datagen/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.0-SNAPSHOT
+    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.x-latest
     hostname: connect
     container_name: connect
     volumes:

--- a/clients/cloud/ksql-datagen/docker-compose.yml
+++ b/clients/cloud/ksql-datagen/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   ksql-datagen:
-    image: confluentinc/ksql-examples:5.4.0-SNAPSHOT
+    image: confluentinc/ksql-examples:5.4.x-latest
     hostname: ksql-datagen
     container_name: ksql-datagen
     volumes:
@@ -17,7 +17,7 @@ services:
       STREAMS_SASL_MECHANISM: "PLAIN"
       STREAMS_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: "HTTPS"
   ksql-datagen-avro:
-    image: confluentinc/ksql-examples:5.4.0-SNAPSHOT
+    image: confluentinc/ksql-examples:5.4.x-latest
     hostname: ksql-datagen-avro
     container_name: ksql-datagen-avro
     volumes:
@@ -35,7 +35,7 @@ services:
       STREAMS__SCHEMA_REGISTRY_BASIC_AUTH_CREDENTIALS_SOURCE: $BASIC_AUTH_CREDENTIALS_SOURCE
       STREAMS__SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO: $SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.0-SNAPSHOT
+    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.x-latest
     hostname: connect
     container_name: connect
     volumes:

--- a/cp-all-in-one-cloud/docker-compose.yml
+++ b/cp-all-in-one-cloud/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     hostname: schema-registry
     container_name: schema-registry
     ports:
@@ -18,7 +18,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_SASL_MECHANISM: "PLAIN"
 
   ksql-server:
-    image: confluentinc/cp-ksql-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-server:5.4.x-latest
     hostname: ksql-server
     container_name: ksql-server
     ports:
@@ -59,13 +59,13 @@ services:
       KSQL_CONSUMER_CONFLUENT_MONITORING_INTERCEPTOR_SASL_JAAS_CONFIG: $SASL_JAAS_CONFIG
 
   ksql-cli:
-    image: confluentinc/cp-ksql-cli:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-cli:5.4.x-latest
     container_name: ksql-cli
     entrypoint: /bin/sh
     tty: true
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-control-center:5.4.x-latest
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -97,7 +97,7 @@ services:
       PORT: 9021
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.0-SNAPSHOT
+    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.x-latest
     hostname: connect
     container_name: connect
     depends_on:
@@ -154,7 +154,7 @@ services:
       CONNECT_CONSUMER_CONFLUENT_MONITORING_INTERCEPTOR_SASL_MECHANISM: PLAIN
 
   rest-proxy:
-    image: confluentinc/cp-kafka-rest:5.4.0-SNAPSHOT
+    image: confluentinc/cp-kafka-rest:5.4.x-latest
     depends_on:
       - schema-registry
     ports:

--- a/cp-all-in-one-community/docker-compose.yml
+++ b/cp-all-in-one-community/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -12,7 +12,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:5.4.0-SNAPSHOT
+    image: confluentinc/cp-kafka:5.4.x-latest
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -42,7 +42,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: cnfldemos/kafka-connect-datagen:0.1.7-5.4.0-SNAPSHOT
+    image: cnfldemos/kafka-connect-datagen:0.1.7-5.4.x-latest
     hostname: connect
     container_name: connect
     depends_on:
@@ -73,7 +73,7 @@ services:
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
 
   ksql-server:
-    image: confluentinc/cp-ksql-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-server:5.4.x-latest
     hostname: ksql-server
     container_name: ksql-server
     depends_on:
@@ -93,7 +93,7 @@ services:
       KSQL_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
 
   ksql-cli:
-    image: confluentinc/cp-ksql-cli:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-cli:5.4.x-latest
     container_name: ksql-cli
     depends_on:
       - broker
@@ -104,7 +104,7 @@ services:
 
   ksql-datagen:
     # Downrev ksql-examples to 5.1.2 due to DEVX-798 (work around issues in 5.2.0)
-    image: confluentinc/ksql-examples:5.4.0-SNAPSHOT
+    image: confluentinc/ksql-examples:5.4.x-latest
     hostname: ksql-datagen
     container_name: ksql-datagen
     depends_on:
@@ -127,7 +127,7 @@ services:
       STREAMS_SCHEMA_REGISTRY_PORT: 8081
 
   rest-proxy:
-    image: confluentinc/cp-kafka-rest:5.4.0-SNAPSHOT
+    image: confluentinc/cp-kafka-rest:5.4.x-latest
     depends_on:
       - zookeeper
       - broker

--- a/cp-all-in-one/docker-compose.yml
+++ b/cp-all-in-one/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -12,7 +12,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: broker
     container_name: broker
     depends_on:
@@ -35,7 +35,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -48,7 +48,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.0-SNAPSHOT
+    image: cnfldemos/cp-server-connect-datagen:0.1.7-5.4.x-latest
     hostname: connect
     container_name: connect
     depends_on:
@@ -83,7 +83,7 @@ services:
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-control-center:5.4.x-latest
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -108,7 +108,7 @@ services:
       PORT: 9021
 
   ksql-server:
-    image: confluentinc/cp-ksql-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-server:5.4.x-latest
     hostname: ksql-server
     container_name: ksql-server
     depends_on:
@@ -128,7 +128,7 @@ services:
       KSQL_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
 
   ksql-cli:
-    image: confluentinc/cp-ksql-cli:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-cli:5.4.x-latest
     container_name: ksql-cli
     depends_on:
       - broker
@@ -139,7 +139,7 @@ services:
 
   ksql-datagen:
     # Downrev ksql-examples to 5.1.2 due to DEVX-798 (work around issues in 5.2.0)
-    image: confluentinc/ksql-examples:5.4.0-SNAPSHOT
+    image: confluentinc/ksql-examples:5.4.x-latest
     hostname: ksql-datagen
     container_name: ksql-datagen
     depends_on:
@@ -162,7 +162,7 @@ services:
       STREAMS_SCHEMA_REGISTRY_PORT: 8081
 
   rest-proxy:
-    image: confluentinc/cp-kafka-rest:5.4.0-SNAPSHOT
+    image: confluentinc/cp-kafka-rest:5.4.x-latest
     depends_on:
       - zookeeper
       - broker

--- a/microservices-orders/docker-compose.yml
+++ b/microservices-orders/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -12,7 +12,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: broker
     container_name: broker
     depends_on:
@@ -36,7 +36,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -49,7 +49,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: confluentinc/cp-server-connect:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server-connect:5.4.x-latest
     hostname: connect
     container_name: connect
     depends_on:
@@ -87,7 +87,7 @@ services:
       CONNECT_INTERNAL_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-control-center:5.4.x-latest
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -112,7 +112,7 @@ services:
       PORT: 9021
 
   ksql-server:
-    image: confluentinc/cp-ksql-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-server:5.4.x-latest
     hostname: ksql-server
     container_name: ksql-server
     depends_on:
@@ -133,7 +133,7 @@ services:
       KSQL_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
 
   ksql-cli:
-    image: confluentinc/cp-ksql-cli:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-cli:5.4.x-latest
     container_name: ksql-cli
     depends_on:
       - broker
@@ -143,7 +143,7 @@ services:
     tty: true
 
   ksql-query-setup:
-    image: confluentinc/cp-ksql-cli:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-cli:5.4.x-latest
     container_name: ksql-query-setup
     depends_on:
       - broker
@@ -157,7 +157,7 @@ services:
     command: "/tmp/run-ksql.sh"
 
   microservices-app:
-    image: confluentinc/kafka-streams-examples:5.4.0-SNAPSHOT
+    image: confluentinc/kafka-streams-examples:5.4.x-latest
     hostname: microservices-app
     container_name: microservices-app
     depends_on:
@@ -182,7 +182,7 @@ services:
 
   # This "container" is a workaround to pre-create topics
   kafka-setup:
-    image: confluentinc/cp-kafka:5.4.0-SNAPSHOT
+    image: confluentinc/cp-kafka:5.4.x-latest
     hostname: kafka-setup
     container_name: kafka-setup
     depends_on:

--- a/multi-datacenter/docker-compose.yml
+++ b/multi-datacenter/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   zookeeper-dc1:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     hostname: zookeeper-dc1
     container_name: zookeeper-dc1
     ports:
@@ -12,7 +12,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   zookeeper-dc2:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     hostname: zookeeper-dc2
     container_name: zookeeper-dc2
     ports:
@@ -22,7 +22,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker-dc1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: broker-dc1
     container_name: broker-dc1
     depends_on:
@@ -47,7 +47,7 @@ services:
       CONFLUENT_METRICS_ENABLE: 'true'
 
   broker-dc2:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: broker-dc2
     container_name: broker-dc2
     depends_on:
@@ -72,7 +72,7 @@ services:
       CONFLUENT_METRICS_ENABLE: 'true'
 
   schema-registry-dc1:
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     hostname: schema-registry-dc1
     container_name: schema-registry-dc1
     restart: always
@@ -88,7 +88,7 @@ services:
       SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL: ERROR
 
   schema-registry-dc2:
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     hostname: schema-registry-dc2
     container_name: schema-registry-dc2
     restart: always
@@ -106,7 +106,7 @@ services:
       SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL: ERROR
 
   connect-dc2:
-    image: confluentinc/cp-enterprise-replicator:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-replicator:5.4.x-latest
     hostname: connect-dc2
     container_name: connect-dc2
     depends_on:
@@ -149,7 +149,7 @@ services:
       KAFKA_JMX_HOSTNAME: localhost
 
   connect-dc1:
-    image: confluentinc/cp-enterprise-replicator:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-replicator:5.4.x-latest
     hostname: connect-dc1
     container_name: connect-dc1
     depends_on:
@@ -192,7 +192,7 @@ services:
       KAFKA_JMX_HOSTNAME: localhost
 
   datagen-dc1-topic1:
-    image: confluentinc/ksql-examples:5.4.0-SNAPSHOT
+    image: confluentinc/ksql-examples:5.4.x-latest
     hostname: datagen-dc1-topic1
     container_name: datagen-dc1-topic1
     depends_on:
@@ -216,7 +216,7 @@ services:
       STREAMS_SCHEMA_REGISTRY_PORT: 8081
 
   datagen-dc1-topic2:
-    image: confluentinc/ksql-examples:5.4.0-SNAPSHOT
+    image: confluentinc/ksql-examples:5.4.x-latest
     hostname: datagen-dc1-topic2
     container_name: datagen-dc1-topic2
     depends_on:
@@ -239,7 +239,7 @@ services:
       STREAMS_SCHEMA_REGISTRY_PORT: 8081
 
   datagen-dc2-topic1:
-    image: confluentinc/ksql-examples:5.4.0-SNAPSHOT
+    image: confluentinc/ksql-examples:5.4.x-latest
     hostname: datagen-dc2-topic1
     container_name: datagen-dc2-topic1
     depends_on:
@@ -264,7 +264,7 @@ services:
 
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-control-center:5.4.x-latest
     hostname: control-center
     container_name: control-center
     depends_on:

--- a/multiregion/docker-compose.yml
+++ b/multiregion/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   zookeeper-west:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     hostname: zookeeper-west
     container_name: zookeeper-west
     networks:
@@ -15,7 +15,7 @@ services:
         ZOOKEEPER_SERVERS: zookeeper-west:2888:3888;zookeeper-central:2888:3888;zookeeper-east:2888:3888
       
   zookeeper-central:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     hostname: zookeeper-central
     container_name: zookeeper-central
     networks:
@@ -30,7 +30,7 @@ services:
       - zookeeper-west
 
   zookeeper-east:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     hostname: zookeeper-east
     container_name: zookeeper-east
     networks:
@@ -46,7 +46,7 @@ services:
       - zookeeper-central
 
   broker-west-1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: broker-west-1
     container_name: broker-west-1
     networks:
@@ -73,7 +73,7 @@ services:
       - zookeeper-east
 
   broker-west-2:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: broker-west-2
     container_name: broker-west-2
     networks:
@@ -99,7 +99,7 @@ services:
       - broker-west-1
 
   broker-east-3:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: broker-east-3
     container_name: broker-east-3
     networks:
@@ -128,7 +128,7 @@ services:
       - broker-west-2
 
   broker-east-4:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: broker-east-4
     container_name: broker-east-4
     networks:

--- a/music/docker-compose.yml
+++ b/music/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -14,7 +14,7 @@ services:
       - "moby:127.0.0.1"
 
   kafka:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: kafka
     container_name: kafka
     ports:
@@ -42,7 +42,7 @@ services:
       - "moby:127.0.0.1"
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -58,7 +58,7 @@ services:
 
   # Continuously generates input data for the Kafka Music application.
   kafka-music-data-generator:
-    image: confluentinc/kafka-streams-examples:5.4.0-SNAPSHOT
+    image: confluentinc/kafka-streams-examples:5.4.x-latest
     hostname: kafka-music-data-generator
     container_name: kafka-music-data-generator
     depends_on:
@@ -83,7 +83,7 @@ services:
 
   # Runs the Kafka Music application.
   kafka-music-application:
-    image: confluentinc/kafka-streams-examples:5.4.0-SNAPSHOT
+    image: confluentinc/kafka-streams-examples:5.4.x-latest
     hostname: kafka-music-application
     container_name: kafka-music-applications-streams
     depends_on:
@@ -116,7 +116,7 @@ services:
       - "moby:127.0.0.1"
 
   ksql-server:
-    image: confluentinc/cp-ksql-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-server:5.4.x-latest
     hostname: ksql-server
     container_name: ksql-server
     depends_on:
@@ -136,7 +136,7 @@ services:
       KSQL_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
 
   ksql-cli:
-    image: confluentinc/cp-ksql-cli:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-cli:5.4.x-latest
     container_name: ksql-cli
     volumes:
       - $PWD/ksql.commands:/tmp/ksql.commands
@@ -147,7 +147,7 @@ services:
     tty: true
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-control-center:5.4.x-latest
     hostname: control-center
     container_name: control-center
     depends_on:

--- a/postgres-debezium-ksql-elasticsearch/docker-compose/docker-compose.yml
+++ b/postgres-debezium-ksql-elasticsearch/docker-compose/docker-compose.yml
@@ -2,13 +2,13 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     ports:
       - '9092:9092'
     depends_on:
@@ -31,7 +31,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     depends_on:
       - zookeeper
       - kafka
@@ -42,7 +42,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:2181
 
   kafka-connect-cp:
-    image: confluentinc/cp-server-connect:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server-connect:5.4.x-latest
     ports:
       - "18083:18083"
     environment:
@@ -75,7 +75,7 @@ services:
 
   # KSQL
   ksql-server:
-    image: confluentinc/cp-ksql-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-server:5.4.x-latest
     depends_on:
       - kafka
       - schema-registry
@@ -124,7 +124,7 @@ services:
   # Runs the Kafka KSQL data generator for ratings
   datagen-ratings:
     # Downrev ksql-examples to 5.1.2 due to DEVX-798 (work around issues in 5.2.0)
-    image: confluentinc/ksql-examples:5.4.0-SNAPSHOT
+    image: confluentinc/ksql-examples:5.4.x-latest
     depends_on:
       - kafka
       - schema-registry
@@ -147,7 +147,7 @@ services:
       STREAMS_SCHEMA_REGISTRY_PORT: 8081
 
   ksql-cli:
-    image: confluentinc/cp-ksql-cli:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-cli:5.4.x-latest
     depends_on:
       - kafka
       - schema-registry

--- a/replicator-schema-translation/docker-compose.yml
+++ b/replicator-schema-translation/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   srcZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: srcZookeeper
     container_name: srcZookeeper
@@ -12,7 +12,7 @@ services:
     ports:
       - "2181:2181"
   destZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: destZookeeper
     container_name: destZookeeper
@@ -23,7 +23,7 @@ services:
     ports:
       - "2281:2281"
   srcKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafka1
     container_name: srcKafka1
     cpus: 0.3
@@ -43,7 +43,7 @@ services:
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
       KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
   destKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafka1
     container_name: destKafka1
     cpus: 0.3
@@ -62,7 +62,7 @@ services:
       KAFKA_DELETE_TOPIC_ENABLE: "true"
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
   connect:
-    image: confluentinc/cp-server-connect:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server-connect:5.4.x-latest
     container_name: connect
     cpus: 0.2
     restart: always
@@ -94,7 +94,7 @@ services:
       CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
       CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
   srcSchemaregistry:
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     container_name: srcSchemaregistry
     cpus: 0.4
     restart: always
@@ -111,7 +111,7 @@ services:
     ports:
       - 8085:8085
   destSchemaregistry:
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     container_name: destSchemaregistry
     cpus: 0.4
     restart: always
@@ -128,14 +128,14 @@ services:
     ports:
       - 8086:8086
   replicator-for-jar-transfer:
-    image: confluentinc/cp-enterprise-replicator:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-replicator:5.4.x-latest
     hostname: replicator-for-jar-transfer
     container_name: replicator-for-jar-transfer
     volumes:
       - mi3:/usr/share/java/kafka-connect-replicator/
     command: "sleep infinity"
   kafka-client:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: kafka-client
     container_name: kafka-client
     cpus: 0.1

--- a/replicator-security/dest_sasl_plain_auth/docker-compose.yml
+++ b/replicator-security/dest_sasl_plain_auth/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   srcZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: srcZookeeper
     container_name: srcZookeeper
@@ -12,7 +12,7 @@ services:
     ports:
       - "2181:2181"
   destZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: destZookeeper
     container_name: destZookeeper
@@ -28,7 +28,7 @@ services:
     volumes:
       - $PWD/scripts/security:/etc/kafka/secrets
   srcKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafka1
     container_name: srcKafka1
     cpus: 0.3
@@ -48,7 +48,7 @@ services:
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
       KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
   destKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafka1
     container_name: destKafka1
     cpus: 0.3
@@ -72,7 +72,7 @@ services:
       KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
       KAFKA_OPTS: -Djava.security.auth.login.config=/etc/kafka/secrets/broker_jaas.conf
   connect:
-    image: confluentinc/cp-server-connect:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server-connect:5.4.x-latest
     container_name: connect
     cpus: 0.2
     restart: always
@@ -118,14 +118,14 @@ services:
       CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
       CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
   replicator-for-jar-transfer:
-    image: confluentinc/cp-enterprise-replicator:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-replicator:5.4.x-latest
     hostname: replicator-for-jar-transfer
     container_name: replicator-for-jar-transfer
     volumes:
       - mi3:/usr/share/java/kafka-connect-replicator/
     command: "sleep infinity"
   srcKafkaClient:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafkaClient
     container_name: srcKafkaClient
     cpus: 0.1
@@ -147,7 +147,7 @@ services:
       KAFKA_ADVERTISED_LISTENERS: ignored
 
   destKafkaClient:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafkaClient
     container_name: destKafkaClient
     cpus: 0.1

--- a/replicator-security/dest_ssl_auth/docker-compose.yml
+++ b/replicator-security/dest_ssl_auth/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   srcZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: srcZookeeper
     container_name: srcZookeeper
@@ -12,7 +12,7 @@ services:
     ports:
       - "2181:2181"
   destZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: destZookeeper
     container_name: destZookeeper
@@ -23,7 +23,7 @@ services:
     ports:
       - "2281:2281"
   srcKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafka1
     container_name: srcKafka1
     cpus: 0.3
@@ -43,7 +43,7 @@ services:
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
       KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
   destKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafka1
     container_name: destKafka1
     cpus: 0.3
@@ -71,7 +71,7 @@ services:
       KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: "HTTPS"
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
   connect:
-    image: confluentinc/cp-server-connect:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server-connect:5.4.x-latest
     container_name: connect
     cpus: 0.2
     restart: always
@@ -115,14 +115,14 @@ services:
       CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
       CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
   replicator-for-jar-transfer:
-    image: confluentinc/cp-enterprise-replicator:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-replicator:5.4.x-latest
     hostname: replicator-for-jar-transfer
     container_name: replicator-for-jar-transfer
     volumes:
       - mi3:/usr/share/java/kafka-connect-replicator/
     command: "sleep infinity"
   srcKafkaClient:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafkaClient
     container_name: srcKafkaClient
     cpus: 0.1
@@ -143,7 +143,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: ignored
       KAFKA_ADVERTISED_LISTENERS: ignored
   destKafkaClient:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafkaClient
     container_name: destKafkaClient
     cpus: 0.1

--- a/replicator-security/dest_ssl_encryption/docker-compose.yml
+++ b/replicator-security/dest_ssl_encryption/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   srcZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: srcZookeeper
     container_name: srcZookeeper
@@ -12,7 +12,7 @@ services:
     ports:
       - "2181:2181"
   destZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: destZookeeper
     container_name: destZookeeper
@@ -23,7 +23,7 @@ services:
     ports:
       - "2281:2281"
   srcKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafka1
     container_name: srcKafka1
     cpus: 0.3
@@ -43,7 +43,7 @@ services:
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
       KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
   destKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafka1
     container_name: destKafka1
     cpus: 0.3
@@ -69,7 +69,7 @@ services:
       KAFKA_SSL_TRUSTSTORE_PASSWORD: confluent
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
   connect:
-    image: confluentinc/cp-server-connect:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server-connect:5.4.x-latest
     container_name: connect
     cpus: 0.2
     restart: always
@@ -113,14 +113,14 @@ services:
       CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
       CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
   replicator-for-jar-transfer:
-    image: confluentinc/cp-enterprise-replicator:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-replicator:5.4.x-latest
     hostname: replicator-for-jar-transfer
     container_name: replicator-for-jar-transfer
     volumes:
       - mi3:/usr/share/java/kafka-connect-replicator/
     command: "sleep infinity"
   srcKafkaClient:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafkaClient
     container_name: srcKafkaClient
     cpus: 0.1
@@ -141,7 +141,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: ignored
       KAFKA_ADVERTISED_LISTENERS: ignored
   destKafkaClient:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafkaClient
     container_name: destKafkaClient
     cpus: 0.1

--- a/replicator-security/source_sasl_plain_auth/docker-compose.yml
+++ b/replicator-security/source_sasl_plain_auth/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   srcZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: srcZookeeper
     container_name: srcZookeeper
@@ -17,7 +17,7 @@ services:
     volumes:
       - $PWD/scripts/security:/etc/kafka/secrets
   destZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: destZookeeper
     container_name: destZookeeper
@@ -28,7 +28,7 @@ services:
     ports:
       - "2281:2281"
   srcKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafka1
     container_name: srcKafka1
     cpus: 0.3
@@ -53,7 +53,7 @@ services:
       KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
       KAFKA_OPTS: -Djava.security.auth.login.config=/etc/kafka/secrets/broker_jaas.conf
   destKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafka1
     container_name: destKafka1
     cpus: 0.3
@@ -72,7 +72,7 @@ services:
       KAFKA_DELETE_TOPIC_ENABLE: "true"
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
   connect:
-    image: confluentinc/cp-server-connect:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server-connect:5.4.x-latest
     container_name: connect
     cpus: 0.2
     restart: always
@@ -103,14 +103,14 @@ services:
       CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
       CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
   replicator-for-jar-transfer:
-    image: confluentinc/cp-enterprise-replicator:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-replicator:5.4.x-latest
     hostname: replicator-for-jar-transfer
     container_name: replicator-for-jar-transfer
     volumes:
       - mi3:/usr/share/java/kafka-connect-replicator/
     command: "sleep infinity"
   srcKafkaClient:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafkaClient
     container_name: srcKafkaClient
     cpus: 0.1
@@ -139,7 +139,7 @@ services:
       KAFKA_SASL_MECHANISM: PLAIN
       KAFKA_OPTS: -Djava.security.auth.login.config=/etc/kafka/secrets/client_jaas.conf
   destKafkaClient:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafkaClient
     container_name: destKafkaClient
     cpus: 0.1

--- a/replicator-security/source_ssl_auth/docker-compose.yml
+++ b/replicator-security/source_ssl_auth/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   srcZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: srcZookeeper
     container_name: srcZookeeper
@@ -12,7 +12,7 @@ services:
     ports:
       - "2181:2181"
   destZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: destZookeeper
     container_name: destZookeeper
@@ -23,7 +23,7 @@ services:
     ports:
       - "2281:2281"
   srcKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafka1
     container_name: srcKafka1
     cpus: 0.3
@@ -52,7 +52,7 @@ services:
       KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: "HTTPS"
       KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
   destKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafka1
     container_name: destKafka1
     cpus: 0.3
@@ -71,7 +71,7 @@ services:
       KAFKA_DELETE_TOPIC_ENABLE: "true"
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
   connect:
-    image: confluentinc/cp-server-connect:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server-connect:5.4.x-latest
     container_name: connect
     cpus: 0.2
     restart: always
@@ -103,14 +103,14 @@ services:
       CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
       CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
   replicator-for-jar-transfer:
-    image: confluentinc/cp-enterprise-replicator:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-replicator:5.4.x-latest
     hostname: replicator-for-jar-transfer
     container_name: replicator-for-jar-transfer
     volumes:
       - mi3:/usr/share/java/kafka-connect-replicator/
     command: "sleep infinity"
   srcKafkaClient:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafkaClient
     container_name: srcKafkaClient
     cpus: 0.1
@@ -137,7 +137,7 @@ services:
       KAFKA_SSL_KEY_PASSWORD: confluent
       KAFKA_SECURITY_PROTOCOL: SSL
   destKafkaClient:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafkaClient
     container_name: destKafkaClient
     cpus: 0.1

--- a/replicator-security/source_ssl_encryption/docker-compose.yml
+++ b/replicator-security/source_ssl_encryption/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   srcZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: srcZookeeper
     container_name: srcZookeeper
@@ -12,7 +12,7 @@ services:
     ports:
       - "2181:2181"
   destZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: destZookeeper
     container_name: destZookeeper
@@ -23,7 +23,7 @@ services:
     ports:
       - "2281:2281"
   srcKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafka1
     container_name: srcKafka1
     cpus: 0.3
@@ -50,7 +50,7 @@ services:
       KAFKA_SSL_TRUSTSTORE_PASSWORD: confluent
       KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
   destKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafka1
     container_name: destKafka1
     cpus: 0.3
@@ -69,7 +69,7 @@ services:
       KAFKA_DELETE_TOPIC_ENABLE: "true"
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
   connect:
-    image: confluentinc/cp-server-connect:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server-connect:5.4.x-latest
     container_name: connect
     cpus: 0.2
     restart: always
@@ -101,14 +101,14 @@ services:
       CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
       CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
   replicator-for-jar-transfer:
-    image: confluentinc/cp-enterprise-replicator:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-replicator:5.4.x-latest
     hostname: replicator-for-jar-transfer
     container_name: replicator-for-jar-transfer
     volumes:
       - mi3:/usr/share/java/kafka-connect-replicator/
     command: "sleep infinity"
   srcKafkaClient:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafkaClient
     container_name: srcKafkaClient
     cpus: 0.1
@@ -135,7 +135,7 @@ services:
       KAFKA_SSL_KEY_PASSWORD: confluent
       KAFKA_SECURITY_PROTOCOL: SSL
   destKafkaClient:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafkaClient
     container_name: destKafkaClient
     cpus: 0.1

--- a/replicator-security/unsecure/docker-compose.yml
+++ b/replicator-security/unsecure/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   srcZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: srcZookeeper
     container_name: srcZookeeper
@@ -12,7 +12,7 @@ services:
     ports:
       - "2181:2181"
   destZookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: destZookeeper
     container_name: destZookeeper
@@ -23,7 +23,7 @@ services:
     ports:
       - "2281:2281"
   srcKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: srcKafka1
     container_name: srcKafka1
     cpus: 0.3
@@ -43,7 +43,7 @@ services:
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
       KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
   destKafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: destKafka1
     container_name: destKafka1
     cpus: 0.3
@@ -62,7 +62,7 @@ services:
       KAFKA_DELETE_TOPIC_ENABLE: "true"
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
   connect:
-    image: confluentinc/cp-server-connect:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server-connect:5.4.x-latest
     container_name: connect
     cpus: 0.2
     restart: always
@@ -93,14 +93,14 @@ services:
       CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
       CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
   replicator-for-jar-transfer:
-    image: confluentinc/cp-enterprise-replicator:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-replicator:5.4.x-latest
     hostname: replicator-for-jar-transfer
     container_name: replicator-for-jar-transfer
     volumes:
       - mi3:/usr/share/java/kafka-connect-replicator/
     command: "sleep infinity"
   kafka-client:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: kafka-client
     container_name: kafka-client
     cpus: 0.1


### PR DESCRIPTION
cp-demo: Bump 5.4.x branch

Issue:
Docker image tag got bumped to in-correct value for docker image tags during 5.4.x branch cut.

Solution:
- learn about all the changes required for devx repositories both during branch cut & release version bumps.
- address immediate issue by bumping these to 5.4.x-latest
- update branch cut steps to avoid future issues:
https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/582517464/Major+Minor+Release+Release+Branch+Creation+Feature+Freeze#Major/MinorRelease:ReleaseBranchCreation(FeatureFreeze)-DevXFollowups

Automate via tooling - Added jira to fix tooling:
https://confluentinc.atlassian.net/browse/ST-2650



