### PR TITLE
DEVX-1565 Updates config.env to use tool provided values

### DIFF
--- a/utils/config.env
+++ b/utils/config.env
@@ -41,8 +41,8 @@ KAFKA_BRANCH=2.4
 #   REPOSITORY=<account>.dkr.ecr.us-west-2.amazonaws.com/confluentinc   # confluentinc repository at the specified ECR registry, images must be pulled separately
 #####################################################
 
-CP_VERSION_MAJOR="$CONFLUENT_MAJOR.$CONFLUENT_MINOR"
-CP_VERSION_FULL="$CONFLUENT_MAJOR.$CONFLUENT_MINOR.$CONFLUENT_PATH"
+CP_VERSION_MAJOR="$CONFLUENT_SHORT"
+CP_VERSION_FULL="$CONFLUENT_MAJOR.$CONFLUENT_MINOR.$CONFLUENT_PATCH"
 GIT_BRANCH=$CONFLUENT_RELEASE_TAG_OR_BRANCH
 JAR_VERSION=$CONFLUENT
 

--- a/utils/config.env
+++ b/utils/config.env
@@ -41,7 +41,7 @@ KAFKA_BRANCH=2.4
 #   REPOSITORY=<account>.dkr.ecr.us-west-2.amazonaws.com/confluentinc   # confluentinc repository at the specified ECR registry, images must be pulled separately
 #####################################################
 
-CP_VERSION_MAJOR="$CONFLUENT_SHORT"
+CP_VERSION_MAJOR=$CONFLUENT_SHORT
 CP_VERSION_FULL="$CONFLUENT_MAJOR.$CONFLUENT_MINOR.$CONFLUENT_PATCH"
 GIT_BRANCH=$CONFLUENT_RELEASE_TAG_OR_BRANCH
 JAR_VERSION=$CONFLUENT

--- a/utils/config.env
+++ b/utils/config.env
@@ -41,10 +41,10 @@ KAFKA_BRANCH=2.4
 #   REPOSITORY=<account>.dkr.ecr.us-west-2.amazonaws.com/confluentinc   # confluentinc repository at the specified ECR registry, images must be pulled separately
 #####################################################
 
-CP_VERSION_MAJOR=5.5
-CP_VERSION_FULL=5.5.0
-GIT_BRANCH=master
-JAR_VERSION=5.5.0-SNAPSHOT
+CP_VERSION_MAJOR="$CONFLUENT_MAJOR.$CONFLUENT_MINOR"
+CP_VERSION_FULL="$CONFLUENT_MAJOR.$CONFLUENT_MINOR.$CONFLUENT_PATH"
+GIT_BRANCH=$CONFLUENT_RELEASE_TAG_OR_BRANCH
+JAR_VERSION=$CONFLUENT
 
 #####################################################
 # The following parameters are for docker-compose.yml only
@@ -57,7 +57,7 @@ JAR_VERSION=5.5.0-SNAPSHOT
 
 # TAG - image tag.
 # The ':' which separates the image name from the TAG is not required here
-TAG=5.5.x-latest
+TAG=$CONFLUENT_DOCKER_TAG
 
 # REPOSITORY - repository for Docker image
 # The '/' which separates the REPOSITORY from the image name is not required here


### PR DESCRIPTION
The existing values in this file are used by various scripts and tools (docker),
so as a first step I made our previous variables, like CP_VERSION_MAJOR, derive
its value from the CONFLUENT_* values which are managed by automation.  This allows
for scripts, like ./music/start.sh:check_running_cp ${CP_VERSION_MAJOR}, to work
w/ the automated values instead of a manually managed one.