### PR TITLE
DEVX-1385 corrects version for jackson xml core lib

### DIFF
--- a/clients/cloud/java/pom.xml
+++ b/clients/cloud/java/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.8.11.1,)</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
This makes the jackson version inherited from the parent pom (modeled after kafka-streams-examples) and results in the proper downloading of the dependency and resolves the ClassNotFound exception that was at the core of this issue.

Tested locally against stag Confluent Cloud