### PR TITLE
DEVX-1531: add client config files and get all settings from configs across clients, update cloud client readmes

### DIFF
--- a/clients/cloud/c/README.md
+++ b/clients/cloud/c/README.md
@@ -2,17 +2,26 @@
 
 Produce messages to and consume messages from a Kafka cluster using the C client [librdkafka](https://github.com/edenhill/librdkafka).
 
-
 # Prerequisites
 
 * [librdkafka](https://github.com/edenhill/librdkafka) installed on your machine, see [installation instructions](https://github.com/edenhill/librdkafka/blob/master/README.md#instructions).
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
+To run this example, download the `librdkafka.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
+Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
 
 * Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Local file with configuration parameters to connect to your Confluent Cloud instance ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
+* Update the `librdkafka.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
 
+Additional configuration properties are supported, see [CONFIGURATION.md](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for the full list.
+
+```bash
+$ cat $HOME/.ccloud/librdkafka.config
+bootstrap.servers={{ BROKER_ENDPOINT }}
+sasl.mechanisms=PLAIN
+security.protocol=SASL_SSL
+sasl.username={{ CLUSTER_API_KEY }}
+sasl.password={{ CLUSTER_API_SECRET }}
+```
 
 # Build the example applications
 
@@ -24,20 +33,6 @@ cc   consumer.c common.c json.c -o consumer -lrdkafka -lm
 cc   producer.c common.c json.c -o producer -lrdkafka -lm
 ```
 
-# Create a configuration file
-
-The configuration file must contain the bootstrap servers and
-the SASL username and password, as shown in your Confluent Cloud settings.
-
-Additional configuration properties are supported, see [CONFIGURATION.md](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for the full list.
-
-```bash
-$ cat $HOME/.ccloud/example.config
-bootstrap.servers=<broker-1,broker-2,broker-3>
-sasl.username=<api-key-id>
-sasl.password=<secret-access-key>
-```
-
 # Example 1: Hello World!
 
 In this example, the producer writes JSON data to a topic in Confluent Cloud.
@@ -47,7 +42,7 @@ The consumer reads the same topic from Confluent Cloud and keeps a rolling sum o
 1. Run the producer, passing in arguments for (a) the topic name, and (b) the local file with configuration parameters to connect to your Confluent Cloud instance:
 
 ```bash
-$ ./producer test1 $HOME/.ccloud/example.config
+$ ./producer test1  $HOME/.ccloud/librdkafka.config
 Creating topic test1
 Topic test1 successfully created
 Producing message #0 to test1: alice={ "count": 1 }
@@ -78,7 +73,7 @@ Message delivered to test1 [0] at offset 9 in 22.81ms: { "count": 10 }
 2. Run the consumer, passing in arguments for (a) the same topic name as used above, (b) the local file with configuration parameters to connect to your Confluent Cloud instance. Verify that the consumer received all the messages, then press Ctrl-C to exit.
 
 ```bash
-$ ./consumer test1 $HOME/.ccloud/example.config
+$ ./consumer test1  $HOME/.ccloud/librdkafka.config
 Subscribing to test1, waiting for assignment and messages...
 Press Ctrl-C to exit.
 Received message on test1 [0] at offset 0: { "count": 1 }

--- a/clients/cloud/c/README.md
+++ b/clients/cloud/c/README.md
@@ -5,23 +5,8 @@ Produce messages to and consume messages from a Kafka cluster using the C client
 # Prerequisites
 
 * [librdkafka](https://github.com/edenhill/librdkafka) installed on your machine, see [installation instructions](https://github.com/edenhill/librdkafka/blob/master/README.md#instructions).
-
-To run this example, download the `librdkafka.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
-Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Update the `librdkafka.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
-
-Additional configuration properties are supported, see [CONFIGURATION.md](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for the full list.
-
-```bash
-$ cat $HOME/.ccloud/librdkafka.config
-bootstrap.servers={{ BROKER_ENDPOINT }}
-sasl.mechanisms=PLAIN
-security.protocol=SASL_SSL
-sasl.username={{ CLUSTER_API_KEY }}
-sasl.password={{ CLUSTER_API_SECRET }}
-```
+* Create a local file (e.g. at `$HOME/.confluent/librdkafka.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 # Build the example applications
 
@@ -42,7 +27,7 @@ The consumer reads the same topic from Confluent Cloud and keeps a rolling sum o
 1. Run the producer, passing in arguments for (a) the topic name, and (b) the local file with configuration parameters to connect to your Confluent Cloud instance:
 
 ```bash
-$ ./producer test1  $HOME/.ccloud/librdkafka.config
+$ ./producer test1 $HOME/.confluent/librdkafka.config
 Creating topic test1
 Topic test1 successfully created
 Producing message #0 to test1: alice={ "count": 1 }
@@ -73,7 +58,7 @@ Message delivered to test1 [0] at offset 9 in 22.81ms: { "count": 10 }
 2. Run the consumer, passing in arguments for (a) the same topic name as used above, (b) the local file with configuration parameters to connect to your Confluent Cloud instance. Verify that the consumer received all the messages, then press Ctrl-C to exit.
 
 ```bash
-$ ./consumer test1  $HOME/.ccloud/librdkafka.config
+$ ./consumer test1 $HOME/.confluent/librdkafka.config
 Subscribing to test1, waiting for assignment and messages...
 Press Ctrl-C to exit.
 Received message on test1 [0] at offset 0: { "count": 1 }

--- a/clients/cloud/c/common.c
+++ b/clients/cloud/c/common.c
@@ -53,19 +53,6 @@ rd_kafka_conf_t *read_config (const char *config_file) {
         }
 
         conf = rd_kafka_conf_new();
-
-        /* Set up basic Confluent Cloud connectivity parameters,
-         * we expect the bootstrap.servers, sasl.username, and sasl.password
-         * to be specified in the configuration file. */
-        if (rd_kafka_conf_set(conf, "security.protocol", "SASL_SSL",
-                              errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK ||
-            rd_kafka_conf_set(conf, "sasl.mechanisms", "PLAIN",
-                              errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) {
-                fprintf(stderr, "Configuration failed: %s\n", errstr);
-                rd_kafka_conf_destroy(conf);
-                return NULL;
-        }
-
         /* Read configuration file, line by line. */
         while (fgets(buf, sizeof(buf), fp)) {
                 char *s = buf;

--- a/clients/cloud/clojure/README.md
+++ b/clients/cloud/clojure/README.md
@@ -8,21 +8,8 @@ For more information, please see the [application development documentation](htt
 
 * Java 8 or higher (Clojure 1.10 recommends using Java 8 or Java 11)
 * The [Leiningen](https://leiningen.org/#install) tool to compile and run the demos
-
-To run this example, download the `java.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
-Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Update the `java.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
-
-```bash
-$ cat $HOME/.ccloud/java.config
-bootstrap.servers={{ BROKER_ENDPOINT }}
-ssl.endpoint.identification.algorithm=https
-security.protocol=SASL_SSL
-sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="{{ CLUSTER_API_KEY }}" password\="{{ CLUSTER_API_SECRET }}";
-```
+* Create a local file (e.g. at `$HOME/.confluent/java.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 # Example 1: Hello World!
 
@@ -33,7 +20,7 @@ The consumer reads the same topic from Confluent Cloud and keeps a rolling sum o
 1. Run the producer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the topic name:
 
 ```shell
-$ lein producer $HOME/.ccloud/java.config test1
+$ lein producer $HOME/.confluent/java.config test1
 …
 Producing record: alice 	{"count":0}
 Producing record: alice 	{"count":1}
@@ -61,7 +48,7 @@ Produced record to topic test1 partiton [0] @ offest 9
 2. Run the consumer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the same topic name as used above. Verify that the consumer received all the messages:
 
 ```shell
-$ lein consumer $HOME/.ccloud/java.config test1
+$ lein consumer $HOME/.confluent/java.config test1
 …
 Waiting for message in KafkaConsumer.poll
 Consumed record with key alice and value {"count":0}, and updated total count to 0

--- a/clients/cloud/clojure/README.md
+++ b/clients/cloud/clojure/README.md
@@ -9,20 +9,19 @@ For more information, please see the [application development documentation](htt
 * Java 8 or higher (Clojure 1.10 recommends using Java 8 or Java 11)
 * The [Leiningen](https://leiningen.org/#install) tool to compile and run the demos
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
+To run this example, download the `java.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
+Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
 
 * Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Local file with configuration parameters to connect to your Confluent Cloud instance ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)). Format the file as follows:
+* Update the `java.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
 
 ```bash
-$ cat ~/.ccloud/example.config
-bootstrap.servers=<broker-1,broker-2,broker-3>
-sasl.username=<api-key-id>
-sasl.password=<secret-access-key>
+$ cat $HOME/.ccloud/java.config
+bootstrap.servers={{ BROKER_ENDPOINT }}
 ssl.endpoint.identification.algorithm=https
 security.protocol=SASL_SSL
 sasl.mechanism=PLAIN
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="{{ CLUSTER_API_KEY }}" password\="{{ CLUSTER_API_SECRET }}";
 ```
 
 # Example 1: Hello World!
@@ -34,7 +33,7 @@ The consumer reads the same topic from Confluent Cloud and keeps a rolling sum o
 1. Run the producer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the topic name:
 
 ```shell
-$ lein producer ~/.ccloud/example.config test1
+$ lein producer $HOME/.ccloud/java.config test1
 …
 Producing record: alice 	{"count":0}
 Producing record: alice 	{"count":1}
@@ -62,7 +61,7 @@ Produced record to topic test1 partiton [0] @ offest 9
 2. Run the consumer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the same topic name as used above. Verify that the consumer received all the messages:
 
 ```shell
-$ lein consumer ~/.ccloud/example.config test1
+$ lein consumer $HOME/.ccloud/java.config test1
 …
 Waiting for message in KafkaConsumer.poll
 Consumed record with key alice and value {"count":0}, and updated total count to 0

--- a/clients/cloud/clojure/src/io/confluent/examples/clients/clj/consumer.clj
+++ b/clients/cloud/clojure/src/io/confluent/examples/clients/clj/consumer.clj
@@ -11,7 +11,8 @@
 (defn- build-properties [config-fname]
   (with-open [config (jio/reader config-fname)]
     (doto (Properties.)
-      (.putAll {ConsumerConfig/KEY_DESERIALIZER_CLASS_CONFIG "org.apache.kafka.common.serialization.StringDeserializer"
+      (.putAll {ConsumerConfig/GROUP_ID_CONFIG, "clojure_example_group"
+                ConsumerConfig/KEY_DESERIALIZER_CLASS_CONFIG "org.apache.kafka.common.serialization.StringDeserializer"
                 ConsumerConfig/VALUE_DESERIALIZER_CLASS_CONFIG "org.apache.kafka.common.serialization.StringDeserializer"})
       (.load config))))
 

--- a/clients/cloud/confluent-cli/README.md
+++ b/clients/cloud/confluent-cli/README.md
@@ -9,20 +9,8 @@ Produce messages to and consume messages from a Kafka cluster using [Confluent C
 
 * [Confluent Platform 5.4](https://www.confluent.io/download/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), which includes the Confluent CLI
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Initialize a properties file at `$HOME/.ccloud/config` with configuration to your Confluent Cloud cluster:
-
-```shell
-$ cat $HOME/.ccloud/config
-bootstrap.servers=<BROKER ENDPOINT>
-ssl.endpoint.identification.algorithm=https
-security.protocol=SASL_SSL
-sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="<API KEY>" password\="<API SECRET>";
-```
+* Create a local file (e.g. at `$HOME/.confluent/java.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 
 # Example 1: Hello World!
@@ -34,12 +22,12 @@ The consumer reads the same topic from Confluent Cloud.
 1. Create the topic in Confluent Cloud
 
 ```bash
-$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` --command-config $HOME/.ccloud/config --topic test1 --create --replication-factor 3 --partitions 6
+$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --command-config $HOME/.confluent/java.config --topic test1 --create --replication-factor 3 --partitions 6
 ```
 
 2. Run the [Confluent CLI producer](https://docs.confluent.io/current/cli/command-reference/confluent-produce.html#cli-confluent-produce?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), writing messages to topic `test1`, passing in additional arguments:
 
-* `--cloud`: write messages to the Confluent Cloud cluster specified in `$HOME/.ccloud/config`
+* `--cloud`: write messages to the Confluent Cloud cluster specified in `$HOME/.confluent/java.config`
 * `--property parse.key=true --property key.separator=,`: pass key and value, separated by a comma
 
 ```bash
@@ -58,7 +46,7 @@ When you are done, press `<ctrl>-d`.
 
 2. Run the [Confluent CLI consumer](https://docs.confluent.io/current/cli/command-reference/confluent-consume.html#cli-confluent-consume?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), reading messages from topic `test1`, passing in additional arguments:
 
-* `--cloud`: read messages from the Confluent Cloud cluster specified in `$HOME/.ccloud/config`
+* `--cloud`: read messages from the Confluent Cloud cluster specified in `$HOME/.confluent/java.config`
 * `--property print.key=true`: print key and value (by default, it only prints value)
 * `--from-beginning`: print all messages from the beginning of the topic
 
@@ -93,14 +81,14 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
     # View the list of registered subjects
     $ curl -u <SR API KEY>:<SR API SECRET> https://<SR ENDPOINT>/subjects
 
-    # Same as above, as a single bash command to parse the values out of $HOME/.ccloud/config
-    $ curl -u $(grep "^schema.registry.basic.auth.user.info" $HOME/.ccloud/config | cut -d'=' -f2) $(grep "^schema.registry.url" $HOME/.ccloud/config | cut -d'=' -f2)/subjects
+    # Same as above, as a single bash command to parse the values out of $HOME/.confluent/java.config
+    $ curl -u $(grep "^schema.registry.basic.auth.user.info" $HOME/.confluent/java.config | cut -d'=' -f2) $(grep "^schema.registry.url" $HOME/.confluent/java.config | cut -d'=' -f2)/subjects
     ```
 
-3. Add the following parameters to your local Confluent Cloud configuration file (``$HOME/.ccloud/config``). In the output below, substitute values for `<SR API KEY>`, `<SR API SECRET>`, and `<SR ENDPOINT>`.
+3. Add the following parameters to your local Confluent Cloud configuration file (``$HOME/.confluent/java.config``). In the output below, substitute values for `<SR API KEY>`, `<SR API SECRET>`, and `<SR ENDPOINT>`.
 
     ```shell
-    $ cat $HOME/.ccloud/config
+    $ cat $HOME/.confluent/java.config
     ...
     basic.auth.credentials.source=USER_INFO
     schema.registry.basic.auth.user.info=<SR API KEY>:<SR API SECRET>
@@ -111,7 +99,7 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
 4. Create the topic in Confluent Cloud
 
 ```bash
-$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` --command-config $HOME/.ccloud/config --topic test2 --create --replication-factor 3 --partitions 6
+$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --command-config $HOME/.confluent/java.config --topic test2 --create --replication-factor 3 --partitions 6
 ```
 
 5. Run the [Confluent CLI producer](https://docs.confluent.io/current/cli/command-reference/confluent-produce.html#cli-confluent-produce?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), writing messages to topic `test2`, passing in additional arguments. The additional Schema Registry parameters are required to be passed in as properties instead of a properties file due to https://github.com/confluentinc/schema-registry/issues/1052.

--- a/clients/cloud/confluent-cli/confluent-cli-ccsr-example.sh
+++ b/clients/cloud/confluent-cli/confluent-cli-ccsr-example.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONFIG_FILE=~/.ccloud/config
+CONFIG_FILE=$HOME/.confluent/java.config
 
 source ../../../utils/helper.sh
 

--- a/clients/cloud/confluent-cli/confluent-cli-example.sh
+++ b/clients/cloud/confluent-cli/confluent-cli-example.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONFIG_FILE=~/.ccloud/config
+CONFIG_FILE=$HOME/.confluent/java.config
 
 source ../../../utils/helper.sh 
 

--- a/clients/cloud/csharp/Program.cs
+++ b/clients/cloud/csharp/Program.cs
@@ -28,18 +28,6 @@ namespace CCloud
 {
     class Program
     {
-        /// <summary>
-        ///     Extract the value associated with key <paramref name="key"/> from the
-        ///     sasl.jaas.config (<paramref name="jaasConfig"/>) configuration value.
-        /// </summary>
-        static string ExtractJaasValue(string jaasConfig, string key)
-        {
-            var beginToken = key + "\\=\"";
-            var startIdx = jaasConfig.IndexOf(beginToken);
-            var endIdx = jaasConfig.IndexOf("\"", startIdx + beginToken.Length);
-            return jaasConfig.Substring(startIdx + beginToken.Length, endIdx - startIdx - beginToken.Length);
-        }
-
         static async Task<ClientConfig> LoadConfig(string configPath, string certDir)
         {
             try
@@ -49,14 +37,15 @@ namespace CCloud
                     .ToDictionary(
                         line => line.Substring(0, line.IndexOf('=')),
                         line => line.Substring(line.IndexOf('=') + 1));
-
+                Enum.TryParse(cloudConfig["sasl.mechanisms"], out SaslMechanism saslMechanism);
+                Enum.TryParse(cloudConfig["security.protocol"], out SecurityProtocol securityProtocol);
                 var clientConfig = new ClientConfig
                 {
                     BootstrapServers = cloudConfig["bootstrap.servers"].Replace("\\", ""),
-                    SaslMechanism = SaslMechanism.Plain,
-                    SecurityProtocol = SecurityProtocol.SaslSsl,
-                    SaslUsername = ExtractJaasValue(cloudConfig["sasl.jaas.config"], "username"),
-                    SaslPassword = ExtractJaasValue(cloudConfig["sasl.jaas.config"], "password")
+                    SaslMechanism = saslMechanism,
+                    SecurityProtocol = securityProtocol,
+                    SaslUsername = cloudConfig["sasl.username"],
+                    SaslPassword = cloudConfig["sasl.password"],
                 };
 
                 if (certDir != null)

--- a/clients/cloud/csharp/README.md
+++ b/clients/cloud/csharp/README.md
@@ -6,22 +6,8 @@ Produce messages to and consume messages from a Kafka cluster using the .NET Pro
 # Prerequisites
 
 * [.NET Core 2.1](https://dotnet.microsoft.com/download) or higher to run the demo application
-
-To run this example, download the `librdkafka.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
-Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Update the `librdkafka.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
-
-
-```shell
-$ cat $HOME/.ccloud/librdkafka.config
-bootstrap.servers={{ BROKER_ENDPOINT }}
-security.protocol=SASL_SSL
-sasl.mechanism=PLAIN
-sasl.username={{ CLUSTER_API_KEY }}
-sasl.password={{ CLUSTER_API_SECRET }}
-```
+* Create a local file (e.g. at `$HOME/.confluent/librdkafka.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 # Example
 
@@ -41,10 +27,10 @@ Run the example application, passing in arguments for (a) whether to produce or 
 $ dotnet build
 
 # Run the producer (Windows)
-$ dotnet run produce test1 $HOME/.ccloud/librdkafka.config /path/to/curl/cacert.pem
+$ dotnet run produce test1 $HOME/.confluent/librdkafka.config /path/to/curl/cacert.pem
 
 # Run the producer (other)
-$ dotnet run produce test1 $HOME/.ccloud/librdkafka.config
+$ dotnet run produce test1 $HOME/.confluent/librdkafka.config
 ```
 
 You should see:
@@ -79,10 +65,10 @@ Run the consumer, passing in arguments for (a) whether to produce or consume (co
 
 ```shell
 # Run the consumer (Windows)
-$ dotnet run consume test1 $HOME/.ccloud/librdkafka.config /path/to/curl/cacert.pem
+$ dotnet run consume test1 $HOME/.confluent/librdkafka.config /path/to/curl/cacert.pem
 
 # Run the consumer (other)
-$ dotnet run consume test1 $HOME/.ccloud/librdkafka.config
+$ dotnet run consume test1 $HOME/.confluent/librdkafka.config
 ```
 
 You should see:

--- a/clients/cloud/csharp/README.md
+++ b/clients/cloud/csharp/README.md
@@ -7,19 +7,20 @@ Produce messages to and consume messages from a Kafka cluster using the .NET Pro
 
 * [.NET Core 2.1](https://dotnet.microsoft.com/download) or higher to run the demo application
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
+To run this example, download the `librdkafka.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
+Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
 
 * Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Initialize a properties file at `$HOME/.ccloud/config` with configuration to your Confluent Cloud cluster:
+* Update the `librdkafka.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
+
 
 ```shell
-$ cat $HOME/.ccloud/config
-bootstrap.servers=<BROKER ENDPOINT>
-ssl.endpoint.identification.algorithm=https
+$ cat $HOME/.ccloud/librdkafka.config
+bootstrap.servers={{ BROKER_ENDPOINT }}
 security.protocol=SASL_SSL
 sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="<API KEY>" password\="<API SECRET>";
+sasl.username={{ CLUSTER_API_KEY }}
+sasl.password={{ CLUSTER_API_SECRET }}
 ```
 
 # Example
@@ -40,10 +41,10 @@ Run the example application, passing in arguments for (a) whether to produce or 
 $ dotnet build
 
 # Run the producer (Windows)
-$ dotnet run produce test1 %HOMEPATH%/.ccloud/config /path/to/curl/cacert.pem
+$ dotnet run produce test1 $HOME/.ccloud/librdkafka.config /path/to/curl/cacert.pem
 
 # Run the producer (other)
-$ dotnet run produce test1 $HOME/.ccloud/config
+$ dotnet run produce test1 $HOME/.ccloud/librdkafka.config
 ```
 
 You should see:
@@ -78,10 +79,10 @@ Run the consumer, passing in arguments for (a) whether to produce or consume (co
 
 ```shell
 # Run the consumer (Windows)
-$ dotnet run consume test1 %HOMEPATH%/.ccloud/config /path/to/curl/cacert.pem
+$ dotnet run consume test1 $HOME/.ccloud/librdkafka.config /path/to/curl/cacert.pem
 
 # Run the consumer (other)
-$ dotnet run consume test1 $HOME/.ccloud/config
+$ dotnet run consume test1 $HOME/.ccloud/librdkafka.config
 ```
 
 You should see:

--- a/clients/cloud/go/README.md
+++ b/clients/cloud/go/README.md
@@ -5,23 +5,8 @@ Produce messages to and consume messages from a Kafka cluster using [Confluent G
 # Prerequisites
 
 * [Confluent's Golang Client for Apache Kafka](https://github.com/confluentinc/confluent-kafka-go#getting-started) installed on your machine
-
-To run this example, download the `librdkafka.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
-Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Update the `librdkafka.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
-
-
-
-```bash
-$ cat $HOME/.ccloud/librdkafka.config
-bootstrap.servers={{ BROKER_ENDPOINT }}
-sasl.mechanisms=PLAIN
-security.protocol=SASL_SSL
-sasl.username={{ CLUSTER_API_KEY }}
-sasl.password={{ CLUSTER_API_SECRET }}
-```
+* Create a local file (e.g. at `$HOME/.confluent/librdkafka.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 # Example 1: Hello World!
 
@@ -33,7 +18,7 @@ The consumer reads the same topic from Confluent Cloud and keeps a rolling sum o
 
 ```bash
 $ go build producer.go
-$ ./producer -f $HOME/.ccloud/librdkafka.config -t test1
+$ ./producer -f $HOME/.confluent/librdkafka.config -t test1
 Preparing to produce record: alice 	 {"Count": 0}
 Preparing to produce record: alice 	 {"Count": 1}
 Preparing to produce record: alice 	 {"Count": 2}
@@ -61,7 +46,7 @@ Successfully produced record to topic test1 partition [0] @ offset 9
 
 ```bash
 $ go build consumer.go
-$ ./consumer -f $HOME/.ccloud/librdkafka.config -t test1
+$ ./consumer -f $HOME/.confluent/librdkafka.config -t test1
 ...
 Consumed record with key alice and value {"Count":0}, and updated total count to 0
 Consumed record with key alice and value {"Count":1}, and updated total count to 1

--- a/clients/cloud/go/README.md
+++ b/clients/cloud/go/README.md
@@ -2,23 +2,25 @@
 
 Produce messages to and consume messages from a Kafka cluster using [Confluent Golang Client for Apache Kafka](https://github.com/confluentinc/confluent-kafka-go).
 
-
 # Prerequisites
 
 * [Confluent's Golang Client for Apache Kafka](https://github.com/confluentinc/confluent-kafka-go#getting-started) installed on your machine
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
+To run this example, download the `librdkafka.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
+Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
 
 * Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Local file with configuration parameters to connect to your Confluent Cloud instance ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)). Format the file as follows:
+* Update the `librdkafka.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
+
 
 
 ```bash
-$ cat ~/.ccloud/example.config
-bootstrap.servers=<broker-1,broker-2,broker-3>
-sasl.username=<api-key-id>
-sasl.password=<secret-access-key>
+$ cat $HOME/.ccloud/librdkafka.config
+bootstrap.servers={{ BROKER_ENDPOINT }}
+sasl.mechanisms=PLAIN
+security.protocol=SASL_SSL
+sasl.username={{ CLUSTER_API_KEY }}
+sasl.password={{ CLUSTER_API_SECRET }}
 ```
 
 # Example 1: Hello World!
@@ -31,7 +33,7 @@ The consumer reads the same topic from Confluent Cloud and keeps a rolling sum o
 
 ```bash
 $ go build producer.go
-$ ./producer -f ~/.ccloud/example.config -t test1
+$ ./producer -f $HOME/.ccloud/librdkafka.config -t test1
 Preparing to produce record: alice 	 {"Count": 0}
 Preparing to produce record: alice 	 {"Count": 1}
 Preparing to produce record: alice 	 {"Count": 2}
@@ -59,7 +61,7 @@ Successfully produced record to topic test1 partition [0] @ offset 9
 
 ```bash
 $ go build consumer.go
-$ ./consumer -f ~/.ccloud/example.config -t test1
+$ ./consumer -f $HOME/.ccloud/librdkafka.config -t test1
 ...
 Consumed record with key alice and value {"Count":0}, and updated total count to 0
 Consumed record with key alice and value {"Count":1}, and updated total count to 1

--- a/clients/cloud/go/consumer.go
+++ b/clients/cloud/go/consumer.go
@@ -46,12 +46,13 @@ func main() {
 	// Create Consumer instance
 	c, err := kafka.NewConsumer(&kafka.ConfigMap{
 		"bootstrap.servers": conf["bootstrap.servers"],
-		"sasl.mechanisms":   "PLAIN",
-		"security.protocol": "SASL_SSL",
+		"sasl.mechanisms": conf["sasl.mechanisms"],
+		"security.protocol": conf["security.protocol"],
 		"sasl.username":     conf["sasl.username"],
 		"sasl.password":     conf["sasl.password"],
 		"group.id":          "go_example_group_1",
-		"auto.offset.reset": "earliest"})
+		"auto.offset.reset": "earliest",
+	})
 	if err != nil {
 		fmt.Printf("Failed to create consumer: %s", err)
 		os.Exit(1)

--- a/clients/cloud/go/producer.go
+++ b/clients/cloud/go/producer.go
@@ -89,8 +89,8 @@ func main() {
 	// Create Producer instance
 	p, err := kafka.NewProducer(&kafka.ConfigMap{
 		"bootstrap.servers": conf["bootstrap.servers"],
-		"sasl.mechanisms":   "PLAIN",
-		"security.protocol": "SASL_SSL",
+		"sasl.mechanisms": conf["sasl.mechanisms"],
+		"security.protocol": conf["security.protocol"],
 		"sasl.username":     conf["sasl.username"],
 		"sasl.password":     conf["sasl.password"]})
 	if err != nil {

--- a/clients/cloud/groovy/README.adoc
+++ b/clients/cloud/groovy/README.adoc
@@ -6,19 +6,20 @@ Produce messages to and consume messages from a Kafka cluster using the Groovy v
 
 * Java 1.8 or higher to run the demo application
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, link:https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud[Confluent Cloud], or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
 
-* Access to a link:https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud[Confluent Cloud] cluster
-* Initialize a properties file at `$HOME/.ccloud/config` with configuration to your Confluent Cloud cluster:
+To run this example, download the `java.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
+Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
+
+* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
+* Update the `java.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
 
 ```shell
-$ cat $HOME/.ccloud/config
-bootstrap.servers=<BROKER ENDPOINT>
+$ cat $HOME/.ccloud/java.config
+bootstrap.servers={{ BROKER_ENDPOINT }}
 ssl.endpoint.identification.algorithm=https
 security.protocol=SASL_SSL
 sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="<API KEY>" password\="<API SECRET>";
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
 ```
 
 == Example 1: Hello World!
@@ -38,7 +39,7 @@ The Kafka Streams API reads the same topic from Confluent Cloud and does a state
 	
  # Run the producer
  $ ./gradlew runApp -PmainClass="io.confluent.examples.clients.cloud.ProducerExample" \
- -PconfigPath="$HOME/.ccloud/config" \
+ -PconfigPath="$HOME/.ccloud/java.config" \
  -Ptopic="test1"
 ----
 
@@ -84,7 +85,7 @@ Verify that the consumer received all the messages:
 	
  # Run the consumer
  $ ./gradlew runApp -PmainClass="io.confluent.examples.clients.cloud.ConsumerExample"\
-   	-PconfigPath="$HOME/.ccloud/config"\
+   	-PconfigPath="$HOME/.ccloud/java.config"\
    	-Ptopic="test1"
 ----
 
@@ -116,7 +117,7 @@ Verify that the consumer received all the messages:
 
  # Run the consumer
  $ ./gradlew runApp -PmainClass="io.confluent.examples.clients.cloud.StreamsExample" \
-   	-PconfigPath="$HOME/.ccloud/config" \
+   	-PconfigPath="$HOME/.ccloud/java.config" \
    	-Ptopic="test1"
  ```
 ....

--- a/clients/cloud/groovy/README.adoc
+++ b/clients/cloud/groovy/README.adoc
@@ -5,22 +5,8 @@ Produce messages to and consume messages from a Kafka cluster using the Groovy v
 == Prerequisites
 
 * Java 1.8 or higher to run the demo application
-
-
-To run this example, download the `java.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
-Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Update the `java.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
-
-```shell
-$ cat $HOME/.ccloud/java.config
-bootstrap.servers={{ BROKER_ENDPOINT }}
-ssl.endpoint.identification.algorithm=https
-security.protocol=SASL_SSL
-sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
-```
+* Create a local file (e.g. at `$HOME/.confluent/java.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 == Example 1: Hello World!
 
@@ -39,7 +25,7 @@ The Kafka Streams API reads the same topic from Confluent Cloud and does a state
 	
  # Run the producer
  $ ./gradlew runApp -PmainClass="io.confluent.examples.clients.cloud.ProducerExample" \
- -PconfigPath="$HOME/.ccloud/java.config" \
+ -PconfigPath="$HOME/.confluent/java.config" \
  -Ptopic="test1"
 ----
 
@@ -85,7 +71,7 @@ Verify that the consumer received all the messages:
 	
  # Run the consumer
  $ ./gradlew runApp -PmainClass="io.confluent.examples.clients.cloud.ConsumerExample"\
-   	-PconfigPath="$HOME/.ccloud/java.config"\
+   	-PconfigPath="$HOME/.confluent/java.config"\
    	-Ptopic="test1"
 ----
 
@@ -117,7 +103,7 @@ Verify that the consumer received all the messages:
 
  # Run the consumer
  $ ./gradlew runApp -PmainClass="io.confluent.examples.clients.cloud.StreamsExample" \
-   	-PconfigPath="$HOME/.ccloud/java.config" \
+   	-PconfigPath="$HOME/.confluent/java.config" \
    	-Ptopic="test1"
  ```
 ....

--- a/clients/cloud/groovy/build.gradle
+++ b/clients/cloud/groovy/build.gradle
@@ -25,7 +25,7 @@ dependencies {
   compile 'org.slf4j:slf4j-log4j12:1.7.6'
 }
 
-group = 'io.confluent.ccloud'
+group = 'io.confluent.confluent'
 version = '5.0.1'
 sourceCompatibility = '1.8'
 
@@ -37,7 +37,7 @@ task runApp(type: JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
   main = project.hasProperty('mainClass') ? project.getProperty('mainClass') : 'package.MyDefaultMain'
   def configPath = project.hasProperty('configPath') ? project.getProperty('configPath') :
-               "${System.getProperty('user.home')}/.ccloud/config"
+               "${System.getProperty('user.home')}/.confluent/config"
   def topic = project.hasProperty('topic') ? project.getProperty('topic') : 'topic1'
   args = [configPath, topic]
 }

--- a/clients/cloud/groovy/build.gradle
+++ b/clients/cloud/groovy/build.gradle
@@ -7,11 +7,11 @@ plugins {
 repositories {
   mavenLocal()
   maven {
-    url = 'http://packages.confluent.io/maven/'
+    url = 'https://packages.confluent.io/maven/'
   }
 
   maven {
-    url = 'http://repo.maven.apache.org/maven2'
+    url = 'https://repo.maven.apache.org/maven2'
   }
 }
 

--- a/clients/cloud/java/README.md
+++ b/clients/cloud/java/README.md
@@ -7,22 +7,8 @@ Produce messages to and consume messages from a Kafka cluster using the Java Pro
 
 * Java 1.8 or higher to run the demo application
 * Maven to compile the demo application
-
-To run this example, download the `java.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
-Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Update the `java.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
-
-
-```shell
-$ cat $HOME/.ccloud/java.config
-ssl.endpoint.identification.algorithm=https
-sasl.mechanism=PLAIN
-bootstrap.servers={{ BROKER_ENDPOINT }}
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
-security.protocol=SASL_SSL
-```
+* Create a local file (e.g. at `$HOME/.confluent/java.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 # Example 1: Hello World!
 
@@ -40,7 +26,7 @@ The Kafka Streams API reads the same topic from Confluent Cloud and does a state
 	# Run the producer
         # If the topic does not already exist, the code will use the Kafka Admin Client API to create the topic
 	$ mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.ProducerExample" \
-	  -Dexec.args="$HOME/.ccloud/java.config test1"
+	  -Dexec.args="$HOME/.confluent/java.config test1"
 	```
 
 	You should see:
@@ -79,7 +65,7 @@ The Kafka Streams API reads the same topic from Confluent Cloud and does a state
     
     # Run the consumer
     $ mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.ConsumerExample" \
-      -Dexec.args="$HOME/.ccloud/java.config test1"
+      -Dexec.args="$HOME/.confluent/java.config test1"
     ```
     
     You should see:
@@ -108,7 +94,7 @@ The Kafka Streams API reads the same topic from Confluent Cloud and does a state
 
     # Run the Kafka streams application
     $ mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.StreamsExample" \
-      -Dexec.args="$HOME/.ccloud/java.config test1"
+      -Dexec.args="$HOME/.confluent/java.config test1"
     ```
 
     You should see:
@@ -156,15 +142,15 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
     # View the list of registered subjects
     $ curl -u {{ SR_API_KEY }}:{{ SR_API_SECRET }} https://{{ SR_ENDPOINT }}/subjects
 
-    # Same as above, as a single bash command to parse the values out of java-sr.config
-    $ curl -u $(grep "^schema.registry.basic.auth.user.info" $HOME/.ccloud/java-sr.config | cut -d'=' -f2) $(grep "^schema.registry.url" $HOME/.ccloud/java-sr.config| cut -d'=' -f2)/subjects
+    # Same as above, as a single bash command to parse the values out of java.config
+    $ curl -u $(grep "^schema.registry.basic.auth.user.info" $HOME/.confluent/java.config | cut -d'=' -f2) $(grep "^schema.registry.url" $HOME/.confluent/java.config| cut -d'=' -f2)/subjects
     ```
 
-3. Add the following parameters to your local Confluent Cloud configuration file (``$HOME/.ccloud/java.config``) or download the `java-sr.config` from [configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud). 
+3. Add the following parameters to your local Confluent Cloud configuration file (``$HOME/.confluent/java.config``). 
 In the output below, substitute values for `{{ SR_API_KEY }}`, `{{ SR_API_SECRET }}`, and `{{ SR_ENDPOINT }}`.
 
     ```shell
-    $ cat $HOME/.ccloud/java-sr.config
+    $ cat $HOME/.confluent/java.config
     ...
     basic.auth.credentials.source=USER_INFO
     schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
@@ -181,7 +167,7 @@ In the output below, substitute values for `{{ SR_API_KEY }}`, `{{ SR_API_SECRET
     # Run the Avro producer
     # If the topic does not already exist, the code will use the Kafka Admin Client API to create the topic
     $ mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.ProducerAvroExample" \
-      -Dexec.args="$HOME/.ccloud/java-sr.config test2"
+      -Dexec.args="$HOME/.confluent/java.config test2"
     ```
 
 5. Run the Avro consumer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the topic name:
@@ -192,7 +178,7 @@ In the output below, substitute values for `{{ SR_API_KEY }}`, `{{ SR_API_SECRET
     
     # Run the Avro consumer
     $ mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.ConsumerAvroExample" \
-      -Dexec.args="$HOME/.ccloud/java-sr.config test2"
+      -Dexec.args="$HOME/.confluent/java.config test2"
     ```
 
 6. Run the Avro Kafka Streams application, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the same topic name as used above. Verify that the application received all the messages:
@@ -203,7 +189,7 @@ In the output below, substitute values for `{{ SR_API_KEY }}`, `{{ SR_API_SECRET
 
     # Run the Avro Kafka streams application
     $ mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.StreamsAvroExample" \
-      -Dexec.args="$HOME/.ccloud/java-sr.config test2"
+      -Dexec.args="$HOME/.confluent/java.config test2"
     ```
 
 7. View the schema information registered in Confluent Cloud Schema Registry. In the output below, substitute values for `{{ SR_API_KEY }}`, `{{ SR_API_SECRET }}`, and `{{ SR_ENDPOINT }}`.

--- a/clients/cloud/java/README.md
+++ b/clients/cloud/java/README.md
@@ -8,19 +8,20 @@ Produce messages to and consume messages from a Kafka cluster using the Java Pro
 * Java 1.8 or higher to run the demo application
 * Maven to compile the demo application
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
+To run this example, download the `java.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
+Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
 
 * Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Initialize a properties file at `$HOME/.ccloud/config` with configuration to your Confluent Cloud cluster:
+* Update the `java.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
+
 
 ```shell
-$ cat $HOME/.ccloud/config
-bootstrap.servers=<BROKER ENDPOINT>
+$ cat $HOME/.ccloud/java.config
 ssl.endpoint.identification.algorithm=https
-security.protocol=SASL_SSL
 sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="<API KEY>" password\="<API SECRET>";
+bootstrap.servers={{ BROKER_ENDPOINT }}
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
+security.protocol=SASL_SSL
 ```
 
 # Example 1: Hello World!
@@ -39,7 +40,7 @@ The Kafka Streams API reads the same topic from Confluent Cloud and does a state
 	# Run the producer
         # If the topic does not already exist, the code will use the Kafka Admin Client API to create the topic
 	$ mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.ProducerExample" \
-	  -Dexec.args="$HOME/.ccloud/config test1"
+	  -Dexec.args="$HOME/.ccloud/java.config test1"
 	```
 
 	You should see:
@@ -78,7 +79,7 @@ The Kafka Streams API reads the same topic from Confluent Cloud and does a state
     
     # Run the consumer
     $ mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.ConsumerExample" \
-      -Dexec.args="$HOME/.ccloud/config test1"
+      -Dexec.args="$HOME/.ccloud/java.config test1"
     ```
     
     You should see:
@@ -107,7 +108,7 @@ The Kafka Streams API reads the same topic from Confluent Cloud and does a state
 
     # Run the Kafka streams application
     $ mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.StreamsExample" \
-      -Dexec.args="$HOME/.ccloud/config test1"
+      -Dexec.args="$HOME/.ccloud/java.config test1"
     ```
 
     You should see:
@@ -149,24 +150,25 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
 
 1. As described in the [Confluent Cloud quickstart](https://docs.confluent.io/current/quickstart/cloud-quickstart/schema-registry.html?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), in the Confluent Cloud GUI, enable Confluent Cloud Schema Registry and create an API key and secret to connect to it.
 
-2. Verify your Confluent Cloud Schema Registry credentials work from your host. In the output below, substitute your values for `<SR API KEY>`, `<SR API SECRET>`, and `<SR ENDPOINT>`.
+2. Verify your Confluent Cloud Schema Registry credentials work from your host. In the output below, substitute your values for `{{ SR_API_KEY }}`, `{{ SR_API_SECRET }}`, and `{{ SR_ENDPOINT }}`.
 
     ```shell
     # View the list of registered subjects
-    $ curl -u <SR API KEY>:<SR API SECRET> https://<SR ENDPOINT>/subjects
+    $ curl -u {{ SR_API_KEY }}:{{ SR_API_SECRET }} https://{{ SR_ENDPOINT }}/subjects
 
-    # Same as above, as a single bash command to parse the values out of $HOME/.ccloud/config
-    $ curl -u $(grep "^schema.registry.basic.auth.user.info" $HOME/.ccloud/config | cut -d'=' -f2) $(grep "^schema.registry.url" $HOME/.ccloud/config | cut -d'=' -f2)/subjects
+    # Same as above, as a single bash command to parse the values out of java-sr.config
+    $ curl -u $(grep "^schema.registry.basic.auth.user.info" $HOME/.ccloud/java-sr.config | cut -d'=' -f2) $(grep "^schema.registry.url" $HOME/.ccloud/java-sr.config| cut -d'=' -f2)/subjects
     ```
 
-3. Add the following parameters to your local Confluent Cloud configuration file (``$HOME/.ccloud/config``). In the output below, substitute values for `<SR API KEY>`, `<SR API SECRET>`, and `<SR ENDPOINT>`.
+3. Add the following parameters to your local Confluent Cloud configuration file (``$HOME/.ccloud/java.config``) or download the `java-sr.config` from [configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud). 
+In the output below, substitute values for `{{ SR_API_KEY }}`, `{{ SR_API_SECRET }}`, and `{{ SR_ENDPOINT }}`.
 
     ```shell
-    $ cat $HOME/.ccloud/config
+    $ cat $HOME/.ccloud/java-sr.config
     ...
     basic.auth.credentials.source=USER_INFO
-    schema.registry.basic.auth.user.info=<SR API KEY>:<SR API SECRET>
-    schema.registry.url=https://<SR ENDPOINT>
+    schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
+    schema.registry.url=https://{{ SR_ENDPOINT }}
     ...
     ```
 
@@ -179,7 +181,7 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
     # Run the Avro producer
     # If the topic does not already exist, the code will use the Kafka Admin Client API to create the topic
     $ mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.ProducerAvroExample" \
-      -Dexec.args="$HOME/.ccloud/config test2"
+      -Dexec.args="$HOME/.ccloud/java-sr.config test2"
     ```
 
 5. Run the Avro consumer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the topic name:
@@ -190,7 +192,7 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
     
     # Run the Avro consumer
     $ mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.ConsumerAvroExample" \
-      -Dexec.args="$HOME/.ccloud/config test2"
+      -Dexec.args="$HOME/.ccloud/java-sr.config test2"
     ```
 
 6. Run the Avro Kafka Streams application, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the same topic name as used above. Verify that the application received all the messages:
@@ -201,18 +203,18 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
 
     # Run the Avro Kafka streams application
     $ mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.StreamsAvroExample" \
-      -Dexec.args="$HOME/.ccloud/config test2"
+      -Dexec.args="$HOME/.ccloud/java-sr.config test2"
     ```
 
-7. View the schema information registered in Confluent Cloud Schema Registry. In the output below, substitute values for `<SR API KEY>`, `<SR API SECRET>`, and `<SR ENDPOINT>`.
+7. View the schema information registered in Confluent Cloud Schema Registry. In the output below, substitute values for `{{ SR_API_KEY }}`, `{{ SR_API_SECRET }}`, and `{{ SR_ENDPOINT }}`.
 
     ```
     # View the list of registered subjects
-    $ curl -u <SR API KEY>:<SR API SECRET> https://<SR ENDPOINT>/subjects
+    $ curl -u {{ SR_API_KEY }}:{{ SR_API_SECRET }} https://{{ SR_ENDPOINT }}/subjects
     ["test2-value"]
     
     # View the schema information for subject `test2-value`
-    $ curl -u <SR API KEY>:<SR API SECRET> https://<SR ENDPOINT>/subjects/test2-value/versions/1
+    $ curl -u {{ SR_API_KEY }}:{{ SR_API_SECRET }} https://{{ SR_ENDPOINT }}/subjects/test2-value/versions/1
     {"subject":"test2-value","version":1,"id":100001,"schema":"{\"name\":\"io.confluent.examples.clients.cloud.DataRecordAvro\",\"type\":\"record\",\"fields\":[{\"name\":\"count\",\"type\":\"long\"}]}"}
     ```
 

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerAvroExample.java
@@ -41,16 +41,10 @@ public class ConsumerAvroExample {
 
     final String topic = args[1];
 
-    // Load properties from a configuration file
-    // The configuration properties defined in the configuration file are assumed to include:
-    //   ssl.endpoint.identification.algorithm=https
-    //   sasl.mechanism=PLAIN
-    //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
-    //   security.protocol=SASL_SSL
-    //   basic.auth.credentials.source=USER_INFO
-    //   schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
-    //   schema.registry.url=https://<SR ENDPOINT>
+    // Load properties from a local configuration file
+    // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
+    // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
+    // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
     final Properties props = loadConfig(args[0]);
 
     // Add additional properties.

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerAvroExample.java
@@ -46,10 +46,10 @@ public class ConsumerAvroExample {
     //   ssl.endpoint.identification.algorithm=https
     //   sasl.mechanism=PLAIN
     //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="<CLUSTER_API_KEY>" password="<CLUSTER_API_SECRET>";
+    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
     //   security.protocol=SASL_SSL
     //   basic.auth.credentials.source=USER_INFO
-    //   schema.registry.basic.auth.user.info=<SR_API_KEY>:<SR_API_SECRET>
+    //   schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
     //   schema.registry.url=https://<SR ENDPOINT>
     final Properties props = loadConfig(args[0]);
 

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
@@ -41,13 +41,10 @@ public class ConsumerExample {
 
     final String topic = args[1];
 
-    // Load properties from a configuration file
-    // The configuration properties defined in the configuration file are assumed to include:
-    //   ssl.endpoint.identification.algorithm=https
-    //   sasl.mechanism=PLAIN
-    //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
-    //   security.protocol=SASL_SSL
+    // Load properties from a local configuration file
+    // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
+    // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
+    // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
     final Properties props = loadConfig(args[0]);
 
     // Add additional properties.

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
@@ -46,7 +46,7 @@ public class ConsumerExample {
     //   ssl.endpoint.identification.algorithm=https
     //   sasl.mechanism=PLAIN
     //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="<CLUSTER_API_KEY>" password="<CLUSTER_API_SECRET>";
+    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
     //   security.protocol=SASL_SSL
     final Properties props = loadConfig(args[0]);
 

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExamplePageviews.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExamplePageviews.java
@@ -46,7 +46,7 @@ public class ConsumerExamplePageviews {
     //   ssl.endpoint.identification.algorithm=https
     //   sasl.mechanism=PLAIN
     //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="<CLUSTER_API_KEY>" password="<CLUSTER_API_SECRET>";
+    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
     //   security.protocol=SASL_SSL
     final Properties props = loadConfig(args[0]);
 

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExamplePageviews.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExamplePageviews.java
@@ -41,13 +41,10 @@ public class ConsumerExamplePageviews {
 
     final String topic = args[1];
 
-    // Load properties from a configuration file
-    // The configuration properties defined in the configuration file are assumed to include:
-    //   ssl.endpoint.identification.algorithm=https
-    //   sasl.mechanism=PLAIN
-    //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
-    //   security.protocol=SASL_SSL
+    // Load properties from a local configuration file
+    // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
+    // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
+    // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
     final Properties props = loadConfig(args[0]);
 
     // Add additional properties.

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerAvroExample.java
@@ -63,16 +63,10 @@ public class ProducerAvroExample {
       System.exit(1);
     }
 
-    // Load properties from a configuration file
-    // The configuration properties defined in the configuration file are assumed to include:
-    //   ssl.endpoint.identification.algorithm=https
-    //   sasl.mechanism=PLAIN
-    //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
-    //   security.protocol=SASL_SSL
-    //   basic.auth.credentials.source=USER_INFO
-    //   schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
-    //   schema.registry.url=https://<SR ENDPOINT>
+    // Load properties from a local configuration file
+    // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
+    // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
+    // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
     final Properties props = loadConfig(args[0]);
 
     // Create topic if needed

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerAvroExample.java
@@ -68,10 +68,10 @@ public class ProducerAvroExample {
     //   ssl.endpoint.identification.algorithm=https
     //   sasl.mechanism=PLAIN
     //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="<CLUSTER_API_KEY>" password="<CLUSTER_API_SECRET>";
+    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
     //   security.protocol=SASL_SSL
     //   basic.auth.credentials.source=USER_INFO
-    //   schema.registry.basic.auth.user.info=<SR_API_KEY>:<SR_API_SECRET>
+    //   schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
     //   schema.registry.url=https://<SR ENDPOINT>
     final Properties props = loadConfig(args[0]);
 

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerExample.java
@@ -63,13 +63,10 @@ public class ProducerExample {
       System.exit(1);
     }
 
-    // Load properties from a configuration file
-    // The configuration properties defined in the configuration file are assumed to include:
-    //   ssl.endpoint.identification.algorithm=https
-    //   sasl.mechanism=PLAIN
-    //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
-    //   security.protocol=SASL_SSL
+    // Load properties from a local configuration file
+    // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
+    // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
+    // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
     final Properties props = loadConfig(args[0]);
 
     // Create topic if needed

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerExample.java
@@ -68,7 +68,7 @@ public class ProducerExample {
     //   ssl.endpoint.identification.algorithm=https
     //   sasl.mechanism=PLAIN
     //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="<CLUSTER_API_KEY>" password="<CLUSTER_API_SECRET>";
+    //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
     //   security.protocol=SASL_SSL
     final Properties props = loadConfig(args[0]);
 

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsAvroExample.java
@@ -64,10 +64,10 @@ public class StreamsAvroExample {
         //   ssl.endpoint.identification.algorithm=https
         //   sasl.mechanism=PLAIN
         //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-        //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="<CLUSTER_API_KEY>" password="<CLUSTER_API_SECRET>";
+        //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
         //   security.protocol=SASL_SSL
         //   basic.auth.credentials.source=USER_INFO
-        //   schema.registry.basic.auth.user.info=<SR_API_KEY>:<SR_API_SECRET>
+        //   schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
         //   schema.registry.url=https://<SR ENDPOINT>
         final Properties props = loadConfig(args[0]);
 

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsAvroExample.java
@@ -59,16 +59,10 @@ public class StreamsAvroExample {
     
         final String topic = args[1];
     
-        // Load properties from a configuration file
-        // The configuration properties defined in the configuration file are assumed to include:
-        //   ssl.endpoint.identification.algorithm=https
-        //   sasl.mechanism=PLAIN
-        //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-        //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
-        //   security.protocol=SASL_SSL
-        //   basic.auth.credentials.source=USER_INFO
-        //   schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
-        //   schema.registry.url=https://<SR ENDPOINT>
+        // Load properties from a local configuration file
+        // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
+        // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
+        // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
         final Properties props = loadConfig(args[0]);
 
         // Add additional properties.

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsExample.java
@@ -61,13 +61,10 @@ public class StreamsExample {
     
         final String topic = args[1];
     
-        // Load properties from a configuration file
-        // The configuration properties defined in the configuration file are assumed to include:
-        //   ssl.endpoint.identification.algorithm=https
-        //   sasl.mechanism=PLAIN
-        //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-        //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
-        //   security.protocol=SASL_SSL
+        // Load properties from a local configuration file
+        // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
+        // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
+        // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
         final Properties props = loadConfig(args[0]);
 
         // Add additional properties.

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsExample.java
@@ -66,7 +66,7 @@ public class StreamsExample {
         //   ssl.endpoint.identification.algorithm=https
         //   sasl.mechanism=PLAIN
         //   bootstrap.servers=<CLUSTER_BOOTSTRAP_SERVER>
-        //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="<CLUSTER_API_KEY>" password="<CLUSTER_API_SECRET>";
+        //   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
         //   security.protocol=SASL_SSL
         final Properties props = loadConfig(args[0]);
 

--- a/clients/cloud/kafka-commands/README.md
+++ b/clients/cloud/kafka-commands/README.md
@@ -7,20 +7,8 @@ Produce messages to and consume messages from a Kafka cluster using the Apache b
 
 * [Confluent Platform 5.4](https://www.confluent.io/download/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Initialize a properties file at `$HOME/.ccloud/config` with configuration to your Confluent Cloud cluster:
-
-```shell
-$ cat $HOME/.ccloud/config
-bootstrap.servers=<BROKER ENDPOINT>
-ssl.endpoint.identification.algorithm=https
-security.protocol=SASL_SSL
-sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="<API KEY>" password\="<API SECRET>";
-```
+* Create a local file (e.g. at `$HOME/.confluent/java.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 
 # Example 1: Hello World!
@@ -32,7 +20,7 @@ The consumer reads the same topic from Confluent Cloud.
 1. Create the topic in Confluent Cloud
 
 ```bash
-$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` --command-config $HOME/.ccloud/config --topic test1 --create --replication-factor 3 --partitions 6
+$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --command-config $HOME/.confluent/java.config --topic test1 --create --replication-factor 3 --partitions 6
 ```
 
 2. Run the command `kafka-console-producer`, writing messages to topic `test1`, passing in additional arguments:
@@ -40,7 +28,7 @@ $ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/con
 * `--property parse.key=true --property key.separator=,`: pass key and value, separated by a comma
 
 ```bash
-$ kafka-console-producer --topic test1 --broker-list `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` --property parse.key=true --property key.separator=, --producer.config $HOME/.ccloud/config
+$ kafka-console-producer --topic test1 --broker-list `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --property parse.key=true --property key.separator=, --producer.config $HOME/.confluent/java.config
 ```
 
 At the `>` prompt, type a few messages, using a `,` as the separator between the message key and value:
@@ -59,7 +47,7 @@ When you are done, press `<ctrl>-d`.
 * `--from-beginning`: print all messages from the beginning of the topic
 
 ```bash
-$ kafka-console-consumer --topic test1 --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` --property print.key=true --from-beginning --consumer.config $HOME/.ccloud/config
+$ kafka-console-consumer --topic test1 --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --property print.key=true --from-beginning --consumer.config $HOME/.confluent/java.config
 ```
 
 You should see the messages you typed in the previous step.
@@ -89,14 +77,14 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
     # View the list of registered subjects
     $ curl -u <SR API KEY>:<SR API SECRET> https://<SR ENDPOINT>/subjects
 
-    # Same as above, as a single bash command to parse the values out of $HOME/.ccloud/config
-    $ curl -u $(grep "^schema.registry.basic.auth.user.info" $HOME/.ccloud/config | cut -d'=' -f2) $(grep "^schema.registry.url" $HOME/.ccloud/config | cut -d'=' -f2)/subjects
+    # Same as above, as a single bash command to parse the values out of $HOME/.confluent/java.config
+    $ curl -u $(grep "^schema.registry.basic.auth.user.info" $HOME/.confluent/java.config | cut -d'=' -f2) $(grep "^schema.registry.url" $HOME/.confluent/java.config | cut -d'=' -f2)/subjects
     ```
 
-3. Add the following parameters to your local Confluent Cloud configuration file (``$HOME/.ccloud/config``). In the output below, substitute values for `<SR API KEY>`, `<SR API SECRET>`, and `<SR ENDPOINT>`.
+3. Add the following parameters to your local Confluent Cloud configuration file (``$HOME/.confluent/java.config``). In the output below, substitute values for `<SR API KEY>`, `<SR API SECRET>`, and `<SR ENDPOINT>`.
 
     ```shell
-    $ cat $HOME/.ccloud/config
+    $ cat $HOME/.confluent/java.config
     ...
     basic.auth.credentials.source=USER_INFO
     schema.registry.basic.auth.user.info=<SR API KEY>:<SR API SECRET>
@@ -107,7 +95,7 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
 4. Create the topic in Confluent Cloud
 
 ```bash
-$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` --command-config $HOME/.ccloud/config --topic test2 --create --replication-factor 3 --partitions 6
+$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --command-config $HOME/.confluent/java.config --topic test2 --create --replication-factor 3 --partitions 6
 ```
 
 5. Run the command `kafka-avro-console-producer`, writing messages to topic `test2`, passing in additional arguments. The additional Schema Registry parameters are required to be passed in as properties instead of a properties file due to https://github.com/confluentinc/schema-registry/issues/1052.
@@ -118,10 +106,10 @@ $ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/con
 * `--property schema.registry.basic.auth.user.info`: `<SR API KEY>:<SR API SECRET>`
 
 ```bash
-$ kafka-avro-console-producer --topic test2 --broker-list `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` --producer.config $HOME/.ccloud/config --property value.schema='{"type":"record","name":"myrecord","fields":[{"name":"count","type":"int"}]}' --property schema.registry.url=https://<SR ENDPOINT> --property basic.auth.credentials.source=USER_INFO --property schema.registry.basic.auth.user.info='<SR API KEY>:<SR API SECRET>'
+$ kafka-avro-console-producer --topic test2 --broker-list `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --producer.config $HOME/.confluent/java.config --property value.schema='{"type":"record","name":"myrecord","fields":[{"name":"count","type":"int"}]}' --property schema.registry.url=https://<SR ENDPOINT> --property basic.auth.credentials.source=USER_INFO --property schema.registry.basic.auth.user.info='<SR API KEY>:<SR API SECRET>'
 
-# Same as above, as a single bash command to parse the values out of $HOME/.ccloud/config
-$ kafka-avro-console-producer --topic test2 --broker-list `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` --producer.config $HOME/.ccloud/config --property value.schema='{"type":"record","name":"myrecord","fields":[{"name":"count","type":"int"}]}' --property schema.registry.url=$(grep "^schema.registry.url" $HOME/.ccloud/config | cut -d'=' -f2) --property basic.auth.credentials.source=USER_INFO --property schema.registry.basic.auth.user.info=$(grep "^schema.registry.basic.auth.user.info" $HOME/.ccloud/config | cut -d'=' -f2)
+# Same as above, as a single bash command to parse the values out of $HOME/.confluent/java.config
+$ kafka-avro-console-producer --topic test2 --broker-list `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --producer.config $HOME/.confluent/java.config --property value.schema='{"type":"record","name":"myrecord","fields":[{"name":"count","type":"int"}]}' --property schema.registry.url=$(grep "^schema.registry.url" $HOME/.confluent/java.config | cut -d'=' -f2) --property basic.auth.credentials.source=USER_INFO --property schema.registry.basic.auth.user.info=$(grep "^schema.registry.basic.auth.user.info" $HOME/.confluent/java.config | cut -d'=' -f2)
 ```
 
 At the `>` prompt, type a few messages:
@@ -141,10 +129,10 @@ When you are done, press `<ctrl>-d`.
 * `--property schema.registry.basic.auth.user.info`: `<SR API KEY>:<SR API SECRET>`
 
 ```bash
-$ kafka-avro-console-consumer --topic test2 --from-beginning --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` --consumer.config $HOME/.ccloud/config --property schema.registry.url=https://<SR ENDPOINT> --property basic.auth.credentials.source=USER_INFO --property schema.registry.basic.auth.user.info='<SR API KEY>:<SR API SECRET>'
+$ kafka-avro-console-consumer --topic test2 --from-beginning --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --consumer.config $HOME/.confluent/java.config --property schema.registry.url=https://<SR ENDPOINT> --property basic.auth.credentials.source=USER_INFO --property schema.registry.basic.auth.user.info='<SR API KEY>:<SR API SECRET>'
 
-# Same as above, as a single bash command to parse the values out of $HOME/.ccloud/config
-$ kafka-avro-console-consumer --topic test2 --from-beginning --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` --consumer.config $HOME/.ccloud/config --property schema.registry.url=$(grep "^schema.registry.url" $HOME/.ccloud/config | cut -d'=' -f2) --property basic.auth.credentials.source=USER_INFO --property schema.registry.basic.auth.user.info=$(grep "^schema.registry.basic.auth.user.info" $HOME/.ccloud/config | cut -d'=' -f2)
+# Same as above, as a single bash command to parse the values out of $HOME/.confluent/java.config
+$ kafka-avro-console-consumer --topic test2 --from-beginning --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --consumer.config $HOME/.confluent/java.config --property schema.registry.url=$(grep "^schema.registry.url" $HOME/.confluent/java.config | cut -d'=' -f2) --property basic.auth.credentials.source=USER_INFO --property schema.registry.basic.auth.user.info=$(grep "^schema.registry.basic.auth.user.info" $HOME/.confluent/java.config | cut -d'=' -f2)
 ```
 
 You should see the messages you typed in the previous step.

--- a/clients/cloud/kafka-commands/kafka-commands-ccsr.sh
+++ b/clients/cloud/kafka-commands/kafka-commands-ccsr.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONFIG_FILE=~/.ccloud/config
+CONFIG_FILE=$HOME/.confluent/java.config
 
 source ../../../utils/helper.sh
 
@@ -24,7 +24,7 @@ echo -e "\n# Produce messages to $topic_name"
 num_messages=10
 (for i in `seq 1 $num_messages`; do echo "{\"count\":${i}}" ; done) | \
    kafka-avro-console-producer --topic $topic_name \
-                               --broker-list `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` \
+                               --broker-list `grep "^\s*bootstrap.server" $HOME/.confluent/config | tail -1` \
                                --producer.config $CONFIG_FILE \
                                --property value.schema='{"type":"record","name":"myrecord","fields":[{"name":"count","type":"int"}]}' \
                                --property basic.auth.credentials.source=${BASIC_AUTH_CREDENTIALS_SOURCE} \
@@ -34,7 +34,7 @@ num_messages=10
 # Consume messages
 echo -e "\n# Consume messages from $topic_name"
 kafka-avro-console-consumer --topic $topic_name \
-                            --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` \
+                            --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/config | tail -1` \
                             --consumer.config $CONFIG_FILE \
                             --property basic.auth.credentials.source=${BASIC_AUTH_CREDENTIALS_SOURCE} \
                             --property schema.registry.basic.auth.user.info=${SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO} \

--- a/clients/cloud/kafka-commands/kafka-commands.sh
+++ b/clients/cloud/kafka-commands/kafka-commands.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONFIG_FILE=~/.ccloud/config
+CONFIG_FILE=$HOME/.confluent/java.config
 
 source ../../../utils/helper.sh 
 
@@ -21,7 +21,7 @@ echo -e "\n# Produce messages to $topic_name"
 num_messages=10
 (for i in `seq 1 $num_messages`; do echo "alice,{\"count\":${i}}" ; done) | \
    kafka-console-producer --topic $topic_name \
-                          --broker-list `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` \
+                          --broker-list `grep "^\s*bootstrap.server" $HOME/.confluent/config | tail -1` \
                           --producer.config $CONFIG_FILE \
                           --property parse.key=true \
                           --property key.separator=, 2>/dev/null
@@ -30,7 +30,7 @@ num_messages=10
 # Consume messages
 echo -e "\n# Consume messages from $topic_name"
 kafka-console-consumer --topic $topic_name \
-                       --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` \
+                       --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/config | tail -1` \
                        --consumer.config $CONFIG_FILE \
                        --property print.key=true \
                        --from-beginning \

--- a/clients/cloud/kafka-connect-datagen/README.md
+++ b/clients/cloud/kafka-connect-datagen/README.md
@@ -10,20 +10,8 @@ Produce messages to and consume messages from a Kafka cluster using [Kafka Conne
 * Docker
 * [Confluent Platform 5.4](https://www.confluent.io/download/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), which includes Confluent CLI
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Initialize a properties file at `$HOME/.ccloud/config` with configuration to your Confluent Cloud cluster:
-
-```shell
-$ cat $HOME/.ccloud/config
-bootstrap.servers=<BROKER ENDPOINT>
-ssl.endpoint.identification.algorithm=https
-security.protocol=SASL_SSL
-sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="<API KEY>" password\="<API SECRET>";
-```
+* Create a local file (e.g. at `$HOME/.confluent/java.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 # Example 1: Hello World!
 
@@ -34,13 +22,13 @@ Use CLI to read that topic from Confluent Cloud.
 1. Create the topic in Confluent Cloud
 
 ```bash
-$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` --command-config $HOME/.ccloud/config --topic test1 --create --replication-factor 3 --partitions 6
+$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --command-config $HOME/.confluent/java.config --topic test1 --create --replication-factor 3 --partitions 6
 ```
 
 2. Generate a file of ENV variables used by Docker to set the bootstrap servers and security configuration.
 
 ```bash
-$ ../../../ccloud/ccloud-generate-cp-configs.sh $HOME/.ccloud/config
+$ ../../../ccloud/ccloud-generate-cp-configs.sh $HOME/.confluent/java.config
 ```
 
 3. Source the generated file of ENV variables
@@ -108,14 +96,14 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
     # View the list of registered subjects
     $ curl -u <SR API KEY>:<SR API SECRET> https://<SR ENDPOINT>/subjects
 
-    # Same as above, as a single bash command to parse the values out of $HOME/.ccloud/config
-    $ curl -u $(grep "^schema.registry.basic.auth.user.info" $HOME/.ccloud/config | cut -d'=' -f2) $(grep "^schema.registry.url" $HOME/.ccloud/config | cut -d'=' -f2)/subjects
+    # Same as above, as a single bash command to parse the values out of $HOME/.confluent/java.config
+    $ curl -u $(grep "^schema.registry.basic.auth.user.info" $HOME/.confluent/java.config | cut -d'=' -f2) $(grep "^schema.registry.url" $HOME/.confluent/java.config | cut -d'=' -f2)/subjects
     ```
 
-3. Add the following parameters to your local Confluent Cloud configuration file (``$HOME/.ccloud/config``). In the output below, substitute values for `<SR API KEY>`, `<SR API SECRET>`, and `<SR ENDPOINT>`.
+3. Add the following parameters to your local Confluent Cloud configuration file (``$HOME/.confluent/java.config``). In the output below, substitute values for `<SR API KEY>`, `<SR API SECRET>`, and `<SR ENDPOINT>`.
 
     ```shell
-    $ cat $HOME/.ccloud/config
+    $ cat $HOME/.confluent/java.config
     ...
     basic.auth.credentials.source=USER_INFO
     schema.registry.basic.auth.user.info=<SR API KEY>:<SR API SECRET>
@@ -126,13 +114,13 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
 4. Create the topic in Confluent Cloud
 
 ```bash
-$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` --command-config $HOME/.ccloud/config --topic test2 --create --replication-factor 3 --partitions 6
+$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --command-config $HOME/.confluent/java.config --topic test2 --create --replication-factor 3 --partitions 6
 ```
 
 5. Generate a file of ENV variables used by Docker to set the bootstrap servers and security configuration.
 
 ```bash
-$ ../../../ccloud/ccloud-generate-cp-configs.sh $HOME/.ccloud/config
+$ ../../../ccloud/ccloud-generate-cp-configs.sh $HOME/.confluent/java.config
 ```
 
 6. Source the generated file of ENV variables

--- a/clients/cloud/kafka-connect-datagen/start-docker-avro.sh
+++ b/clients/cloud/kafka-connect-datagen/start-docker-avro.sh
@@ -5,7 +5,7 @@
 
 check_jq || exit
 
-CONFIG_FILE=~/.ccloud/config
+CONFIG_FILE=$HOME/.confluent/java.config
 check_ccloud_config $CONFIG_FILE || exit
 
 ./stop-docker.sh

--- a/clients/cloud/kafka-connect-datagen/start-docker.sh
+++ b/clients/cloud/kafka-connect-datagen/start-docker.sh
@@ -5,7 +5,7 @@
 
 check_jq || exit
 
-CONFIG_FILE=~/.ccloud/config
+CONFIG_FILE=$HOME/.confluent/java.config
 check_ccloud_config $CONFIG_FILE || exit
 
 ./stop-docker.sh

--- a/clients/cloud/kafka-connect-datagen/stop-docker.sh
+++ b/clients/cloud/kafka-connect-datagen/stop-docker.sh
@@ -3,7 +3,7 @@
 # Source library
 . ../../../utils/helper.sh
 
-CONFIG_FILE=~/.ccloud/config
+CONFIG_FILE=$HOME/.confluent/java.config
 check_ccloud_config $CONFIG_FILE || exit
 
 ../../../ccloud/ccloud-generate-cp-configs.sh $CONFIG_FILE

--- a/clients/cloud/kafkacat/README.md
+++ b/clients/cloud/kafkacat/README.md
@@ -6,21 +6,8 @@ Produce messages to and consume messages from a Kafka cluster using [kafkacat](h
 # Prerequisites
 
 * [kafkacat](https://github.com/edenhill/kafkacat) installed on your machine.  You must [build](https://github.com/edenhill/kafkacat#build) `kafkacat` from the latest master branch to get the `-F` functionality that makes it easy to pass in the configuration to your Confluent Cloud configuration file.
-
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Initialize a properties file at `$HOME/.ccloud/config` with configuration to your Confluent Cloud cluster:
-
-```shell
-$ cat $HOME/.ccloud/config
-bootstrap.servers=<BROKER ENDPOINT>
-ssl.endpoint.identification.algorithm=https
-security.protocol=SASL_SSL
-sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="<API KEY>" password\="<API SECRET>";
-```
+* Create a local file (e.g. at `$HOME/.confluent/java.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 # Example 1: Hello World!
 
@@ -31,16 +18,16 @@ The consumer reads the same topic from Confluent Cloud.
 1. Create the topic in Confluent Cloud
 
 ```bash
-$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.ccloud/config | tail -1` --command-config $HOME/.ccloud/config --topic test1 --create --replication-factor 3 --partitions 6
+$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --command-config $HOME/.confluent/java.config --topic test1 --create --replication-factor 3 --partitions 6
 ```
 
 2. Run `kafkacat`, writing messages to topic `test1`, passing in additional arguments:
 
-* `-F $HOME/.ccloud/config`: configuration file for connecting to the Confluent Cloud cluster
+* `-F $HOME/.confluent/java.config`: configuration file for connecting to the Confluent Cloud cluster
 * `-K ,`: pass key and value, separated by a comma
 
 ```bash
-$ kafkacat -F $HOME/.ccloud/config -K , -P -t test1
+$ kafkacat -F $HOME/.confluent/java.config -K , -P -t test1
 ```
 
 Type a few messages, using a `,` as the separator between the message key and value:
@@ -55,18 +42,18 @@ When you are done, press `<ctrl>-d`.
 
 2. Run `kafkacat` again, reading messages from topic `test`, passing in additional arguments:
 
-* `-F $HOME/.ccloud/config`: configuration file for connecting to the Confluent Cloud cluster
+* `-F $HOME/.confluent/java.config`: configuration file for connecting to the Confluent Cloud cluster
 * `-K ,`: pass key and value, separated by a comma
 * `-e`: exit successfully when last message received
 
 ```bash
-$ kafkacat -F $HOME/.ccloud/config -K , -C -t test1 -e
+$ kafkacat -F $HOME/.confluent/java.config -K , -C -t test1 -e
 ```
 
 You should see the messages you typed in the previous step.
 
 ```bash
-% Reading configuration from file $HOME/.ccloud/config
+% Reading configuration from file $HOME/.confluent/java.config
 % Reached end of topic test1 [3] at offset 0
 alice,{"count":0}
 alice,{"count":1}

--- a/clients/cloud/kafkacat/kafkacat-example.sh
+++ b/clients/cloud/kafkacat/kafkacat-example.sh
@@ -3,7 +3,7 @@
 set -eu
 
 source ../../../utils/helper.sh
-CONFIG_FILE=~/.ccloud/config
+CONFIG_FILE=$HOME/.confluent/java.config
 check_ccloud_config $CONFIG_FILE || exit
 
 # Set topic name
@@ -20,11 +20,11 @@ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $CONFIG_FILE | tail
 # Produce messages
 num_messages=10
 (for i in `seq 1 $num_messages`; do echo "alice,{\"count\":${i}}" ; done) | \
-   kafkacat -F $HOME/.ccloud/config \
+   kafkacat -F $HOME/.confluent/config \
             -K , \
             -P -t $topic_name
 
 # Consume messages
-kafkacat -F $HOME/.ccloud/config \
+kafkacat -F $HOME/.confluent/config \
          -K , \
          -C -t $topic_name -e

--- a/clients/cloud/kotlin/README.adoc
+++ b/clients/cloud/kotlin/README.adoc
@@ -6,19 +6,18 @@ Produce messages to and consume messages from a Kafka cluster using the Kotlin v
 
 * Java 1.8 or higher to run the demo application
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, link:https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud[Confluent Cloud], or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
+To run this example, update the `example.config` file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
 
-* Access to a link:https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud[Confluent Cloud] cluster
-* Initialize a properties file at `$HOME/.ccloud/config` with configuration to your Confluent Cloud cluster:
+* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
+* Update the `example.config` file with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
 
 ```shell
-$ cat $HOME/.ccloud/config
-bootstrap.servers=<BROKER ENDPOINT>
+$ cat example.config
+bootstrap.servers={{ BROKER_ENDPOINT }}
 ssl.endpoint.identification.algorithm=https
 security.protocol=SASL_SSL
 sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="<API KEY>" password\="<API SECRET>";
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="{{ CLUSTER_API_KEY }}" password\="{{ CLUSTER_API_SECRET }}";
 ```
 
 == Example 1: Hello World!
@@ -38,7 +37,7 @@ The Kafka Streams API reads the same topic from Confluent Cloud and does a state
 	
  # Run the producer
  $ ./gradlew runApp -PmainClass="io.confluent.examples.clients.cloud.ProducerExample" \
- -PconfigPath="$HOME/.ccloud/config" \
+ -PconfigPath="$HOME/examples/clients/cloud/kotlin/example.config" \
  -Ptopic="test1"
 ----
 
@@ -84,7 +83,7 @@ Verify that the consumer received all the messages:
 	
  # Run the consumer
  $ ./gradlew runApp -PmainClass="io.confluent.examples.clients.cloud.ConsumerExample"\
-   	-PconfigPath="$HOME/.ccloud/config"\
+   	-PconfigPath="$HOME/examples/clients/cloud/kotlin/example.config"\
    	-Ptopic="test1"
 ----
 
@@ -116,7 +115,7 @@ Verify that the consumer received all the messages:
 
  # Run the consumer
  $ ./gradlew runApp -PmainClass="io.confluent.examples.clients.cloud.StreamsExample" \
-   	-PconfigPath="$HOME/.ccloud/config" \
+   	-PconfigPath="$HOME/examples/clients/cloud/kotlin/example.config" \
    	-Ptopic="test1"
  ```
 ....

--- a/clients/cloud/kotlin/README.adoc
+++ b/clients/cloud/kotlin/README.adoc
@@ -5,20 +5,8 @@ Produce messages to and consume messages from a Kafka cluster using the Kotlin v
 == Prerequisites
 
 * Java 1.8 or higher to run the demo application
-
-To run this example, update the `example.config` file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Update the `example.config` file with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
-
-```shell
-$ cat example.config
-bootstrap.servers={{ BROKER_ENDPOINT }}
-ssl.endpoint.identification.algorithm=https
-security.protocol=SASL_SSL
-sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="{{ CLUSTER_API_KEY }}" password\="{{ CLUSTER_API_SECRET }}";
-```
+* Create a local file (e.g. at `$HOME/.confluent/java.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 == Example 1: Hello World!
 
@@ -37,7 +25,7 @@ The Kafka Streams API reads the same topic from Confluent Cloud and does a state
 	
  # Run the producer
  $ ./gradlew runApp -PmainClass="io.confluent.examples.clients.cloud.ProducerExample" \
- -PconfigPath="$HOME/examples/clients/cloud/kotlin/example.config" \
+ -PconfigPath="$HOME/.confluent/java.config" \
  -Ptopic="test1"
 ----
 
@@ -83,7 +71,7 @@ Verify that the consumer received all the messages:
 	
  # Run the consumer
  $ ./gradlew runApp -PmainClass="io.confluent.examples.clients.cloud.ConsumerExample"\
-   	-PconfigPath="$HOME/examples/clients/cloud/kotlin/example.config"\
+   	-PconfigPath="$HOME/.confluent/java.config"\
    	-Ptopic="test1"
 ----
 
@@ -115,7 +103,7 @@ Verify that the consumer received all the messages:
 
  # Run the consumer
  $ ./gradlew runApp -PmainClass="io.confluent.examples.clients.cloud.StreamsExample" \
-   	-PconfigPath="$HOME/examples/clients/cloud/kotlin/example.config" \
+   	-PconfigPath="$HOME/.confluent/java.config" \
    	-Ptopic="test1"
  ```
 ....

--- a/clients/cloud/kotlin/build.gradle.kts
+++ b/clients/cloud/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-group = "io.confluent.ccloud"
+group = "io.confluent.confluent"
 
 plugins {
   java

--- a/clients/cloud/kotlin/gradle.properties
+++ b/clients/cloud/kotlin/gradle.properties
@@ -1,3 +1,3 @@
-configPath=~/.ccloud/config
+configPath=$HOME/.confluent/java.config
 topic=topic1
 mainClass=io.confluent.examples.clients.cloud.ConsumerExample

--- a/clients/cloud/ksql-datagen/README.md
+++ b/clients/cloud/ksql-datagen/README.md
@@ -9,21 +9,8 @@ Produce messages to and consume messages from a Kafka cluster using the [KSQL da
 
 * [Confluent Platform 5.4](https://www.confluent.io/download/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)
 * Docker
-
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Initialize a properties file at `$HOME/.ccloud/config` with configuration to your Confluent Cloud cluster:
-
-```shell
-$ cat $HOME/.ccloud/config
-bootstrap.servers=<BROKER ENDPOINT>
-ssl.endpoint.identification.algorithm=https
-security.protocol=SASL_SSL
-sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="<API KEY>" password\="<API SECRET>";
-```
+* Create a local file (e.g. at `$HOME/.confluent/java.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 # Example 1: Hello World!
 
@@ -34,13 +21,13 @@ Use CLI to read that topic from Confluent Cloud.
 1. Create the topic in Confluent Cloud
 
 ```bash
-$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" ~/.ccloud/config | tail -1` --command-config ~/.ccloud/config --topic test1 --create --replication-factor 3 --partitions 6
+$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --command-config $HOME/.confluent/java.config --topic test1 --create --replication-factor 3 --partitions 6
 ```
 
 2. Generate a file of ENV variables used by Docker to set the bootstrap servers and security configuration.
 
 ```bash
-$ ../../../ccloud/ccloud-generate-cp-configs.sh $HOME/.ccloud/config
+$ ../../../ccloud/ccloud-generate-cp-configs.sh $HOME/.confluent/java.config
 ```
 
 3. Source the generated file of ENV variables
@@ -90,14 +77,14 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
     # View the list of registered subjects
     $ curl -u <SR API KEY>:<SR API SECRET> https://<SR ENDPOINT>/subjects
 
-    # Same as above, as a single bash command to parse the values out of $HOME/.ccloud/config
-    $ curl -u $(grep "^schema.registry.basic.auth.user.info" $HOME/.ccloud/config | cut -d'=' -f2) $(grep "^schema.registry.url" $HOME/.ccloud/config | cut -d'=' -f2)/subjects
+    # Same as above, as a single bash command to parse the values out of $HOME/.confluent/java.config
+    $ curl -u $(grep "^schema.registry.basic.auth.user.info" $HOME/.confluent/java.config | cut -d'=' -f2) $(grep "^schema.registry.url" $HOME/.confluent/java.config | cut -d'=' -f2)/subjects
     ```
 
-3. Add the following parameters to your local Confluent Cloud configuration file (``$HOME/.ccloud/config``). In the output below, substitute values for `<SR API KEY>`, `<SR API SECRET>`, and `<SR ENDPOINT>`.
+3. Add the following parameters to your local Confluent Cloud configuration file (``$HOME/.confluent/java.config``). In the output below, substitute values for `<SR API KEY>`, `<SR API SECRET>`, and `<SR ENDPOINT>`.
 
     ```shell
-    $ cat $HOME/.ccloud/config
+    $ cat $HOME/.confluent/java.config
     ...
     basic.auth.credentials.source=USER_INFO
     schema.registry.basic.auth.user.info=<SR API KEY>:<SR API SECRET>
@@ -108,13 +95,13 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
 4. Create the topic in Confluent Cloud
 
 ```bash
-$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" ~/.ccloud/config | tail -1` --command-config ~/.ccloud/config --topic test2 --create --replication-factor 3 --partitions 6
+$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $HOME/.confluent/java.config | tail -1` --command-config $HOME/.confluent/java.config --topic test2 --create --replication-factor 3 --partitions 6
 ```
 
 5. Generate a file of ENV variables used by Docker to set the bootstrap servers and security configuration.
 
 ```bash
-$ ../../../ccloud/ccloud-generate-cp-configs.sh $HOME/.ccloud/config
+$ ../../../ccloud/ccloud-generate-cp-configs.sh $HOME/.confluent/java.config
 ```
 
 6. Source the generated file of ENV variables

--- a/clients/cloud/ksql-datagen/start-docker-avro.sh
+++ b/clients/cloud/ksql-datagen/start-docker-avro.sh
@@ -3,7 +3,7 @@
 # Source library
 . ../../../utils/helper.sh
 
-CONFIG_FILE=~/.ccloud/config
+CONFIG_FILE=$HOME/.confluent/java.config
 check_ccloud_config $CONFIG_FILE || exit
 
 ./stop-docker.sh

--- a/clients/cloud/ksql-datagen/start-docker.sh
+++ b/clients/cloud/ksql-datagen/start-docker.sh
@@ -3,7 +3,7 @@
 # Source library
 . ../../../utils/helper.sh
 
-CONFIG_FILE=~/.ccloud/config
+CONFIG_FILE=$HOME/.confluent/java.config
 check_ccloud_config $CONFIG_FILE || exit
 
 ./stop-docker.sh

--- a/clients/cloud/ksql-datagen/stop-docker.sh
+++ b/clients/cloud/ksql-datagen/stop-docker.sh
@@ -3,7 +3,7 @@
 # Source library
 . ../../../utils/helper.sh
 
-CONFIG_FILE=~/.ccloud/config
+CONFIG_FILE=$HOME/.confluent/java.config
 check_ccloud_config $CONFIG_FILE || exit
 
 ../../../ccloud/ccloud-generate-cp-configs.sh $CONFIG_FILE

--- a/clients/cloud/nodejs/README.md
+++ b/clients/cloud/nodejs/README.md
@@ -13,21 +13,8 @@ $ npm install
 ```
 _Note: Users of macOS 10.13 (High Sierra) and above should heed [node-rdkafka's additional configuration instructions related to OpenSSL](https://github.com/Blizzard/node-rdkafka/blob/56c31c4e81f2a042666160338ad65dc4f8f2d87e/README.md#mac-os-high-sierra--mojave) before running `npm install`._
 
-To run this example, download the `librdkafka.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
-Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Update the `librdkafka.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
-
-
-```bash
-$ cat $HOME/.ccloud/librdkafka.config
-bootstrap.servers={{ BROKER_ENDPOINT }}
-sasl.mechanisms=PLAIN
-security.protocol=SASL_SSL
-sasl.username={{ CLUSTER_API_KEY }}
-sasl.password={{ CLUSTER_API_SECRET }}
-```
+* Create a local file (e.g. at `$HOME/.confluent/librdkafka.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 # Example 1: Hello World!
 
@@ -37,7 +24,7 @@ The consumer reads the same topic from Confluent Cloud and keeps a rolling sum o
 
 1. Run the producer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the topic name:
 ```bash
-$ node producer.js -f $HOME/.ccloud/librdkafka.config -t test1
+$ node producer.js -f $HOME/.confluent/librdkafka.config -t test1
 Created topic test1
 Producing record alice	{"count":0}
 Producing record alice	{"count":1}
@@ -63,7 +50,7 @@ Successfully produced record to topic "test1" partition 0 {"count":9}
 
 2. Run the consumer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the same topic name as used above. Verify that the consumer received all the messages:
 ```bash
-$ node consumer.js -f $HOME/.ccloud/librdkafka.config -t test1
+$ node consumer.js -f $HOME/.confluent/librdkafka.config -t test1
 Consuming messages from test1
 Consumed record with key alice and value {"count":0} of partition 0 @ offset 0. Updated total count to 1
 Consumed record with key alice and value {"count":1} of partition 0 @ offset 1. Updated total count to 2

--- a/clients/cloud/nodejs/README.md
+++ b/clients/cloud/nodejs/README.md
@@ -13,16 +13,20 @@ $ npm install
 ```
 _Note: Users of macOS 10.13 (High Sierra) and above should heed [node-rdkafka's additional configuration instructions related to OpenSSL](https://github.com/Blizzard/node-rdkafka/blob/56c31c4e81f2a042666160338ad65dc4f8f2d87e/README.md#mac-os-high-sierra--mojave) before running `npm install`._
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
+To run this example, download the `librdkafka.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
+Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
 
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster.
-* Local file with configuration parameters to connect to your Confluent Cloud instance ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)). Format the file as follows:
+* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
+* Update the `librdkafka.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
+
+
 ```bash
-$ cat $HOME/.ccloud/example.config
-bootstrap.servers=<broker-1,broker-2,broker-3>
-sasl.username=<api-key-id>
-sasl.password=<secret-access-key>
+$ cat $HOME/.ccloud/librdkafka.config
+bootstrap.servers={{ BROKER_ENDPOINT }}
+sasl.mechanisms=PLAIN
+security.protocol=SASL_SSL
+sasl.username={{ CLUSTER_API_KEY }}
+sasl.password={{ CLUSTER_API_SECRET }}
 ```
 
 # Example 1: Hello World!
@@ -33,7 +37,7 @@ The consumer reads the same topic from Confluent Cloud and keeps a rolling sum o
 
 1. Run the producer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the topic name:
 ```bash
-$ node producer.js -f $HOME/.ccloud/example.config -t test1
+$ node producer.js -f $HOME/.ccloud/librdkafka.config -t test1
 Created topic test1
 Producing record alice	{"count":0}
 Producing record alice	{"count":1}
@@ -59,7 +63,7 @@ Successfully produced record to topic "test1" partition 0 {"count":9}
 
 2. Run the consumer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the same topic name as used above. Verify that the consumer received all the messages:
 ```bash
-$ node consumer.js -f $HOME/.ccloud/example.config -t test1
+$ node consumer.js -f $HOME/.ccloud/librdkafka.config -t test1
 Consuming messages from test1
 Consumed record with key alice and value {"count":0} of partition 0 @ offset 0. Updated total count to 1
 Consumed record with key alice and value {"count":1} of partition 0 @ offset 1. Updated total count to 2

--- a/clients/cloud/nodejs/consumer.js
+++ b/clients/cloud/nodejs/consumer.js
@@ -28,8 +28,8 @@ function createConsumer(config, onData) {
     'bootstrap.servers': config['bootstrap.servers'],
     'sasl.username': config['sasl.username'],
     'sasl.password': config['sasl.password'],
-    'security.protocol': 'SASL_SSL',
-    'sasl.mechanisms': 'PLAIN',
+    'security.protocol': config['security.protocol'],
+    'sasl.mechanisms': config['sasl.mechanisms'],
     'group.id': 'node-example-group-1'
   }, {
     'auto.offset.reset': 'earliest'

--- a/clients/cloud/nodejs/producer.js
+++ b/clients/cloud/nodejs/producer.js
@@ -30,8 +30,8 @@ function ensureTopicExists(config) {
     'bootstrap.servers': config['bootstrap.servers'],
     'sasl.username': config['sasl.username'],
     'sasl.password': config['sasl.password'],
-    'security.protocol': 'SASL_SSL',
-    'sasl.mechanisms': 'PLAIN'
+    'security.protocol': config['security.protocol'],
+    'sasl.mechanisms': config['sasl.mechanisms']
   });
 
   return new Promise((resolve, reject) => {
@@ -59,8 +59,8 @@ function createProducer(config, onDeliveryReport) {
     'bootstrap.servers': config['bootstrap.servers'],
     'sasl.username': config['sasl.username'],
     'sasl.password': config['sasl.password'],
-    'security.protocol': 'SASL_SSL',
-    'sasl.mechanisms': 'PLAIN',
+    'security.protocol': config['security.protocol'],
+    'sasl.mechanisms': config['sasl.mechanisms'],
     'dr_msg_cb': true
   });
 

--- a/clients/cloud/python/README.md
+++ b/clients/cloud/python/README.md
@@ -6,29 +6,14 @@ Produce messages to and consume messages from a Kafka cluster using [Confluent P
 # Prerequisites
 
 * [Confluent's Python Client for Apache Kafka](https://github.com/confluentinc/confluent-kafka-python) installed on your machine. Check that you are using version 1.0.0 or higher (e.g., `pip show confluent-kafka`).
-
-To run this example, download the `librdkafka.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
-Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Update the `librdkafka.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
-
-
-```bash
-$ cat $HOME/.ccloud/librdkafka.config
-bootstrap.servers={{ BROKER_ENDPOINT }}
-sasl.mechanisms=PLAIN
-security.protocol=SASL_SSL
-sasl.username={{ CLUSTER_API_KEY }}
-sasl.password={{ CLUSTER_API_SECRET }}
-```
-
+* Create a local file (e.g. at `$HOME/.confluent/librdkafka.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 ## Configure SSL trust store
 
 Depending on your operating system or Linux distro you may need to take extra steps to set up the SSL CA root certificates. If your systems does not have the SSL CA root certificates properly set up, here is an example of an error message you may see.
 
 ```
-$ ./producer.py -f $HOME/.ccloud/librdkafka.config -t hello
+$ ./producer.py -f $HOME/.confluent/librdkafka.config -t hello
 %3|1554125834.196|FAIL|rdkafka#producer-2| [thrd:sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/boot]: sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/bootstrap: Failed to verify broker certificate: unable to get issuer certificate (after 626ms in state CONNECT)
 %3|1554125834.197|ERROR|rdkafka#producer-2| [thrd:sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/boot]: sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/bootstrap: Failed to verify broker certificate: unable to get issuer certificate (after 626ms in state CONNECT)
 %3|1554125834.197|ERROR|rdkafka#producer-2| [thrd:sasl_ssl://pkc-epgnk.us-central1.gcp.confluent.cloud\:9092/boot]: 1/1 brokers are down
@@ -57,7 +42,7 @@ The consumer reads the same topic from Confluent Cloud and keeps a rolling sum o
 1. Run the producer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the topic name:
 
 ```bash
-$ ./producer.py -f $HOME/.ccloud/librdkafka.config -t test1
+$ ./producer.py -f $HOME/.confluent/librdkafka.config -t test1
 Producing record: alice 	 {"count": 0}
 Producing record: alice 	 {"count": 1}
 Producing record: alice 	 {"count": 2}
@@ -84,7 +69,7 @@ Produced record to topic test1 partition [0] @ offset 9
 2. Run the consumer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the same topic name as used above. Verify that the consumer received all the messages:
 
 ```bash
-$ ./consumer.py -f $HOME/.ccloud/librdkafka.config -t test1
+$ ./consumer.py -f $HOME/.confluent/librdkafka.config -t test1
 ...
 Waiting for message or event/error in poll()
 Consumed record with key alice and value {"count": 0}, and updated total count to 0
@@ -116,15 +101,15 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
     # View the list of registered subjects
     $ curl -u {{ SR_API_KEY }}:{{ SR_API_SECRET }} https://{{ SR_ENDPOINT }}/subjects
 
-    # Same as above, as a single bash command to parse the values out of  $HOME/.ccloud/librdkafka-sr.config
-    $ curl -u $(grep "^schema.registry.basic.auth.user.info"  $HOME/.ccloud/librdkafka-sr.config | cut -d'=' -f2) $(grep "^schema.registry.url"  $HOME/.ccloud/librdkafka-sr.config | cut -d'=' -f2)/subjects
+    # Same as above, as a single bash command to parse the values out of  $HOME/.confluent/librdkafka.config
+    $ curl -u $(grep "^schema.registry.basic.auth.user.info"  $HOME/.confluent/librdkafka.config | cut -d'=' -f2) $(grep "^schema.registry.url"  $HOME/.confluent/librdkafka.config | cut -d'=' -f2)/subjects
     ```
 
-3. Add the following parameters to your local Confluent Cloud configuration file, or use the `librdkafka-sr.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud).
+3. Add the following parameters to your local Confluent Cloud configuration file.
   In the output below, substitute values for `{{ SR_API_KEY }}`, `{{ SR_API_SECRET }}`, and `{{ SR_ENDPOINT }}`.
  
     ```shell
-    $ cat $HOME/.ccloud/librdkafka-sr.config
+    $ cat $HOME/.confluent/librdkafka.config
     ...
     basic.auth.credentials.source=USER_INFO
     schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
@@ -135,13 +120,13 @@ Note that your VPC must be able to connect to the Confluent Cloud Schema Registr
 4. Create the topic in Confluent Cloud
 
 ```bash
-$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server"  $HOME/.ccloud/librdkafka-sr.config | tail -1` --command-config  $HOME/.ccloud/librdkafka-sr.config --topic test2 --create --replication-factor 3 --partitions 6
+$ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server"  $HOME/.confluent/librdkafka.config | tail -1` --command-config  $HOME/.confluent/librdkafka.config --topic test2 --create --replication-factor 3 --partitions 6
 ```
 
 5. Run the Avro producer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the topic name:
 
 ```bash
-$ ./producer_ccsr.py -f  $HOME/.ccloud/librdkafka-sr.config-t test2
+$ ./producer_ccsr.py -f  $HOME/.confluent/librdkafka.config-t test2
 Producing Avro record: alice	0
 Producing Avro record: alice	1
 Producing Avro record: alice	2
@@ -168,7 +153,7 @@ Produced record to topic test2 partition [0] @ offset 9
 6. Run the Avro consumer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the same topic name as used above. Verify that the consumer received all the messages:
 
 ```bash
-$ ./consumer_ccsr.py -f $HOME/.ccloud/librdkafka-sr.config -t test2
+$ ./consumer_ccsr.py -f $HOME/.confluent/librdkafka.config -t test2
 ...
 Waiting for message or event/error in poll()
 Consumed record with key alice and value 0,                       and updated total count to 0

--- a/clients/cloud/python/consumer.py
+++ b/clients/cloud/python/consumer.py
@@ -40,12 +40,12 @@ if __name__ == '__main__':
     #   topic if no committed offsets exist
     c = Consumer({
         'bootstrap.servers': conf['bootstrap.servers'],
-        'sasl.mechanisms': 'PLAIN',
-        'security.protocol': 'SASL_SSL',
+        'sasl.mechanisms': conf['sasl.mechanisms'],
+        'security.protocol': conf['security.protocol'],
         'sasl.username': conf['sasl.username'],
         'sasl.password': conf['sasl.password'],
         'group.id': 'python_example_group_1',
-        'auto.offset.reset': 'earliest'
+        'auto.offset.reset': 'earliest',
     })
 
     # Subscribe to topic

--- a/clients/cloud/python/consumer_ccsr.py
+++ b/clients/cloud/python/consumer_ccsr.py
@@ -43,8 +43,8 @@ if __name__ == '__main__':
     #   topic if no committed offsets exist
     c = AvroConsumer({
         'bootstrap.servers': conf['bootstrap.servers'],
-        'sasl.mechanisms': 'PLAIN',
-        'security.protocol': 'SASL_SSL',
+        'sasl.mechanisms': conf['sasl.mechanisms'],
+        'security.protocol': conf['security.protocol'],
         'sasl.username': conf['sasl.username'],
         'sasl.password': conf['sasl.password'],
         'schema.registry.url': conf['schema.registry.url'],

--- a/clients/cloud/python/producer.py
+++ b/clients/cloud/python/producer.py
@@ -34,14 +34,13 @@ if __name__ == '__main__':
     config_file = args.config_file
     topic = args.topic
     conf = ccloud_lib.read_ccloud_config(config_file)
-
     # Create Producer instance
     p = Producer({
-           'bootstrap.servers': conf['bootstrap.servers'],
-           'sasl.mechanisms': 'PLAIN',
-           'security.protocol': 'SASL_SSL',
-           'sasl.username': conf['sasl.username'],
-           'sasl.password': conf['sasl.password']
+        'bootstrap.servers': conf['bootstrap.servers'],
+        'sasl.mechanisms': conf['sasl.mechanisms'],
+        'security.protocol': conf['security.protocol'],
+        'sasl.username': conf['sasl.username'],
+        'sasl.password': conf['sasl.password'],
     })
 
     # Create topic if needed

--- a/clients/cloud/python/producer_ccsr.py
+++ b/clients/cloud/python/producer_ccsr.py
@@ -36,17 +36,16 @@ if __name__ == '__main__':
     config_file = args.config_file
     topic = args.topic
     conf = ccloud_lib.read_ccloud_config(config_file)
-
     # Create AvroProducer instance
     p = AvroProducer({
-           'bootstrap.servers': conf['bootstrap.servers'],
-           'sasl.mechanisms': 'PLAIN',
-           'security.protocol': 'SASL_SSL',
-           'sasl.username': conf['sasl.username'],
-           'sasl.password': conf['sasl.password'],
-           'schema.registry.url': conf['schema.registry.url'],
-           'schema.registry.basic.auth.credentials.source': conf['basic.auth.credentials.source'],
-           'schema.registry.basic.auth.user.info': conf['schema.registry.basic.auth.user.info']
+        'bootstrap.servers': conf['bootstrap.servers'],
+        'sasl.mechanisms': conf['sasl.mechanisms'],
+        'security.protocol': conf['security.protocol'],
+        'sasl.username': conf['sasl.username'],
+        'sasl.password': conf['sasl.password'],
+        'schema.registry.url': conf['schema.registry.url'],
+        'schema.registry.basic.auth.credentials.source': conf['basic.auth.credentials.source'],
+        'schema.registry.basic.auth.user.info': conf['schema.registry.basic.auth.user.info'] 
     }, default_key_schema=ccloud_lib.schema_key, default_value_schema=ccloud_lib.schema_value)
 
     # Create topic if needed

--- a/clients/cloud/ruby/README.md
+++ b/clients/cloud/ruby/README.md
@@ -9,20 +9,8 @@ Produce messages to and consume messages from a Kafka cluster using the [ ZenDes
     $ cd clients/ruby
     $ bundle install
     ```
-
-To run this example, download the `librdkafka.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
-Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Update the `librdkafka.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
-
-    ```bash
-    $ cat $HOME/.ccloud/librdkafa.config
-	bootstrap.servers={{ BROKER_ENDPOINT }}
-sasl.username={{ CLUSTER_API_KEY }}
-sasl.password={{ CLUSTER_API_SECRET }}
-    ```
-
+* Create a local file (e.g. at `$HOME/.confluent/librdkafka.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 # Example 1: Hello World!
 
@@ -32,7 +20,7 @@ The consumer reads the same topic from Confluent Cloud and keeps a rolling sum o
 
 1. Run the producer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the topic name:
     ```bash
-    $ ruby producer.rb -f $HOME/.ccloud/librdkafa.config --topic test1
+    $ ruby producer.rb -f $HOME/.confluent/librdkafa.config --topic test1
     Created topic test1
     Producing record: alice	{"count":0}
     Producing record: alice	{"count":1}
@@ -49,7 +37,7 @@ The consumer reads the same topic from Confluent Cloud and keeps a rolling sum o
 
 2. Run the consumer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the same topic name as used above. Verify that the consumer received all the messages:
     ```bash
-    $ ruby consumer.rb -f $HOME/.ccloud/librdkafa.config --topic test1
+    $ ruby consumer.rb -f $HOME/.confluent/librdkafa.config --topic test1
     Consuming messages from test1
     Consumed record with key alice and value {"count":0}, and updated total count 0
     Consumed record with key alice and value {"count":1}, and updated total count 1

--- a/clients/cloud/ruby/README.md
+++ b/clients/cloud/ruby/README.md
@@ -1,29 +1,28 @@
 # Overview
 
 Produce messages to and consume messages from a Kafka cluster using the [ ZenDesk Ruby Client for Apache Kafka](https://github.com/zendesk/ruby-kafka).
-
-
 # Prerequisites
 
 * [Bundler](https://bundler.io/) installed on your machine. Install via `gem install bundler`
 * Install gems
-
     ```bash
     $ cd clients/ruby
     $ bundle install
     ```
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
+To run this example, download the `librdkafka.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
+Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
 
 * Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Local file with configuration parameters to connect to your Confluent Cloud instance ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)). Format the file as follows:
+* Update the `librdkafka.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
+
     ```bash
-    $ cat ~/.ccloud/example.config
-    bootstrap.servers=<broker-1,broker-2,broker-3>
-    sasl.username=<api-key-id>
-    sasl.password=<secret-access-key>
+    $ cat $HOME/.ccloud/librdkafa.config
+	bootstrap.servers={{ BROKER_ENDPOINT }}
+sasl.username={{ CLUSTER_API_KEY }}
+sasl.password={{ CLUSTER_API_SECRET }}
     ```
+
 
 # Example 1: Hello World!
 
@@ -33,7 +32,7 @@ The consumer reads the same topic from Confluent Cloud and keeps a rolling sum o
 
 1. Run the producer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the topic name:
     ```bash
-    $ ruby producer.rb -f ~/.ccloud/example.config --topic test1
+    $ ruby producer.rb -f $HOME/.ccloud/librdkafa.config --topic test1
     Created topic test1
     Producing record: alice	{"count":0}
     Producing record: alice	{"count":1}
@@ -50,7 +49,7 @@ The consumer reads the same topic from Confluent Cloud and keeps a rolling sum o
 
 2. Run the consumer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the same topic name as used above. Verify that the consumer received all the messages:
     ```bash
-    $ ruby consumer.rb -f ~/.ccloud/example.config --topic test1
+    $ ruby consumer.rb -f $HOME/.ccloud/librdkafa.config --topic test1
     Consuming messages from test1
     Consumed record with key alice and value {"count":0}, and updated total count 0
     Consumed record with key alice and value {"count":1}, and updated total count 1

--- a/clients/cloud/rust/README.md
+++ b/clients/cloud/rust/README.md
@@ -3,22 +3,21 @@
 Produce messages to and consume messages from a Kafka cluster using the [rust-rdkafka client for Apache Kafka](https://github.com/fede1024/rust-rdkafka).
 
 # Prerequisites
-
 * [Rust client for Apache Kafka](https://github.com/fede1024/rust-rdkafka#installation) installed on your machine
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
+To run this example, download the `librdkafka.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
+Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
 
 * Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Local file with configuration parameters to connect to your Confluent Cloud instance ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)). Format the file as follows:
+* Update the `librdkafka.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
 
 ```bash
-$ cat ~/.ccloud/example.config
-sasl.mechanism=PLAIN
-sasl.username=<api_key>
-sasl.password=<api_secret>
-bootstrap.servers=<broker_1,broker_2,broker_3>
+$ cat $HOME/.ccloud/librdkafka.config
+bootstrap.servers={{ BROKER_ENDPOINT }}
+sasl.mechanisms=PLAIN
 security.protocol=SASL_SSL
+sasl.username={{ CLUSTER_API_KEY }}
+sasl.password={{ CLUSTER_API_SECRET }}
 ```
 
 # Example 1: Hello World!
@@ -37,7 +36,7 @@ $ cargo build
 2. Run the producer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the topic name:
 
 ```bash
-$ ./target/debug/producer --config ~/.ccloud/example.conf --topic test1
+$ ./target/debug/producer --config $HOME/.ccloud/librdkafka.config --topic test1
 Preparing to produce record: alice 0
 Preparing to produce record: alice 1
 Preparing to produce record: alice 2
@@ -61,7 +60,7 @@ Successfully produced record to topic test1 partition [5] @ offset 125
 3. Run the consumer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the same topic name as used above. Verify that the consumer received all the messages:
 
 ```bash
-$ ./target/debug/consumer --config ~/.ccloud/example.conf --topic test1
+$ ./target/debug/consumer --config $HOME/.ccloud/librdkafka.config --topic test1
 Consumed record from topic test1 partition [5] @ offset 117 with key alice and value 0
 Consumed record from topic test1 partition [5] @ offset 118 with key alice and value 1
 Consumed record from topic test1 partition [5] @ offset 119 with key alice and value 2

--- a/clients/cloud/rust/README.md
+++ b/clients/cloud/rust/README.md
@@ -4,21 +4,8 @@ Produce messages to and consume messages from a Kafka cluster using the [rust-rd
 
 # Prerequisites
 * [Rust client for Apache Kafka](https://github.com/fede1024/rust-rdkafka#installation) installed on your machine
-
-To run this example, download the `librdkafka.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
-Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Update the `librdkafka.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
-
-```bash
-$ cat $HOME/.ccloud/librdkafka.config
-bootstrap.servers={{ BROKER_ENDPOINT }}
-sasl.mechanisms=PLAIN
-security.protocol=SASL_SSL
-sasl.username={{ CLUSTER_API_KEY }}
-sasl.password={{ CLUSTER_API_SECRET }}
-```
+* Create a local file (e.g. at `$HOME/.confluent/librdkafka.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 # Example 1: Hello World!
 In this example, the producer writes data to a Kafka topic in Confluent Cloud. 
@@ -36,7 +23,7 @@ $ cargo build
 2. Run the producer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the topic name:
 
 ```bash
-$ ./target/debug/producer --config $HOME/.ccloud/librdkafka.config --topic test1
+$ ./target/debug/producer --config $HOME/.confluent/librdkafka.config --topic test1
 Preparing to produce record: alice 0
 Preparing to produce record: alice 1
 Preparing to produce record: alice 2
@@ -60,7 +47,7 @@ Successfully produced record to topic test1 partition [5] @ offset 125
 3. Run the consumer, passing in arguments for (a) the local file with configuration parameters to connect to your Confluent Cloud instance and (b) the same topic name as used above. Verify that the consumer received all the messages:
 
 ```bash
-$ ./target/debug/consumer --config $HOME/.ccloud/librdkafka.config --topic test1
+$ ./target/debug/consumer --config $HOME/.confluent/librdkafka.config --topic test1
 Consumed record from topic test1 partition [5] @ offset 117 with key alice and value 0
 Consumed record from topic test1 partition [5] @ offset 118 with key alice and value 1
 Consumed record from topic test1 partition [5] @ offset 119 with key alice and value 2

--- a/clients/cloud/scala/README.md
+++ b/clients/cloud/scala/README.md
@@ -7,20 +7,8 @@ For more information, please see the [application development documentation](htt
 
 # Prerequisites
 
-To run this example, download the `java.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
-Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
-
-* Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Update the `java.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
-
-```shell
-$ cat $HOME/.ccloud/java.config
-bootstrap.servers={{ BROKER_ENDPOINT }}
-ssl.endpoint.identification.algorithm=https
-security.protocol=SASL_SSL
-sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}"; 
-```
+* Create a local file (e.g. at `$HOME/.confluent/java.config`) with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.  Follow [these detailed instructions](https://github.com/confluentinc/configuration-templates/tree/master/README.md) to properly create this file. 
+* If you are running on Confluent Cloud, you must have access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
 
 # Quickstart
 
@@ -33,7 +21,7 @@ sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule require
 		$ sbt clean compile
 		
 		# Run the consumer 
-		$ sbt "runMain io.confluent.examples.clients.scala.Consumer $HOME/.ccloud/java.config testtopic"
+		$ sbt "runMain io.confluent.examples.clients.scala.Consumer $HOME/.confluent/java.config testtopic"
 		```
 		You should see
 		
@@ -51,13 +39,13 @@ sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule require
     		$ sbt clean compile
     		
     		# Run the consumer
-    		$ sbt "runMain io.confluent.examples.clients.scala.Streams $HOME/.ccloud/java.config  testtopic"
+    		$ sbt "runMain io.confluent.examples.clients.scala.Streams $HOME/.confluent/java.config  testtopic"
         ```
 
 	3. Then, in a new window run the Kafka producer application to write records to the Kafka cluster, you should see these appear in the consumer window.
 
 		```shell
-		$ sbt "runMain io.confluent.examples.clients.scala.Producer $HOME/.ccloud/java.config testtopic"
+		$ sbt "runMain io.confluent.examples.clients.scala.Producer $HOME/.confluent/java.config testtopic"
 		```
         		
         You should see

--- a/clients/cloud/scala/README.md
+++ b/clients/cloud/scala/README.md
@@ -1,23 +1,25 @@
 # Scala Producer and Consumer for Confluent Cloud
 
 Produce messages to and consume messages from a Kafka cluster using the Scala Producer and Consumer, and Kafka Streams API.
+
 For more information, please see the [application development documentation](https://docs.confluent.io/current/api-javadoc.html?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)
+
 
 # Prerequisites
 
-To run this example, create a local file with configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster.
-If this is a Confluent Cloud cluster, you must have:
+To run this example, download the `java.config` file from [confluentinc/configuration-templates](https://github.com/confluentinc/configuration-templates/tree/master/clients/cloud) and save it to a `$HOME/.ccloud` folder. 
+Update the configuration parameters to connect to your Kafka cluster, which can be on your local host, [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud), or any other cluster. If this is a Confluent Cloud cluster, you must have:
 
 * Access to a [Confluent Cloud](https://www.confluent.io/confluent-cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) cluster
-* Initialize a properties file at `$HOME/.ccloud/config` with configuration to your Confluent Cloud cluster:
+* Update the `java.config` file from  with the broker endpoint and api key to connect to your Confluent Cloud cluster ([how do I find those?](https://docs.confluent.io/current/cloud/using/config-client.html#librdkafka-based-c-clients?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)).
 
 ```shell
-$ cat $HOME/.ccloud/config
-bootstrap.servers=<BROKER ENDPOINT>
+$ cat $HOME/.ccloud/java.config
+bootstrap.servers={{ BROKER_ENDPOINT }}
 ssl.endpoint.identification.algorithm=https
 security.protocol=SASL_SSL
 sasl.mechanism=PLAIN
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="<API KEY>" password\="<API SECRET>";
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}"; 
 ```
 
 # Quickstart
@@ -31,7 +33,7 @@ sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule require
 		$ sbt clean compile
 		
 		# Run the consumer 
-		$ sbt "runMain io.confluent.examples.clients.scala.Consumer $HOME/.ccloud/config testtopic"
+		$ sbt "runMain io.confluent.examples.clients.scala.Consumer $HOME/.ccloud/java.config testtopic"
 		```
 		You should see
 		
@@ -49,13 +51,13 @@ sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule require
     		$ sbt clean compile
     		
     		# Run the consumer
-    		$ sbt "runMain io.confluent.examples.clients.scala.Streams $HOME/.ccloud/config testtopic"
+    		$ sbt "runMain io.confluent.examples.clients.scala.Streams $HOME/.ccloud/java.config  testtopic"
         ```
 
 	3. Then, in a new window run the Kafka producer application to write records to the Kafka cluster, you should see these appear in the consumer window.
 
 		```shell
-		$ sbt "runMain io.confluent.examples.clients.scala.Producer $HOME/.ccloud/config testtopic"
+		$ sbt "runMain io.confluent.examples.clients.scala.Producer $HOME/.ccloud/java.config testtopic"
 		```
         		
         You should see

--- a/clients/cloud/scala/build.sbt
+++ b/clients/cloud/scala/build.sbt
@@ -16,11 +16,11 @@ lazy val root = (project in file(".")).
 
       libraryDependencies ++= Seq(
       "com.typesafe" % "config" % "1.3.2",
-      "org.apache.kafka" % "kafka-clients" % "2.1.0",
-      "org.apache.kafka" % "connect-json" % "2.1.0",
-      "org.apache.kafka" % "connect-runtime" % "2.1.0",
-      "org.apache.kafka" % "kafka-streams" % "2.1.0",
-        "org.apache.kafka" %% "kafka-streams-scala" % "2.1.0",
+      "org.apache.kafka" % "kafka-clients" % "2.4.0",
+      "org.apache.kafka" % "connect-json" % "2.4.0",
+      "org.apache.kafka" % "connect-runtime" % "2.4.0",
+      "org.apache.kafka" % "kafka-streams" % "2.4.0",
+        "org.apache.kafka" %% "kafka-streams-scala" % "2.4.0",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.5",
       "org.apache.kafka" % "connect-runtime" % "2.1.0",
         "io.confluent" % "kafka-json-serializer" % "5.0.1",

--- a/clients/cloud/scala/project/build.properties
+++ b/clients/cloud/scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.3.8


### PR DESCRIPTION
Updated after discussion with @ybyzek and @rspurgeon 

- References configs that can be found here https://github.com/confluentinc/configuration-templates and will be the central source for the examples repo and ccloud ui 
- Updates readme's to reflect this change
- Future goal would be to add a script that can autogenerate these configs for them based on their cluster info 
