### PR TITLE
DEVX-1625: Revert window start for clickstream

### DIFF
--- a/clickstream/ksql/ksql-clickstream-demo/demo/clickstream-schema.sql
+++ b/clickstream/ksql/ksql-clickstream-demo/demo/clickstream-schema.sql
@@ -12,14 +12,14 @@ CREATE STREAM clickstream (_time bigint,time varchar, ip varchar, request varcha
 ----------------------------------------------------------------------------------------------------------------------------
 
  -- number of events per minute - think about key-for-distribution-purpose - shuffling etc - shouldnt use 'userid'
-CREATE table events_per_min AS SELECT userid, WindowStart() AS EVENT_TS, count(*) AS events FROM clickstream window TUMBLING (size 60 second) GROUP BY userid;
+CREATE table events_per_min AS SELECT userid,  count(*) AS events FROM clickstream window TUMBLING (size 60 second) GROUP BY userid;
 
 -- 3. BUILD STATUS_CODES
 -- static table
 CREATE TABLE clickstream_codes (code int, definition varchar) with (key='code', kafka_topic = 'clickstream_codes', value_format = 'json');
 
 -- 4. BUILD PAGE_VIEWS
-CREATE TABLE pages_per_min AS SELECT userid, WindowStart() AS EVENT_TS, count(*) AS pages FROM clickstream WINDOW HOPPING (size 60 second, advance by 5 second) WHERE request like '%html%' GROUP BY userid ;
+CREATE TABLE pages_per_min AS SELECT userid,  count(*) AS pages FROM clickstream WINDOW HOPPING (size 60 second, advance by 5 second) WHERE request like '%html%' GROUP BY userid ;
 
 ----------------------------------------------------------------------------------------------------------------------------
 -- URL STATUS CODES (Join AND Alert)
@@ -28,14 +28,14 @@ CREATE TABLE pages_per_min AS SELECT userid, WindowStart() AS EVENT_TS, count(*)
 ----------------------------------------------------------------------------------------------------------------------------
 
 -- Use 'HAVING' Filter to show ERROR codes > 400 where count > 5
-CREATE TABLE ERRORS_PER_MIN_ALERT AS SELECT status, WindowStart() AS EVENT_TS, count(*) AS errors FROM clickstream window HOPPING ( size 30 second, advance by 20 second) WHERE status > 400 GROUP BY status HAVING count(*) > 5 AND count(*) is not NULL;
+CREATE TABLE ERRORS_PER_MIN_ALERT AS SELECT status,  count(*) AS errors FROM clickstream window HOPPING ( size 30 second, advance by 20 second) WHERE status > 400 GROUP BY status HAVING count(*) > 5 AND count(*) is not NULL;
 
-CREATE table ERRORS_PER_MIN AS SELECT status, WindowStart() AS EVENT_TS, count(*) AS errors FROM clickstream window HOPPING ( size 60 second, advance by 5  second) WHERE status > 400 GROUP BY status;
+CREATE table ERRORS_PER_MIN AS SELECT status,  count(*) AS errors FROM clickstream window HOPPING ( size 60 second, advance by 5  second) WHERE status > 400 GROUP BY status;
 
 --Join using a STREAM
 CREATE STREAM ENRICHED_ERROR_CODES AS SELECT code, definition FROM clickstream LEFT JOIN clickstream_codes ON clickstream.status = clickstream_codes.code;
 -- Aggregate (count&groupBy) using a TABLE-Window
-CREATE TABLE ENRICHED_ERROR_CODES_COUNT AS SELECT code, WindowStart() AS EVENT_TS, definition, COUNT(*) AS count FROM ENRICHED_ERROR_CODES WINDOW TUMBLING (size 30 second) GROUP BY code, definition HAVING COUNT(*) > 1;
+CREATE TABLE ENRICHED_ERROR_CODES_COUNT AS SELECT code,  definition, COUNT(*) AS count FROM ENRICHED_ERROR_CODES WINDOW TUMBLING (size 30 second) GROUP BY code, definition HAVING COUNT(*) > 1;
 
 ----------------------------------------------------------------------------------------------------------------------------
 -- Clickstream users for enrichment and exception monitoring
@@ -54,7 +54,7 @@ CREATE TABLE WEB_USERS (user_id int, registered_At BIGINT, username varchar, fir
 CREATE STREAM USER_CLICKSTREAM AS SELECT userid, u.username, ip, u.city, request, status, bytes FROM clickstream c LEFT JOIN web_users u ON c.userid = u.user_id;
 
 -- Aggregate (count&groupBy) using a TABLE-Window
-CREATE TABLE USER_IP_ACTIVITY AS SELECT username, WindowStart() AS EVENT_TS, ip, city, COUNT(*) AS count FROM USER_CLICKSTREAM WINDOW TUMBLING (size 60 second) GROUP BY username, ip, city HAVING COUNT(*) > 1;
+CREATE TABLE USER_IP_ACTIVITY AS SELECT username,  ip, city, COUNT(*) AS count FROM USER_CLICKSTREAM WINDOW TUMBLING (size 60 second) GROUP BY username, ip, city HAVING COUNT(*) > 1;
 
 ----------------------------------------------------------------------------------------------------------------------------
 -- User session monitoring
@@ -63,5 +63,5 @@ CREATE TABLE USER_IP_ACTIVITY AS SELECT username, WindowStart() AS EVENT_TS, ip,
 --
 ----------------------------------------------------------------------------------------------------------------------------
 
-CREATE TABLE CLICK_USER_SESSIONS AS SELECT username, WindowStart() AS EVENT_TS, count(*) AS events FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username;
+CREATE TABLE CLICK_USER_SESSIONS AS SELECT username, count(*) AS events FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username;
 

--- a/clickstream/ksql/ksql-clickstream-demo/demo/clickstream-schema.sql
+++ b/clickstream/ksql/ksql-clickstream-demo/demo/clickstream-schema.sql
@@ -12,14 +12,14 @@ CREATE STREAM clickstream (_time bigint,time varchar, ip varchar, request varcha
 ----------------------------------------------------------------------------------------------------------------------------
 
  -- number of events per minute - think about key-for-distribution-purpose - shuffling etc - shouldnt use 'userid'
-CREATE table events_per_min AS SELECT userid,  count(*) AS events FROM clickstream window TUMBLING (size 60 second) GROUP BY userid;
+CREATE table events_per_min AS SELECT userid, count(*) AS events FROM clickstream window TUMBLING (size 60 second) GROUP BY userid;
 
 -- 3. BUILD STATUS_CODES
 -- static table
 CREATE TABLE clickstream_codes (code int, definition varchar) with (key='code', kafka_topic = 'clickstream_codes', value_format = 'json');
 
 -- 4. BUILD PAGE_VIEWS
-CREATE TABLE pages_per_min AS SELECT userid,  count(*) AS pages FROM clickstream WINDOW HOPPING (size 60 second, advance by 5 second) WHERE request like '%html%' GROUP BY userid ;
+CREATE TABLE pages_per_min AS SELECT userid, count(*) AS pages FROM clickstream WINDOW HOPPING (size 60 second, advance by 5 second) WHERE request like '%html%' GROUP BY userid ;
 
 ----------------------------------------------------------------------------------------------------------------------------
 -- URL STATUS CODES (Join AND Alert)
@@ -28,14 +28,14 @@ CREATE TABLE pages_per_min AS SELECT userid,  count(*) AS pages FROM clickstream
 ----------------------------------------------------------------------------------------------------------------------------
 
 -- Use 'HAVING' Filter to show ERROR codes > 400 where count > 5
-CREATE TABLE ERRORS_PER_MIN_ALERT AS SELECT status,  count(*) AS errors FROM clickstream window HOPPING ( size 30 second, advance by 20 second) WHERE status > 400 GROUP BY status HAVING count(*) > 5 AND count(*) is not NULL;
+CREATE TABLE ERRORS_PER_MIN_ALERT AS SELECT status, count(*) AS errors FROM clickstream window HOPPING ( size 30 second, advance by 20 second) WHERE status > 400 GROUP BY status HAVING count(*) > 5 AND count(*) is not NULL;
 
-CREATE table ERRORS_PER_MIN AS SELECT status,  count(*) AS errors FROM clickstream window HOPPING ( size 60 second, advance by 5  second) WHERE status > 400 GROUP BY status;
+CREATE table ERRORS_PER_MIN AS SELECT status, count(*) AS errors FROM clickstream window HOPPING ( size 60 second, advance by 5  second) WHERE status > 400 GROUP BY status;
 
 --Join using a STREAM
 CREATE STREAM ENRICHED_ERROR_CODES AS SELECT code, definition FROM clickstream LEFT JOIN clickstream_codes ON clickstream.status = clickstream_codes.code;
 -- Aggregate (count&groupBy) using a TABLE-Window
-CREATE TABLE ENRICHED_ERROR_CODES_COUNT AS SELECT code,  definition, COUNT(*) AS count FROM ENRICHED_ERROR_CODES WINDOW TUMBLING (size 30 second) GROUP BY code, definition HAVING COUNT(*) > 1;
+CREATE TABLE ENRICHED_ERROR_CODES_COUNT AS SELECT code, definition, COUNT(*) AS count FROM ENRICHED_ERROR_CODES WINDOW TUMBLING (size 30 second) GROUP BY code, definition HAVING COUNT(*) > 1;
 
 ----------------------------------------------------------------------------------------------------------------------------
 -- Clickstream users for enrichment and exception monitoring
@@ -54,7 +54,7 @@ CREATE TABLE WEB_USERS (user_id int, registered_At BIGINT, username varchar, fir
 CREATE STREAM USER_CLICKSTREAM AS SELECT userid, u.username, ip, u.city, request, status, bytes FROM clickstream c LEFT JOIN web_users u ON c.userid = u.user_id;
 
 -- Aggregate (count&groupBy) using a TABLE-Window
-CREATE TABLE USER_IP_ACTIVITY AS SELECT username,  ip, city, COUNT(*) AS count FROM USER_CLICKSTREAM WINDOW TUMBLING (size 60 second) GROUP BY username, ip, city HAVING COUNT(*) > 1;
+CREATE TABLE USER_IP_ACTIVITY AS SELECT username, ip, city, COUNT(*) AS count FROM USER_CLICKSTREAM WINDOW TUMBLING (size 60 second) GROUP BY username, ip, city HAVING COUNT(*) > 1;
 
 ----------------------------------------------------------------------------------------------------------------------------
 -- User session monitoring

--- a/clickstream/ksql/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
+++ b/clickstream/ksql/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
@@ -49,6 +49,8 @@ curl -s -X "POST" "http://$CONNECT_HOST:8083/connectors/" \
     "connection.url": "http://'$ELASTIC_HOST':9200",
     "transforms": "FilterNulls",
     "transforms.FilterNulls.type": "io.confluent.transforms.NullFilter"
+    "transforms.ExtractTimestamp.type": "org.apache.kafka.connect.transforms.InsertField$Value",
+    "transforms.ExtractTimestamp.timestamp.field" : "EVENT_TS"
   }
 }' >>/tmp/log.txt 2>&1
 

--- a/clickstream/ksql/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
+++ b/clickstream/ksql/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
@@ -47,8 +47,8 @@ curl -s -X "POST" "http://$CONNECT_HOST:8083/connectors/" \
     "type.name": "type.name=kafkaconnect",
     "topic.index.map": "'$TABLE_NAME':'$table_name'",
     "connection.url": "http://'$ELASTIC_HOST':9200",
-    "transforms": "FilterNulls",
-    "transforms.FilterNulls.type": "io.confluent.transforms.NullFilter"
+    "transforms": "FilterNulls,ExtractTimestamp",
+    "transforms.FilterNulls.type": "io.confluent.transforms.NullFilter",
     "transforms.ExtractTimestamp.type": "org.apache.kafka.connect.transforms.InsertField$Value",
     "transforms.ExtractTimestamp.timestamp.field" : "EVENT_TS"
   }


### PR DESCRIPTION
Looks like changes introduced in 5.1.0 "WindowStart() as..." are the culprit as the window start timestamp never advances after the start