### PR TITLE
DEVX-1739 Upgrades gke-base demo to 5.5.0 Operator release

### DIFF
--- a/kubernetes/gke-base/Makefile-impl
+++ b/kubernetes/gke-base/Makefile-impl
@@ -60,7 +60,7 @@ gke-base-validate: gke-check-dependencies init
 ###### OPERATOR MANAGEMENT ######
 gke-base-deploy-operator: #_ Deploys the Confluent Operator into the configured k8s cluster 
 	@$(call echo_stdout_header,deploy operator)	
-	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set operator.image.tag=$(OPERATOR_VERSION) --set operator.enabled=true operator $(OPERATOR_PATH)helm/confluent-operator
+	helm upgrade --install --namespace $(GKE_BASE_KUBECTL_NAMESPACE) $(GKE_BASE_HELM_COMMON_FLAGS) --set operator.enabled=true operator $(OPERATOR_PATH)helm/confluent-operator
 	@$(call echo_stdout_footer_pass,operator deployed)
 
 gke-base-wait-for-operator: #_ Waits until the Confluent Operator rollout status is complete

--- a/utils/config.env
+++ b/utils/config.env
@@ -53,10 +53,10 @@ KAFKA_CONNECT_DATAGEN_DOCKER_TAG=0.3.2-5.5.0
 # number for demos that use CP Operator.
 # This will need to be managed manually until some
 # tooling automation can be put in place to deal
-# with the different release cadence.
-OPERATOR_VERSION=0.275.1
-OPERATOR_BUNDLE_VERSION=20200310-v0.142.1
-OPERATOR_CP_IMAGE_TAG=5.4.1.0
-OPERATOR_KAFKA_CONNECT_DATAGEN_IMAGE_TAG=0.3.1-5.4.1.0
+# with the different release cadence or the releases
+# are syncronized.
+OPERATOR_BUNDLE_VERSION=5.5.0
+OPERATOR_CP_IMAGE_TAG=5.5.0.0
+OPERATOR_KAFKA_CONNECT_DATAGEN_IMAGE_TAG=0.3.2-5.5.0.0
 #####################################################
 


### PR DESCRIPTION
- Removes the OPERATOR_VERSION from config.env.  Reconsidered value in maintaining a seperate version number outside of the CP helm bundle now that Confluent has tied the Helm bundle to a CP release.
- Also upgraded the kafka-connect datagen image to latest and 5.5.0 CP version.

Changes verified w/ a run of gke-base `make demo` with success:

```
make demo
...
✔ GKE Base Demo running
```

Validation:
```
root@client-console:/opt# kafka-console-consumer --bootstrap-server kafka:9071 --consumer.config /etc/kafka-client-properties/kafka-client.properties --topic clicks
{"ip":"222.245.174.248","userid":22,"remote_user":"-","time":"7971","_time":7971,"request":"GET /site/user_status.html HTTP/1.1","status":"200","bytes":"2048","referrer":"-","agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"}
{"ip":"111.203.236.146","userid":24,"remote_user":"-","time":"7981","_time":7981,"request":"GET /site/login.html HTTP/1.1","status":"406","bytes":"14096","referrer":"-","agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"}
^CProcessed a total of 2 messages
root@client-console:/opt#

```