### PR TITLE
DEVX-1408: fix logging in avro example

### DIFF
--- a/clients/avro/pom.xml
+++ b/clients/avro/pom.xml
@@ -28,7 +28,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <!-- Maven properties for compilation -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <log4j.version>1.7.25</log4j.version>
     <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
   </properties>
 
@@ -69,6 +68,10 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>gson</artifactId>
       <version>2.2.4</version>
     </dependency>
+    <dependency>
+       <groupId>org.slf4j</groupId>
+       <artifactId>slf4j-log4j12</artifactId>
+     </dependency>
   </dependencies>
 
   <build>

--- a/clients/avro/src/main/resources/log4j.properties
+++ b/clients/avro/src/main/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Root logger option
+log4j.rootLogger=WARN, stdout
+ 
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.err
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
Output is now:

```
avro(DEVX-1408): mvn exec:java -Dexec.mainClass=io.confluent.examples.clients.basicavro.ProducerExample

[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: osx
[INFO] os.detected.arch: x86_64
[INFO] os.detected.version: 10.14
[INFO] os.detected.version.major: 10
[INFO] os.detected.version.minor: 14
[INFO] os.detected.classifier: osx-x86_64
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building java-client-avro-examples 5.4.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- exec-maven-plugin:1.5.0:java (default-cli) @ java-client-avro-examples ---
Successfully produced 10 messages to a topic called transactions
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 13.838 s
[INFO] Finished at: 2019-12-19T07:58:45-05:00
[INFO] Final Memory: 23M/193M
[INFO] ------------------------------------------------------------------------
```