### PR TITLE
no need to expose 29092

### DIFF
--- a/cp-all-in-one-community/docker-compose.yml
+++ b/cp-all-in-one-community/docker-compose.yml
@@ -18,7 +18,6 @@ services:
     depends_on:
       - zookeeper
     ports:
-      - "29092:29092"
       - "9092:9092"
     environment:
       KAFKA_BROKER_ID: 1


### PR DESCRIPTION
No need to expose 29092, since it's only going to work within the docker network. For external connections use 9092 (already exposed).
Partially a nit, but also makes it more ambiguous for people trying to understand it. 