### PR TITLE
[ci skip] Setting this to the correct version in 5.4.x

### DIFF
--- a/ccloud/beginner-cloud/docker-compose.yml
+++ b/ccloud/beginner-cloud/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   connect-cloud:
-    image: cnfldemos/cp-server-connect-datagen:0.2.0-5.4.0
+    image: cnfldemos/cp-server-connect-datagen:0.2.0-5.4.x-latest
     hostname: connect-cloud
     container_name: connect-cloud
     ports:


### PR DESCRIPTION
My work in patterns.json missed this specific tag update, so this PR is fixing it on 5.4.x, I will be sending PRs for fixes in the 5.4.0-post and 5.4.1-post branch later.