### PR TITLE
DEVX-1512: Schema Registry Tutorial project compile fails on machine …

### DIFF
--- a/clients/avro/pom.xml
+++ b/clients/avro/pom.xml
@@ -24,7 +24,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <properties>
     <!-- Keep versions as properties to allow easy modification -->
-    <java.version>1.8</java.version>
+    <java.version>8</java.version>
     <avro.version>1.9.1</avro.version>
     <gson.version>2.2.4</gson.version>
     <!-- Maven properties for compilation -->

--- a/clients/cloud/java/pom.xml
+++ b/clients/cloud/java/pom.xml
@@ -23,7 +23,7 @@
     </description>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>8</java.version>
         <slf4j-api.version>1.7.6</slf4j-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <avro.version>1.9.1</avro.version>

--- a/connect-streams-pipeline/pom.xml
+++ b/connect-streams-pipeline/pom.xml
@@ -23,7 +23,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   </description> 
 
   <properties>
-    <java.version>1.8</java.version>
+    <java.version>8</java.version>
     <avro.version>1.9.1</avro.version>
     <gson.version>2.2.4</gson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/multi-datacenter/pom.xml
+++ b/multi-datacenter/pom.xml
@@ -25,8 +25,8 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <properties>
     <!-- Keep versions as properties to allow easy modification -->
     <avro.version>1.9.1</avro.version>
-		<java.version>1.8</java.version>
-		<gson.version>2.2.4</gson.version>
+    <java.version>8</java.version>
+    <gson.version>2.2.4</gson.version>
     <!-- Maven properties for compilation -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
…with Java 1.11

> 1.8 fails with maven-compiler-plugin version 3.8.1 (used in the SR tutorial and for some of the other examples), but works with maven-compiler-plugin version 3.3 (used in kafka-streams-examples)

Fix: change `java.version` from `1.8` to `8`

Note: I have validated that the four affected projects in this PR compile with java 8 and java 11