### PR TITLE
DEVX-1643 cp-quickstart uses KAFKA_CONNECT_DATAGEN_VERSION

### DIFF
--- a/cp-quickstart/start.sh
+++ b/cp-quickstart/start.sh
@@ -9,7 +9,7 @@ check_cli_v2 || exit
 
 ./stop.sh
 
-confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.2.0
+confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:$KAFKA_CONNECT_DATAGEN_VERSION
 confluent local start
 sleep 10
 


### PR DESCRIPTION
Verified locally by running start.sh against 5.5.x nightly build:

```
Downloading component Kafka Connect Datagen 0.3.1, provided by Confluent, Inc. from Confluent Hub and installing into /Users/rspurgeon/software/cp/confluent-5.5.0-SNAPSHOT/share/confluent-hub-components
Implicit confirmation of the question: Do you want to uninstall existing version 0.3.1?
Adding installation directory to plugin path in the following files:
  /Users/rspurgeon/software/cp/confluent-5.5.0-SNAPSHOT/etc/kafka/connect-distributed.properties
  /Users/rspurgeon/software/cp/confluent-5.5.0-SNAPSHOT/etc/kafka/connect-standalone.properties
  /Users/rspurgeon/software/cp/confluent-5.5.0-SNAPSHOT/etc/schema-registry/connect-avro-distributed.properties
  /Users/rspurgeon/software/cp/confluent-5.5.0-SNAPSHOT/etc/schema-registry/connect-avro-standalone.properties

Completed
    The local commands are intended for a single-node development environment
    only, NOT for production usage. https://docs.confluent.io/current/cli/index.html
```