### PR TITLE
DEVX-1315 sets pom.xml rest-utils-parent to 5.4.0 (1 of n )

### DIFF
--- a/clients/avro/pom.xml
+++ b/clients/avro/pom.xml
@@ -7,7 +7,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
       <groupId>io.confluent</groupId>
       <artifactId>rest-utils-parent</artifactId>
-      <version>5.4.0-SNAPSHOT</version>
+      <version>5.4.0</version>
   </parent>
 
   <artifactId>java-client-avro-examples</artifactId>

--- a/clients/cloud/java/pom.xml
+++ b/clients/cloud/java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
       <groupId>io.confluent</groupId>
       <artifactId>rest-utils-parent</artifactId>
-      <version>5.4.0-SNAPSHOT</version>
+      <version>5.4.0</version>
     </parent>
 
     <artifactId>clients-example</artifactId>

--- a/connect-streams-pipeline/pom.xml
+++ b/connect-streams-pipeline/pom.xml
@@ -7,7 +7,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>io.confluent</groupId>
     <artifactId>rest-utils-parent</artifactId>
-    <version>5.4.0-SNAPSHOT</version>
+    <version>5.4.0</version>
   </parent>
 
   <artifactId>connect-streams-examples</artifactId>

--- a/microservices-orders/services-start.sh
+++ b/microservices-orders/services-start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RESTPORT=18894
-JAR=/usr/share/java/kafka-streams-examples/kafka-streams-examples-5.4.0-SNAPSHOT-standalone.jar
+JAR=/usr/share/java/kafka-streams-examples/kafka-streams-examples-5.4.0-standalone.jar
 
 java -cp $JAR io.confluent.examples.streams.microservices.OrdersService broker:9092 http://schema-registry:8081 localhost $RESTPORT > /dev/null 2>&1 &
 

--- a/multi-datacenter/pom.xml
+++ b/multi-datacenter/pom.xml
@@ -7,7 +7,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>io.confluent</groupId>
     <artifactId>rest-utils-parent</artifactId>
-    <version>5.4.0-SNAPSHOT</version>
+    <version>5.4.0</version>
   </parent>
 
   <artifactId>java-client-avro-examples</artifactId>


### PR DESCRIPTION
This commit should be merged forward w/ strategy ours so downstream
branches do not receive this.

This commit will be followed shortly by a commit that updates an artifact
in the multi-datacenter demo to fix a naming issue, which we do
want to flow downstream.