### PR TITLE
DEVX-1204 tweaks clickstream ksql script to work w/ 5.4

### DIFF
--- a/clickstream/ksql/ksql-clickstream-demo/demo/clickstream-schema.sql
+++ b/clickstream/ksql/ksql-clickstream-demo/demo/clickstream-schema.sql
@@ -1,5 +1,4 @@
 set 'commit.interval.ms'='2000';
-set 'cache.max.bytes.buffering'='10000000';
 set 'auto.offset.reset'='earliest';
 
 -- 1. SOURCE of ClickStream
@@ -65,3 +64,4 @@ CREATE TABLE USER_IP_ACTIVITY AS SELECT username, WindowStart() AS EVENT_TS, ip,
 ----------------------------------------------------------------------------------------------------------------------------
 
 CREATE TABLE CLICK_USER_SESSIONS AS SELECT username, WindowStart() AS EVENT_TS, count(*) AS events FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username;
+


### PR DESCRIPTION
`cache.max.bytes.buffering` is no longer supported.   Adding a new line to the last line in the script file allowed the script to be properly parsed by ksql cli