### PR TITLE
DEVX-1627 Updates kafka-connect-datagen version in cp-all-in-ones (5.4.1)

### DIFF
--- a/cp-all-in-one-cloud/docker-compose.yml
+++ b/cp-all-in-one-cloud/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       PORT: 9021
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.2.0-5.4.0
+    image: cnfldemos/cp-server-connect-datagen:0.3.1-5.4.1
     hostname: connect
     container_name: connect
     depends_on:

--- a/cp-all-in-one-community/docker-compose.yml
+++ b/cp-all-in-one-community/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: cnfldemos/kafka-connect-datagen:0.2.0-5.4.0
+    image: cnfldemos/kafka-connect-datagen:0.3.1-5.4.1
     hostname: connect
     container_name: connect
     depends_on:

--- a/cp-all-in-one/docker-compose.yml
+++ b/cp-all-in-one/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.2.0-5.4.0
+    image: cnfldemos/cp-server-connect-datagen:0.3.1-5.4.1
     hostname: connect
     container_name: connect
     depends_on:


### PR DESCRIPTION
Validated with https://docs.confluent.io/current/quickstart/ce-docker-quickstart.html#ce-docker-quickstart