### PR TITLE
DOCS-3222 Added tips on settings for continuous migration

### DIFF
--- a/replicator-schema-translation/docs/index.rst
+++ b/replicator-schema-translation/docs/index.rst
@@ -103,7 +103,7 @@ Run the Demo
       docker-compose exec connect /etc/kafka/scripts/set_sr_modes_post_translation.sh
       
 .. tip:: This demo shows a `one-time migration` of schemas across self-managed clusters. To configure a
-         `continuous migration`, the last steps would be to keep the origin (source) in READONLY mode, and set the destination
+         `continuous migration`, the last steps would be to keep the origin (source) |sr| in READONLY mode, and set the destination
          to READWRITE. Note that this only works for a "one-way" migration; that is, an active-to-passive
          |crep| setup. This is especially helpful if configure topic names to be different on the destination,
          using the translation configuration, ``topic.rename.format`` (described in :ref:`Replicator configuration destination topics <rep-destination-topics>`),

--- a/replicator-schema-translation/docs/index.rst
+++ b/replicator-schema-translation/docs/index.rst
@@ -80,7 +80,7 @@ Run the Demo
 
       docker-compose exec connect /etc/kafka/scripts/submit_replicator.sh
 
-   Your output should show the posted |crep| configuration. The key configuration that enables the schema translation is `schema.subject.translator.class=io.confluent.connect.replicator.schemas.DefaultSubjectTranslator`
+   Your output should show the posted |crep| configuration. The key configuration that enables the schema translation is ``schema.subject.translator.class=io.confluent.connect.replicator.schemas.DefaultSubjectTranslator``
 
    .. sourcecode:: bash
 
@@ -103,11 +103,9 @@ Run the Demo
       docker-compose exec connect /etc/kafka/scripts/set_sr_modes_post_translation.sh
       
 .. tip:: This demo shows a `one-time migration` of schemas across self-managed clusters. To configure a
-         `continuous migration`, the last steps would be to keep the origin (source) |sr| in READONLY mode, and set the destination
-         to READWRITE. Note that this only works for a "one-way" migration; that is, an active-to-passive
-         |crep| setup. This is especially helpful if configure topic names to be different on the destination,
-         using the translation configuration, ``topic.rename.format`` (described in :ref:`Replicator configuration destination topics <rep-destination-topics>`),
-         to rename the subjects in the schemas accordingly as it migrates them.
+         `continuous migration`, the last steps would be to keep the origin (source) |sr| in READONLY mode,
+         and set the destination to READWRITE. Note that this would set up a "one-way" migration; that is,
+         an active-to-passive |crep| setup.
 
 ========
 Teardown
@@ -124,11 +122,13 @@ Suggested Reading
 =================
 
 * :ref:`schemaregistry_migrate`
-* :ref:`schemaregistry_config`
+* :ref:`sr-subjects-topics-primer`
 * :ref:`replicator_quickstart`
+* :ref:`replicator_failover`
 
 * These sections in :ref:`Replicator Configuration Options<connect_replicator_config_options>`: 
 
   - :ref:`rep-source-topics`
   - :ref:`rep-destination-topics`
   - :ref:`schema_translation`
+

--- a/replicator-schema-translation/docs/index.rst
+++ b/replicator-schema-translation/docs/index.rst
@@ -102,7 +102,7 @@ Run the Demo
 
       docker-compose exec connect /etc/kafka/scripts/set_sr_modes_post_translation.sh
       
-.. tip:: This demo showed a `one-time migration` of schemas across self-managed clusters. To configure a
+.. tip:: This demo shows a `one-time migration` of schemas across self-managed clusters. To configure a
          `continuous migration`, the last steps would be to keep the origin (source) in READONLY mode, and set the destination
          to READWRITE. Note that this only works for a "one-way" migration; that is, an active-to-passive
          |crep| setup. This is especially helpful if configure topic names to be different on the destination,
@@ -132,4 +132,3 @@ Suggested Reading
   - :ref:`rep-source-topics`
   - :ref:`rep-destination-topics`
   - :ref:`schema_translation`
-

--- a/replicator-schema-translation/docs/index.rst
+++ b/replicator-schema-translation/docs/index.rst
@@ -101,6 +101,13 @@ Run the Demo
    .. sourcecode:: bash
 
       docker-compose exec connect /etc/kafka/scripts/set_sr_modes_post_translation.sh
+      
+.. tip:: This demo showed a `one-time migration` of schemas across self-managed clusters. To configure a
+         `continuous migration`, the last steps would be to keep the origin (source) in READONLY mode, and set the destination
+         to READWRITE. Note that this only works for a "one-way" migration; that is, an active-to-passive
+         |crep| setup. This is especially helpful if configure topic names to be different on the destination,
+         using the translation configuration, ``topic.rename.format`` (described in :ref:`Replicator configuration destination topics <rep-destination-topics>`),
+         to rename the subjects in the schemas accordingly as it migrates them.
 
 ========
 Teardown
@@ -111,4 +118,18 @@ Teardown
    .. sourcecode:: bash
 
       docker-compose down
+      
+=================
+Suggested Reading
+=================
+
+* :ref:`schemaregistry_migrate`
+* :ref:`schemaregistry_config`
+* :ref:`replicator_quickstart`
+
+* These sections in :ref:`Replicator Configuration Options<connect_replicator_config_options>`: 
+
+  - :ref:`rep-source-topics`
+  - :ref:`rep-destination-topics`
+  - :ref:`schema_translation`
 


### PR DESCRIPTION
#### Jira ticket: https://confluentinc.atlassian.net/browse/DOCS-3222

#### Target branch: 5.4.0-post in examples repo

#### Related PRs:

https://github.com/confluentinc/docs/pull/3589

#### Description:

- Added a tip and some "suggested reading" links to the examples document to address how to set options for a continuous migration across self-managed clusters. (The demo shows a one-time migration.)

- See PR https://github.com/confluentinc/docs/pull/3589 for related updates to the Migrate Schemas document in the `docs` repository.


Signed-off-by: Victoria Bialas <vicky@confluent.io>