### PR TITLE
DEVX-1689 Removes eclipse plugin and deprecated functions from SR example code

### DIFF
--- a/clients/avro/pom.xml
+++ b/clients/avro/pom.xml
@@ -111,14 +111,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-eclipse-plugin</artifactId>
-        <version>2.19.1</version>
-        <configuration>
-            <downloadJavadocs>true</downloadJavadocs>
-        </configuration>
-      </plugin>
-      <plugin>
           <groupId>io.confluent</groupId>
           <artifactId>kafka-schema-registry-maven-plugin</artifactId>
           <version>${confluent.version}</version>

--- a/clients/avro/src/main/java/io/confluent/examples/clients/basicavro/ConsumerExample.java
+++ b/clients/avro/src/main/java/io/confluent/examples/clients/basicavro/ConsumerExample.java
@@ -1,6 +1,6 @@
 package io.confluent.examples.clients.basicavro;
 
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -10,7 +10,6 @@ import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -26,7 +25,7 @@ public class ConsumerExample {
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
         props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        props.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://localhost:8081");
+        props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://localhost:8081");
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class);
         props.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, true); 
@@ -35,7 +34,7 @@ public class ConsumerExample {
             consumer.subscribe(Collections.singletonList(TOPIC));
 
             while (true) {
-                final ConsumerRecords<String, Payment> records = consumer.poll(100);
+                final ConsumerRecords<String, Payment> records = consumer.poll(Duration.ofMillis(100));
                 for (final ConsumerRecord<String, Payment> record : records) {
                     final String key = record.key();
                     final Payment value = record.value();

--- a/clients/avro/src/main/java/io/confluent/examples/clients/basicavro/ProducerExample.java
+++ b/clients/avro/src/main/java/io/confluent/examples/clients/basicavro/ProducerExample.java
@@ -1,6 +1,6 @@
 package io.confluent.examples.clients.basicavro;
 
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -8,7 +8,6 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import org.apache.kafka.common.errors.SerializationException;
 
-import java.util.Collections;
 import java.util.Properties;
 
 public class ProducerExample {
@@ -24,7 +23,7 @@ public class ProducerExample {
         props.put(ProducerConfig.RETRIES_CONFIG, 0);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class);
-        props.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://localhost:8081");
+        props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://localhost:8081");
 
         try (KafkaProducer<String, Payment> producer = new KafkaProducer<String, Payment>(props)) {
 


### PR DESCRIPTION
@londoncalling In addition to removing the eclipse plugin from this example, I also removed some deprecated code.   Please verify, I believe that these changes will require a docs change in the following places:
https://docs.confluent.io/current/schema-registry/schema_registry_tutorial.html#example-producer-code
https://docs.confluent.io/current/schema-registry/schema_registry_tutorial.html#example-producer-code
