### PR TITLE
Update ccloud inline with latest ksql syntax

### DIFF
--- a/ccloud/docs/index.rst
+++ b/ccloud/docs/index.rst
@@ -213,9 +213,9 @@ KSQL
       
        Stream Name              | Kafka Topic              | Format 
       --------------------------------------------------------------
-       PAGEVIEWS_ORIGINAL       | pageviews                | AVRO   
+       PAGEVIEWS_ORIGINAL       | pageviews                | AVRO
        PAGEVIEWS_FEMALE         | PAGEVIEWS_FEMALE         | AVRO   
-       PAGEVIEWS_FEMALE_LIKE_89 | pageviews_enriched_r8_r9 | AVRO   
+       PAGEVIEWS_FEMALE_LIKE_89 | pageviews_enriched_r8_r9 | AVRO
       --------------------------------------------------------------
 
 
@@ -225,7 +225,7 @@ KSQL
       --------------------------------------
        ROWTIME  | BIGINT           (system) 
        ROWKEY   | VARCHAR(STRING)  (system) 
-       USERID   | VARCHAR(STRING)  (key)    
+       USERID   | VARCHAR(STRING)
        PAGEID   | VARCHAR(STRING)           
        REGIONID | VARCHAR(STRING)           
        GENDER   | VARCHAR(STRING)           
@@ -252,8 +252,8 @@ KSQL
       --------------------------------------
        ROWTIME  | BIGINT           (system) 
        ROWKEY   | VARCHAR(STRING)  (system) 
-       GENDER   | VARCHAR(STRING)  (key)    
-       REGIONID | VARCHAR(STRING)  (key)    
+       GENDER   | VARCHAR(STRING)
+       REGIONID | VARCHAR(STRING)
        NUMUSERS | BIGINT                    
       --------------------------------------
       For runtime statistics and query details run: DESCRIBE EXTENDED <Stream,Table>;
@@ -291,8 +291,8 @@ KSQL
 
    .. sourcecode:: bash
 
-      ksql> SELECT * FROM PAGEVIEWS_FEMALE_LIKE_89 LIMIT 3;
-      ksql> SELECT * FROM USERS_ORIGINAL LIMIT 3;
+      ksql> SELECT * FROM PAGEVIEWS_FEMALE_LIKE_89 EMIT CHANGES LIMIT 3;
+      ksql> SELECT * FROM USERS_ORIGINAL EMIT CHANGES LIMIT 3;
 
 #. In this demo, KSQL is run with Confluent Monitoring Interceptors configured which enables |c3| Data Streams to monitor KSQL queries. The consumer group names ``_confluent-ksql-default_query_`` correlate to the KSQL query names shown above, and |c3| is showing the records that are incoming to each query.
 

--- a/ccloud/ksql.commands
+++ b/ccloud/ksql.commands
@@ -1,5 +1,5 @@
 CREATE STREAM pageviews_original (viewtime bigint, userid varchar, pageid varchar) WITH (kafka_topic='pageviews', value_format='AVRO');
 CREATE TABLE users_original (registertime bigint, gender varchar, regionid varchar, userid varchar) WITH (kafka_topic='users', value_format='AVRO', key = 'userid');
 CREATE STREAM pageviews_female AS SELECT users_original.userid AS userid, pageid, regionid, gender FROM pageviews_original LEFT JOIN users_original ON pageviews_original.userid = users_original.userid WHERE gender = 'FEMALE';
-CREATE STREAM pageviews_female_like_89 WITH (value_format='AVRO') AS SELECT * FROM pageviews_female WHERE regionid LIKE '%_8' OR regionid LIKE '%_9';
-CREATE TABLE pageviews_regions WITH (value_format='avro') AS SELECT gender, regionid , COUNT(*) AS numusers FROM pageviews_female WINDOW TUMBLING (size 30 second) GROUP BY gender, regionid HAVING COUNT(*) > 1;
+CREATE STREAM pageviews_female_like_89 AS SELECT * FROM pageviews_female WHERE regionid LIKE '%_8' OR regionid LIKE '%_9';
+CREATE TABLE pageviews_regions AS SELECT gender, regionid , COUNT(*) AS numusers FROM pageviews_female WINDOW TUMBLING (size 30 second) GROUP BY gender, regionid HAVING COUNT(*) > 1;


### PR DESCRIPTION
Updated the ccloud example inline with the latest ksqlDB syntax.

Note: I've not run the demo completely. I've only run the ksql commands. It may be worth running through the whole demo to ensure it works fully.

Part of work for https://github.com/confluentinc/ksql/issues/4144