### PR TITLE
quiets check_running_cp a bit to reduce demo noise

### DIFF
--- a/utils/helper.sh
+++ b/utils/helper.sh
@@ -161,9 +161,9 @@ function check_running_cp() {
   check_curl
   expected_version=$1
 
-  actual_version=$( confluent local version | tail -1 | awk -F':' '{print $2;}' | awk '$1 > 0 { print substr($1,1,3)}' )
+  actual_version=$( confluent local version 2>/dev/null | awk -F':' '{print $2;}' | awk '$1 > 0 { print substr($1,1,3)}' )
   if [[ $expected_version != $actual_version ]]; then
-    echo -e "\nThis script expects Confluent Platform version $expected_version but the running version is $actual_version.\nTo proceed please either: change the examples repo branch to $actual_version or update the running Confluent Platform to version $expected_version.\n"
+    printf "\nThis script expects Confluent Platform version $expected_version but the running version is $actual_version.\nTo proceed please either: change the examples repo branch to $actual_version or update the running Confluent Platform to version $expected_version.\n"
     exit 1
   fi
 

--- a/utils/helper.sh
+++ b/utils/helper.sh
@@ -157,8 +157,17 @@ function check_gcp_creds() {
   fi
 }
 
+function require_cp_or_exit() {
+  command -v confluent >/dev/null 2>&1 || {
+    printf "\nconfluent command not found.  Please check your Confluent Platform installation\n"
+    exit 1;
+  }
+}
+
 function check_running_cp() {
+  require_cp_or_exit
   check_curl
+
   expected_version=$1
 
   actual_version=$( confluent local version 2>/dev/null | awk -F':' '{print $2;}' | awk '$1 > 0 { print substr($1,1,3)}' )
@@ -171,6 +180,8 @@ function check_running_cp() {
 }
 
 function check_cp() {
+  require_cp_or_exit
+
   type=$( confluent local version 2>/dev/null | tail -1 | awk -F: '{print $1;}' | tr '[:lower:]' '[:upper:]')
   case $type in
     *PLATFORM*)


### PR DESCRIPTION
the cp local warning gets very redundant in demo scripts.  This function is just meant to check the version of the installed cp, so don't we need to show the warning here