### PR TITLE
DEVX-1596 Removes extraneous spaces in front of HEREDOC anchor in uti…

### DIFF
--- a/utils/helper.sh
+++ b/utils/helper.sh
@@ -686,7 +686,7 @@ function ccloud_login(){
     send "$PASSWORD\r";
     expect "Logged in as "
     set result $expect_out(buffer)
-  END
+END
   )
   echo "$OUTPUT"
   if [[ ! "$OUTPUT" =~ "Logged in as" ]]; then


### PR DESCRIPTION
…ls/helper.sh

With these spaces some shells fail to parse the HereDoc

This was tested on Ubuntu 18.04 with bash 4.4 by sourcing the script.   Previously this would fail, but with this change does not.

Testing this with a demo is not currently possible as it's not used by any script.  See DEVX-1603