### PR TITLE
DEVX-1314 Centralizes Operator demo versions

### DIFF
--- a/kubernetes/common/Makefile
+++ b/kubernetes/common/Makefile
@@ -1,8 +1,5 @@
 .PHONY: *
 
-COMMON_MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-COMMON_MKFILE_DIR := $(dir $(COMMON_MKFILE_PATH))
-
 HELP_TAB_WIDTH = 25
 
 .DEFAULT_GOAL := help
@@ -14,6 +11,17 @@ echo_pass = printf "\e[32m✔ \033\e[0m$(1)\n"
 echo_stdout_header = printf "\n+++++++++++++ $(1)\n"
 echo_stdout_footer = printf "+++++++++++++ $(1)\n"
 echo_stdout_footer_pass = printf "\e[32m✔ \033\e[0m ++++++++++ $(1) \n"
+
+COMMON_MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+COMMON_MKFILE_DIR := $(dir $(COMMON_MKFILE_PATH))
+
+# includes should come after any usage of MAKEFILE_LIST
+# as it affects the results of that command and the result of our usage of
+# lastword above changes after this include
+include ../../utils/config.env
+
+OPERATOR_DOWNLOAD_PATH := $(COMMON_MKFILE_DIR)cp/operator/confluent-operator-$(OPERATOR_BUNDLE_VERSION).tar.gz
+OPERATOR_PATH := $(dir $(OPERATOR_DOWNLOAD_PATH))$(OPERATOR_BUNDLE_VERSION)/
 
 check-dependency = $(if $(shell command -v $(1)),$(call echo_pass,found $(1)),$(call echo_fail,$(1) not installed);exit 1)
 
@@ -32,16 +40,14 @@ help: ## shows help for each target
 extended-help: 
 	@$(foreach m,$(MAKEFILE_LIST),grep -E '^[a-zA-Z_-]+:.*?#_ .*$$' $(m) | sort | awk 'BEGIN {FS = ":.*?#_ "}; {printf "\033[36m%-$(HELP_TAB_WIDTH)s\033[0m %s\n", $$1, $$2}';)
 
-OPERATOR_VERSION ?= 20200310-v0.142.1
-OPERATOR_DOWNLOAD_PATH := $(COMMON_MKFILE_DIR)cp/operator/confluent-operator-$(OPERATOR_VERSION).tar.gz
-OPERATOR_PATH := $(dir $(OPERATOR_DOWNLOAD_PATH))$(OPERATOR_VERSION)/
-
 get-helm-bundle: #_ Download the Confluent Operator Helm bundle locally in preparation for installation
-	@mkdir -p $(dir $(OPERATOR_DOWNLOAD_PATH))
 ifeq (,$(wildcard $(OPERATOR_DOWNLOAD_PATH)))
+	@mkdir -p $(dir $(OPERATOR_DOWNLOAD_PATH))
 	@echo "downloading Confluent Operator to $(OPERATOR_DOWNLOAD_PATH)"
-	@curl -s https://platform-ops-bin.s3-us-west-1.amazonaws.com/operator/confluent-operator-$(OPERATOR_VERSION).tar.gz --output $(OPERATOR_DOWNLOAD_PATH)
-	@mkdir -p $(dir $(OPERATOR_DOWNLOAD_PATH))/$(OPERATOR_VERSION)/
+	@curl -s https://platform-ops-bin.s3-us-west-1.amazonaws.com/operator/confluent-operator-$(OPERATOR_HELM_CHART_VERSION).tar.gz --output $(OPERATOR_DOWNLOAD_PATH)
+endif
+ifeq (,$(wildcard $(OPERATOR_PATH)))
+	@mkdir -p $(dir $(OPERATOR_DOWNLOAD_PATH))$(OPERATOR_HELM_CHART_VERSION)/
 	@echo "Extracting operator to $(OPERATOR_PATH)"
 	@tar xf $(OPERATOR_DOWNLOAD_PATH) -C $(OPERATOR_PATH)
 endif

--- a/kubernetes/gke-base/Makefile-impl
+++ b/kubernetes/gke-base/Makefile-impl
@@ -30,7 +30,7 @@ GKE_BASE_ADDITIONAL_HELM_FLAGS ?=
 GKE_BASE_SKIP_CLICKS ?=
 GKE_BASE_SKIP_CLIENT_CONSOLE ?=
  
-GKE_BASE_HELM_COMMON_FLAGS := --wait --timeout=5m -f $(GKE_BASE_MKFILE_DIR)cfg/values.yaml --set global.provider.region=$(GKE_BASE_REGION) --set global.provider.kubernetes.deployment.zones={$(GKE_BASE_ZONE)} $(GKE_BASE_ADDITIONAL_HELM_FLAGS)
+GKE_BASE_HELM_COMMON_FLAGS := --wait --timeout=5m -f $(GKE_BASE_MKFILE_DIR)cfg/values.yaml --set global.initContainer.image.tag=$(OPERATOR_CP_IMAGE_TAG) --set global.provider.region=$(GKE_BASE_REGION) --set global.provider.kubernetes.deployment.zones={$(GKE_BASE_ZONE)} $(GKE_BASE_ADDITIONAL_HELM_FLAGS)
 
 gke-check-dependencies: check-dependencies
 	@$(call check-var-defined,GCP_PROJECT_ID)
@@ -60,7 +60,7 @@ gke-base-validate: gke-check-dependencies init
 ###### OPERATOR MANAGEMENT ######
 gke-base-deploy-operator: #_ Deploys the Confluent Operator into the configured k8s cluster 
 	@$(call echo_stdout_header,deploy operator)	
-	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set operator.enabled=true operator $(OPERATOR_PATH)helm/confluent-operator
+	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set operator.image.tag=$(OPERATOR_VERSION) --set operator.enabled=true operator $(OPERATOR_PATH)helm/confluent-operator
 	@$(call echo_stdout_footer_pass,operator deployed)
 
 gke-base-wait-for-operator: #_ Waits until the Confluent Operator rollout status is complete
@@ -82,7 +82,7 @@ gke-base-wait-for-operator-destruction: #j Will wait until the Confluent Operato
 ###### ZOOKEEPER MANAGEMENT ######
 gke-base-deploy-zookeeper: #_ Deploys Zookeeper into the configured k8s cluster
 	@$(call echo_stdout_header,Deploy Zookeeper)
-	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set zookeeper.replicas=$(GKE_BASE_ZOOKEEPER_REPLICAS) --set zookeeper.enabled=true zookeeper $(OPERATOR_PATH)helm/confluent-operator
+	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set zookeeper.image.tag=$(OPERATOR_CP_IMAGE_TAG) --set zookeeper.replicas=$(GKE_BASE_ZOOKEEPER_REPLICAS) --set zookeeper.enabled=true zookeeper $(OPERATOR_PATH)helm/confluent-operator
 	@$(call echo_stdout_footer_pass,Zookeeper deployed)
 
 gke-base-wait-for-zookeeper: #_ Waits until the Zookeeper rollout is complete
@@ -108,7 +108,7 @@ gke-base-wait-for-zookeeper-destruction: #_ Waits until the Zookeper cluster is 
 ######### KAFKA MANAGEMENT ######
 gke-base-deploy-kafka: #_ Deploys Kafka into the configured k8s cluster
 	@$(call echo_stdout_header,deploy kafka) 
-	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set kafka.replicas=$(GKE_BASE_KAFKA_REPLICAS) --set kafka.enabled=true kafka $(OPERATOR_PATH)helm/confluent-operator
+	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set kafka.image.tag=$(OPERATOR_CP_IMAGE_TAG) --set kafka.replicas=$(GKE_BASE_KAFKA_REPLICAS) --set kafka.enabled=true kafka $(OPERATOR_PATH)helm/confluent-operator
 	@$(call echo_stdout_footer_pass,Kafka deployed)
 
 gke-base-wait-for-kafka: #_ Waits until the Kafka rollout is complete
@@ -131,7 +131,7 @@ gke-base-wait-for-kafka-destruction: #_ Waits until the Kafka cluster is destroy
 ### SCHEMA REGISTRY MANAGEMENT ##
 gke-base-deploy-schemaregistry: #_ Deploys the Schmea Registry to the configured k8s cluster
 	@$(call echo_stdout_header,Deploy Schema Registry)
-	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set schemaregistry.enabled=true --set schemaregistry.replicas=$(GKE_BASE_SCHEMA_REGISTRY_REPLICAS) schemaregistry $(OPERATOR_PATH)helm/confluent-operator
+	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set schemaregistry.image.tag=$(OPERATOR_CP_IMAGE_TAG) --set schemaregistry.enabled=true --set schemaregistry.replicas=$(GKE_BASE_SCHEMA_REGISTRY_REPLICAS) schemaregistry $(OPERATOR_PATH)helm/confluent-operator
 	@$(call echo_stdout_footer_pass,Schema Registry deployed)
 
 gke-base-wait-for-schemaregistry: #_ Waits until the Schema Registry rollout is complete
@@ -154,7 +154,7 @@ gke-base-wait-for-schemaregistry-destruction: #_ Waits until the Schema Registry
 ##### CONNECT  MANAGEMENT #######
 gke-base-deploy-connect: #_ Deploys Kafka Connect to the configured k8s cluster
 	@$(call echo_stdout_header,Deploy Kafka Connect)
-	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set connect.enabled=true --set connect.replicas=$(GKE_BASE_CONNECT_REPLICAS) connect $(OPERATOR_PATH)helm/confluent-operator
+	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set connect.image.tag=$(OPERATOR_KAFKA_CONNECT_DATAGEN_IMAGE_TAG) --set connect.enabled=true --set connect.replicas=$(GKE_BASE_CONNECT_REPLICAS) connect $(OPERATOR_PATH)helm/confluent-operator
 	@$(call echo_stdout_footer_pass,Kafka Connect deployed)
 
 gke-base-wait-for-connect: #_ Waits until the Kafka Connect rollout is complete
@@ -177,7 +177,7 @@ gke-base-wait-for-connect-destruction: #_ Waits until Kafka Connect is destroyed
 ### CONTROL CENTER MANAGEMENT ####
 gke-base-deploy-controlcenter: #_ Deploys Confluent Control Center to the configured k8s cluster
 	@$(call echo_stdout_header,Deploy Control Center)
-	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set controlcenter.enabled=true controlcenter $(OPERATOR_PATH)helm/confluent-operator
+	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set controlcenter.image.tag=$(OPERATOR_CP_IMAGE_TAG) --set controlcenter.enabled=true controlcenter $(OPERATOR_PATH)helm/confluent-operator
 	@$(call echo_stdout_footer_pass,Control Center deployed)
 
 gke-base-wait-for-controlcenter: #_ Waits until the Control Center rollout is complete

--- a/kubernetes/gke-base/cfg/values.yaml
+++ b/kubernetes/gke-base/cfg/values.yaml
@@ -1,10 +1,4 @@
-confluentPlatformImage: &cpImage
-  image: 
-    tag: 5.4.1.0
- 
 global:
-  initContainer:
-    <<: *cpImage
   provider:
     registry:
       fqdn: docker.io 
@@ -15,23 +9,13 @@ global:
       parameters:
         type: pd-ssd 
 
-manager:
-  name: manager
-
-#operator:
-#  name: operator
-#  image:
-#    tag: 0.176.1
-
 zookeeper:
-  <<: *cpImage
   disableHostPort: true
   resources:
     cpu: 200m
     memory: 512Mi
   
 kafka:
-  <<: *cpImage
   disableHostPort: true
   resources:
     cpu: 200m
@@ -47,7 +31,6 @@ kafka:
     - auto.create.topics.enable=true
 
 schemaregistry:
-  <<: *cpImage
   dependencies:
     kafka:
       bootstrapEndpoint: kafka:9071 
@@ -55,7 +38,6 @@ schemaregistry:
 connect:
   image:
     repository: cnfldemos/cp-server-connect-operator-datagen 
-    tag: 0.3.1-5.4.1.0
   tls:
     enabled: false
   loadBalancer:
@@ -69,7 +51,6 @@ connect:
       url: http://schemaregistry:8081 
 
 controlcenter:
-  <<: *cpImage
   loadBalancer:
     enabled: false
   dependencies:

--- a/utils/config.env
+++ b/utils/config.env
@@ -26,6 +26,16 @@ CP_VERSION_FULL="$CONFLUENT_MAJOR.$CONFLUENT_MINOR.$CONFLUENT_PATCH"
 # The '/' which separates the REPOSITORY from the image name is not required here
 REPOSITORY=confluentinc
 
+#####################################################
+# We use below values in both Docker and Makefile(s)
+# and neither of them do well with variables that
+# derive value from other variables with interpolation.
+# This is why we don't reuse previous values below
+# as it doesn't work in the docker-compose ${var}
+# syntax and also doesn't work when this is included
+# in a Makefile
+#####################################################
+
 ############### kafka-connect-datagen ###############
 # We can't use the CP docker tag above for the aggregate datagen version because
 #   kafka-connect-datagen is not, currently, part of the CP build process.  
@@ -34,8 +44,19 @@ REPOSITORY=confluentinc
 #   Published kafka-connect-datagen images can be found here:
 #     https://hub.docker.com/r/cnfldemos/kafka-connect-datagen/tags
 KAFKA_CONNECT_DATAGEN_VERSION=0.3.1
-# Docker doesn't seem able to interpolate variables so we can't 
-#   reuse the previous value here
-KAFKA_CONNECT_DATAGEN_DOCKER_TAG=0.3.1-5.4.1 
+KAFKA_CONNECT_DATAGEN_DOCKER_TAG=0.3.1-5.4.1
+#####################################################
+
+#################### Operator #######################
+# CP Operator has a different release cadence than
+# CP so we need to maintain a different version 
+# number for demos that use CP Operator.
+# This will need to be managed manually until some
+# tooling automation can be put in place to deal
+# with the different release cadence.
+OPERATOR_VERSION=0.275.1
+OPERATOR_BUNDLE_VERSION=20200310-v0.142.1
+OPERATOR_CP_IMAGE_TAG=5.4.1.0
+OPERATOR_KAFKA_CONNECT_DATAGEN_IMAGE_TAG=0.3.1-5.4.1.0
 #####################################################
 


### PR DESCRIPTION
This puts relevant version numbers for Operator demos in the
utils/config.env file so that we have a unified place to rev them.

Verified by running `make demo` and seeing the following `kubectl get all` output:

```
NAME                                        READY   STATUS      RESTARTS   AGE
pod/cc-operator-b47b984f9-9hqzh             1/1     Running     0          12m
pod/clicks-datagen-connector-deploy-gnmj8   0/1     Completed   0          9m
pod/client-console                          1/1     Running     0          11m
pod/connectors-0                            1/1     Running     0          10m
pod/controlcenter-0                         1/1     Running     0          8m57s
pod/kafka-0                                 1/1     Running     1          11m
pod/schemaregistry-0                        1/1     Running     0          11m
pod/zookeeper-0                             1/1     Running     0          12m

NAME                                TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                                        AGE
service/connectors                  ClusterIP   None          <none>        8083/TCP,9083/TCP,7203/TCP,7777/TCP            10m
service/connectors-0-internal       ClusterIP   10.0.6.178    <none>        8083/TCP,9083/TCP,7203/TCP,7777/TCP            10m
service/controlcenter               ClusterIP   None          <none>        9021/TCP,7203/TCP,7777/TCP                     8m58s
service/controlcenter-0-internal    ClusterIP   10.0.9.161    <none>        9021/TCP,7203/TCP,7777/TCP                     8m58s
service/kafka                       ClusterIP   None          <none>        9071/TCP,9072/TCP,9092/TCP,7203/TCP,7777/TCP   11m
service/kafka-0-internal            ClusterIP   10.0.1.182    <none>        9071/TCP,9072/TCP,9092/TCP,7203/TCP,7777/TCP   11m
service/schemaregistry              ClusterIP   None          <none>        8081/TCP,9081/TCP,7203/TCP,7777/TCP            11m
service/schemaregistry-0-internal   ClusterIP   10.0.0.139    <none>        8081/TCP,9081/TCP,7203/TCP,7777/TCP            11m
service/zookeeper                   ClusterIP   None          <none>        3888/TCP,2888/TCP,2181/TCP,7203/TCP,7777/TCP   12m
service/zookeeper-0-internal        ClusterIP   10.0.15.185   <none>        3888/TCP,2888/TCP,2181/TCP,7203/TCP,7777/TCP   12m

NAME                          READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/cc-operator   1/1     1            1           12m

NAME                                    DESIRED   CURRENT   READY   AGE
replicaset.apps/cc-operator-b47b984f9   1         1         1       12m

NAME                              READY   AGE
statefulset.apps/connectors       1/1     10m
statefulset.apps/controlcenter    1/1     8m57s
statefulset.apps/kafka            1/1     11m
statefulset.apps/schemaregistry   1/1     11m
statefulset.apps/zookeeper        1/1     12m

NAME                                        COMPLETIONS   DURATION   AGE
job.batch/clicks-datagen-connector-deploy   1/1           6s         9m

NAME                                       AGE
kafkacluster.cluster.confluent.com/kafka   12m

NAME                                               AGE
zookeepercluster.cluster.confluent.com/zookeeper   12m
```
