### PR TITLE
DEVX-1641 updates start.sh scripts that validate CP version to use tool value

### DIFF
--- a/ccloud/start.sh
+++ b/ccloud/start.sh
@@ -5,7 +5,7 @@
 
 check_env || exit 1
 check_jq || exit 1
-check_running_cp ${CP_VERSION_MAJOR} || exit 1
+check_running_cp ${CONFLUENT_SHORT} || exit 1
 
 # File with Confluent Cloud configuration parameters: example template
 #   $ cat ~/.ccloud/config

--- a/cloud-etl/read-data.sh
+++ b/cloud-etl/read-data.sh
@@ -17,7 +17,7 @@ while read -r line ; do echo "$line" | base64 --decode; echo; done <<< "$(aws ki
 
 if check_confluent_binary; then
 
-  check_running_cp ${CP_VERSION_MAJOR} || exit
+  check_running_cp ${CONFLUENT_SHORT} || exit
 
   echo -e "\nData from Kafka topic $KAFKA_TOPIC_NAME_IN:"
   echo -e "confluent local consume $KAFKA_TOPIC_NAME_IN -- --cloud --from-beginning --property print.key=true --max-messages 10"

--- a/connect-streams-pipeline/start.sh
+++ b/connect-streams-pipeline/start.sh
@@ -5,7 +5,7 @@
 
 check_env || exit 1
 check_mvn || exit 1
-check_running_cp ${CP_VERSION_MAJOR} || exit 
+check_running_cp ${CONFLUENT_SHORT} || exit 
 
 ./stop.sh
 

--- a/cp-quickstart/start.sh
+++ b/cp-quickstart/start.sh
@@ -4,7 +4,7 @@
 . ../utils/helper.sh
 
 check_env || exit 1
-check_running_cp ${CP_VERSION_MAJOR} || exit
+check_running_cp ${CONFLUENT_SHORT} || exit
 check_cli_v2 || exit
 
 ./stop.sh

--- a/microservices-orders/start.sh
+++ b/microservices-orders/start.sh
@@ -9,7 +9,7 @@ check_jot || exit 1
 check_netstat || exit 1
 check_running_elasticsearch 5.6.5 || exit 1
 check_running_kibana || exit 1
-check_running_cp ${CP_VERSION_MAJOR} || exit 1
+check_running_cp ${CONFLUENT_SHORT} || exit 1
 
 ./stop.sh
 

--- a/music/start.sh
+++ b/music/start.sh
@@ -5,7 +5,7 @@
 
 check_env || exit 1
 check_mvn || exit 1
-check_running_cp ${CP_VERSION_MAJOR} || exit 
+check_running_cp ${CONFLUENT_SHORT} || exit 
 
 ./stop.sh
 

--- a/mysql-debezium/start.sh
+++ b/mysql-debezium/start.sh
@@ -4,7 +4,7 @@
 . ../utils/helper.sh
 
 check_env || exit 1
-check_running_cp ${CP_VERSION_MAJOR} || exit
+check_running_cp ${CONFLUENT_SHORT} || exit
 check_mysql 5.7.25 || exit
 check_running_elasticsearch 5.6.5 || exit 1
 check_running_kibana || exit 1

--- a/utils/config.env
+++ b/utils/config.env
@@ -41,7 +41,6 @@ KAFKA_BRANCH=2.4
 #   REPOSITORY=<account>.dkr.ecr.us-west-2.amazonaws.com/confluentinc   # confluentinc repository at the specified ECR registry, images must be pulled separately
 #####################################################
 
-CP_VERSION_MAJOR=$CONFLUENT_SHORT
 CP_VERSION_FULL="$CONFLUENT_MAJOR.$CONFLUENT_MINOR.$CONFLUENT_PATCH"
 GIT_BRANCH=$CONFLUENT_RELEASE_TAG_OR_BRANCH
 JAR_VERSION=$CONFLUENT


### PR DESCRIPTION


instead of the prvious redirected one, which was redundant.