### PR TITLE
Simplified requirements.txt file to mention only confluent-kafka+extras

### DIFF
--- a/clients/cloud/python/requirements.txt
+++ b/clients/cloud/python/requirements.txt
@@ -1,7 +1,1 @@
-requests
-fastavro>=0.23.0
-avro-python3==1.9.2.1
-jsonschema
-protobuf
-confluent-kafka
-confluent-kafka[avro]
+confluent-kafka[avro,jsonschema,protobuf]


### PR DESCRIPTION
Dependencies will be automatically installed by pip.