### PR TITLE
DEVX-1643 Updates clients kafka-connect-datagen to use parameterized version 

### DIFF
--- a/clients/cloud/kafka-connect-datagen/docker-compose.yml
+++ b/clients/cloud/kafka-connect-datagen/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.2.0-5.4.0
+    image: cnfldemos/cp-server-connect-datagen:${KAFKA_CONNECT_DATAGEN_DOCKER_TAG}
     hostname: connect
     container_name: connect
     volumes:


### PR DESCRIPTION
tested with the following:

```
docker-compose up -d
WARNING: The BOOTSTRAP_SERVERS variable is not set. Defaulting to a blank string.
WARNING: The SCHEMA_REGISTRY_URL variable is not set. Defaulting to a blank string.
WARNING: The BASIC_AUTH_CREDENTIALS_SOURCE variable is not set. Defaulting to a blank string.
WARNING: The SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO variable is not set. Defaulting to a blank string.
WARNING: The SASL_JAAS_CONFIG variable is not set. Defaulting to a blank string.
WARNING: The SASL_JAAS_CONFIG_PROPERTY_FORMAT variable is not set. Defaulting to a blank string.
Starting connect ... done
k%
14:14:17 in examples/clients/cloud/kafka-connect-datagen on  DEVX-1643 [!]
[I] ➜ docker ps -a
CONTAINER ID        IMAGE                                             COMMAND
dbad079dcd52        cnfldemos/cp-server-connect-datagen:0.3.1-5.4.1
```