### PR TITLE
DEVX-1539 updates kafka go client import path

### DIFF
--- a/clients/cloud/go/consumer.go
+++ b/clients/cloud/go/consumer.go
@@ -27,7 +27,7 @@ import (
 	"./ccloud"
 	"encoding/json"
 	"fmt"
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 	"os"
 	"os/signal"
 	"syscall"

--- a/clients/cloud/go/producer.go
+++ b/clients/cloud/go/producer.go
@@ -28,7 +28,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 	"os"
 	"time"
 )


### PR DESCRIPTION
At some point the import path for the confluent-kafka-go client library has been updated.