### PR TITLE
DEVX-1736 Upgrades kafka-connect-datagen 0.3.2 and 5.5.0

### DIFF
--- a/clickstream/docs/index.rst
+++ b/clickstream/docs/index.rst
@@ -40,7 +40,7 @@ are quite large and depending on your network connection may take
 
    .. code:: bash
 
-       docker run -v $PWD/confluent-hub-components:/share/confluent-hub-components confluentinc/ksqldb-server:0.8.0 confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.3.1
+       docker run -v $PWD/confluent-hub-components:/share/confluent-hub-components confluentinc/ksqldb-server:0.8.0 confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.3.2
        docker run -v $PWD/confluent-hub-components:/share/confluent-hub-components confluentinc/ksqldb-server:0.8.0 confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:5.4.1
 
 

--- a/utils/config.env
+++ b/utils/config.env
@@ -43,8 +43,8 @@ REPOSITORY=confluentinc
 #   and there will be a delay between CP releases and kafka-connect-datagen releases.
 #   Published kafka-connect-datagen images can be found here:
 #     https://hub.docker.com/r/cnfldemos/kafka-connect-datagen/tags
-KAFKA_CONNECT_DATAGEN_VERSION=0.3.1
-KAFKA_CONNECT_DATAGEN_DOCKER_TAG=0.3.1-5.4.1
+KAFKA_CONNECT_DATAGEN_VERSION=0.3.2
+KAFKA_CONNECT_DATAGEN_DOCKER_TAG=0.3.2-5.5.0
 #####################################################
 
 #################### Operator #######################


### PR DESCRIPTION
Depends on https://github.com/confluentinc/cp-all-in-one/pull/8