### PR TITLE
DEVX-1379: Use 5.4.0-standalone built jar for kafka-streams

### DIFF
--- a/microservices-orders/get-kafka-streams-examples.sh
+++ b/microservices-orders/get-kafka-streams-examples.sh
@@ -2,7 +2,7 @@
 
 # Compile java client code
 [[ -d "kafka-streams-examples" ]] || git clone https://github.com/confluentinc/kafka-streams-examples.git
-(cd kafka-streams-examples && git fetch && git checkout 5.4.x && git pull && mvn clean compile -DskipTests package)
+(cd kafka-streams-examples && git fetch && git checkout 5.4.0-post && git pull && mvn clean compile -DskipTests package)
 if [[ $? != 0 ]]; then
   echo "ERROR: There seems to be a BUILD FAILURE error? Please troubleshoot"
   exit 1

--- a/music/start.sh
+++ b/music/start.sh
@@ -14,8 +14,8 @@ confluent local start
 
 [[ -d "kafka-streams-examples" ]] || git clone https://github.com/confluentinc/kafka-streams-examples.git
 (cd kafka-streams-examples && git checkout 5.4.0-post)
-[[ -f "kafka-streams-examples/target/kafka-streams-examples-5.4.0-SNAPSHOT-standalone.jar" ]] || (cd kafka-streams-examples && mvn clean package -DskipTests)
-java -cp kafka-streams-examples/target/kafka-streams-examples-5.4.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.interactivequeries.kafkamusic.KafkaMusicExampleDriver &>/dev/null &
+[[ -f "kafka-streams-examples/target/kafka-streams-examples-5.4.0-standalone.jar" ]] || (cd kafka-streams-examples && mvn clean package -DskipTests)
+java -cp kafka-streams-examples/target/kafka-streams-examples-5.4.0-standalone.jar io.confluent.examples.streams.interactivequeries.kafkamusic.KafkaMusicExampleDriver &>/dev/null &
 
 sleep 5
 


### PR DESCRIPTION
kafka-streams-examples 5.4.0-post is available, and it doesn't build w/ the SNAPSHOT on that branch, so this fixes that routine up in microservices and music