### PR TITLE
Switch DataGen  `maxInterval` to `msgRate`

### DIFF
--- a/clients/cloud/ksql-datagen/docker-compose.yml
+++ b/clients/cloud/ksql-datagen/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: ksql-datagen
     volumes:
       - $PWD/delta_configs/ksql-datagen.delta:/tmp/ksql-datagen.delta
-    command: "bash -c '/usr/bin/ksql-datagen quickstart=orders format=json topic=test1 maxInterval=2000 bootstrap-server=$BOOTSTRAP_SERVERS propertiesFile=/tmp/ksql-datagen.delta'"
+    command: "bash -c '/usr/bin/ksql-datagen quickstart=orders format=json topic=test1 msgRate=5 bootstrap-server=$BOOTSTRAP_SERVERS propertiesFile=/tmp/ksql-datagen.delta'"
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"
       KSQL_LOG4J_OPTS: "-Dlog4j.configuration=file:/etc/ksql/log4j-rolling.properties"
@@ -22,7 +22,7 @@ services:
     container_name: ksql-datagen-avro
     volumes:
       - $PWD/delta_configs/ksql-datagen.delta:/tmp/ksql-datagen.delta
-    command: "bash -c '/usr/bin/ksql-datagen quickstart=orders format=avro topic=test2 maxInterval=2000 schemaRegistryUrl=$SCHEMA_REGISTRY_URL bootstrap-server=$BOOTSTRAP_SERVERS propertiesFile=/tmp/ksql-datagen.delta'"
+    command: "bash -c '/usr/bin/ksql-datagen quickstart=orders format=avro topic=test2 msgRate=5 schemaRegistryUrl=$SCHEMA_REGISTRY_URL bootstrap-server=$BOOTSTRAP_SERVERS propertiesFile=/tmp/ksql-datagen.delta'"
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"
       KSQL_LOG4J_OPTS: "-Dlog4j.configuration=file:/etc/ksql/log4j-rolling.properties"

--- a/multi-datacenter/docker-compose.yml
+++ b/multi-datacenter/docker-compose.yml
@@ -207,7 +207,7 @@ services:
                        sleep 50 && \
                        cub sr-ready schema-registry-dc1 8081 90 && \
                        sleep 10 && \
-                       /usr/bin/ksql-datagen schema=/tmp/schema-dc1.avro key=userid format=avro topic=topic1 maxInterval=1000 schemaRegistryUrl=http://schema-registry-dc1:8081 bootstrap-server=broker-dc1:29091 propertiesFile=/tmp/datagen.properties'"
+                       /usr/bin/ksql-datagen schema=/tmp/schema-dc1.avro key=userid format=avro topic=topic1 msgRate=10 schemaRegistryUrl=http://schema-registry-dc1:8081 bootstrap-server=broker-dc1:29091 propertiesFile=/tmp/datagen.properties'"
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"
       KSQL_LOG4J_OPTS: "-Dlog4j.configuration=file:/etc/ksql/log4j-silent.properties"
@@ -230,7 +230,7 @@ services:
                        sleep 50 && \
                        cub sr-ready schema-registry-dc1 8081 90 && \
                        sleep 20 && \
-                       /usr/bin/ksql-datagen format=avro quickstart=users topic=topic2 maxInterval=1000 schemaRegistryUrl=http://schema-registry-dc1:8081 bootstrap-server=broker-dc1:29091 propertiesFile=/tmp/datagen.properties'"
+                       /usr/bin/ksql-datagen format=avro quickstart=users topic=topic2 msgRate=10 schemaRegistryUrl=http://schema-registry-dc1:8081 bootstrap-server=broker-dc1:29091 propertiesFile=/tmp/datagen.properties'"
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"
       KSQL_LOG4J_OPTS: "-Dlog4j.configuration=file:/etc/ksql/log4j-silent.properties"
@@ -254,7 +254,7 @@ services:
                        sleep 50 && \
                        cub sr-ready schema-registry-dc2 8082 90 && \
                        sleep 10 && \
-                       /usr/bin/ksql-datagen schema=/tmp/schema-dc2.avro key=userid format=avro topic=topic1 maxInterval=1000 schemaRegistryUrl=http://schema-registry-dc2:8082 bootstrap-server=broker-dc2:29092 propertiesFile=/tmp/datagen.properties'"
+                       /usr/bin/ksql-datagen schema=/tmp/schema-dc2.avro key=userid format=avro topic=topic1 msgRate=10 schemaRegistryUrl=http://schema-registry-dc2:8082 bootstrap-server=broker-dc2:29092 propertiesFile=/tmp/datagen.properties'"
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"
       KSQL_LOG4J_OPTS: "-Dlog4j.configuration=file:/etc/ksql/log4j-silent.properties"

--- a/mysql-debezium/live-coding.adoc
+++ b/mysql-debezium/live-coding.adoc
@@ -29,14 +29,14 @@ screen -d -m -S CP_demo -t mysql mysql -uroot demo
 screen -S CP_demo -p 0 -X screen -t topic-raw kafka-avro-console-consumer --bootstrap-server localhost:9092 --property schema.registry.url=http://localhost:8081 --topic asgard.demo.customers-raw --from-beginning  | jq '.'
 screen -S CP_demo -p 0 -X screen -t topic-flat kafka-avro-console-consumer --bootstrap-server localhost:9092 --property schema.registry.url=http://localhost:8081 --topic asgard.demo.customers --from-beginning  | jq '.'
 screen -S CP_demo -p 0 -X screen -t ksql ksql
-screen -S CP_demo -p 0 -X screen -t datagen ~/git/ksql/bin/ksql-datagen quickstart=ratings format=avro topic=ratings maxInterval=500
+screen -S CP_demo -p 0 -X screen -t datagen ~/git/ksql/bin/ksql-datagen quickstart=ratings format=avro topic=ratings msgRate=10
 ----
 
 === Start ratings datagen (if not already in `screen`)
 
 [source,bash]
 ----
-~/git/ksql/bin/ksql-datagen quickstart=ratings format=avro topic=ratings maxInterval=500
+~/git/ksql/bin/ksql-datagen quickstart=ratings format=avro topic=ratings msgRate=10
 ----
 
 

--- a/mysql-debezium/start.sh
+++ b/mysql-debezium/start.sh
@@ -29,7 +29,7 @@ sleep 10
 
 if is_ce; then PROPERTIES=" propertiesFile=$CONFLUENT_HOME/etc/ksql/datagen.properties"; else PROPERTIES=""; fi
 kafka-topics --zookeeper localhost:2181 --create --topic ratings --partitions 4 --replication-factor 1
-ksql-datagen quickstart=ratings format=avro topic=ratings maxInterval=500 $PROPERTIES &>/dev/null &
+ksql-datagen quickstart=ratings format=avro topic=ratings msgRate=10 $PROPERTIES &>/dev/null &
 sleep 10
 
 ksql http://localhost:8088 <<EOF

--- a/postgres-debezium-ksql-elasticsearch/docker-compose/docker-compose.yml
+++ b/postgres-debezium-ksql-elasticsearch/docker-compose/docker-compose.yml
@@ -178,7 +178,7 @@ services:
                        cub sr-ready schema-registry 8081 300 && \
                        echo Waiting a few seconds for topic creation to finish... && \
                        sleep 20 && \
-		               /usr/bin/ksql-datagen quickstart=ratings format=avro topic=ratings maxInterval=500 bootstrap-server=kafka:29092 schemaRegistryUrl=http://schema-registry:8081'"
+		               /usr/bin/ksql-datagen quickstart=ratings format=avro topic=ratings msgRate=10 bootstrap-server=kafka:29092 schemaRegistryUrl=http://schema-registry:8081'"
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"
       KSQL_LOG4J_OPTS: "-Dlog4j.configuration=file:/etc/ksql/log4j-rolling.properties"


### PR DESCRIPTION
Update use of DataGen to remove use of deprecated `maxInterval` and replace with new `msgRate` command line arg.

* the old `maxInterval` introduced a sleep between each message produced.
* the new `msgRate` throttles the message production to the required message rate per second.

Note: the `DatagenConnector` connector still looks to use `maxInterval` and so its config hasn't been updated.

Note: I've not run these examples to test this change.

Note: I also noticed that this issue referenced a lot: https://github.com/confluentinc/ksql/issues/1031, which necessitated listing all the columns in CREATE STREAM/TABLE commands, but that issue is resolved, so may be worth cleaning those up...?