### PR TITLE
DEVX-1643 clickstream uses paramterized kafka-connect-datagen version

### DIFF
--- a/clickstream/start.sh
+++ b/clickstream/start.sh
@@ -6,7 +6,7 @@
 ./stop.sh
 
 # Get jars for source and sink connectors
-docker run -v $PWD/confluent-hub-components:/share/confluent-hub-components confluentinc/ksqldb-server:0.8.0 confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.3.0
+docker run -v $PWD/confluent-hub-components:/share/confluent-hub-components confluentinc/ksqldb-server:0.8.0 confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:$KAFKA_CONNECT_DATAGEN_VERSION
 docker run -v $PWD/confluent-hub-components:/share/confluent-hub-components confluentinc/ksqldb-server:0.8.0 confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:5.4.1
 
 docker-compose up -d


### PR DESCRIPTION
Tested with the following result:
```
Downloading component Kafka Connect Datagen 0.3.1, provided by Confluent, Inc. from Confluent Hub and installing into /share/confluent-hub-components
Implicit confirmation of the question: Do you want to uninstall existing version 0.3.1?
Adding installation directory to plugin path in the following files:

Completed
```