### PR TITLE
csharp .NET Confluent Cloud example client improvements

### DIFF
--- a/clients/cloud/csharp/.gitignore
+++ b/clients/cloud/csharp/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+*.swp

--- a/clients/cloud/csharp/CCloud.csproj
+++ b/clients/cloud/csharp/CCloud.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/clients/cloud/csharp/CCloud.csproj
+++ b/clients/cloud/csharp/CCloud.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/clients/cloud/csharp/CCloud.csproj
+++ b/clients/cloud/csharp/CCloud.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.4.0" />
+    <PackageReference Include="Confluent.Kafka" Version="1.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/clients/cloud/csharp/CCloud.csproj
+++ b/clients/cloud/csharp/CCloud.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Confluent.Kafka" Version="1.4.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>

--- a/clients/cloud/csharp/Program.cs
+++ b/clients/cloud/csharp/Program.cs
@@ -142,8 +142,8 @@ namespace CCloud
                     while (true)
                     {
                         var cr = consumer.Consume(cts.Token);
-                        totalCount += JObject.Parse(cr.Value).Value<int>("count");
-                        Console.WriteLine($"Consumed record with key {cr.Key} and value {cr.Value}, and updated total count to {totalCount}");
+                        totalCount += JObject.Parse(cr.Message.Value).Value<int>("count");
+                        Console.WriteLine($"Consumed record with key {cr.Message.Key} and value {cr.Message.Value}, and updated total count to {totalCount}");
                     }
                 }
                 catch (OperationCanceledException)

--- a/clients/cloud/csharp/Program.cs
+++ b/clients/cloud/csharp/Program.cs
@@ -37,16 +37,8 @@ namespace CCloud
                     .ToDictionary(
                         line => line.Substring(0, line.IndexOf('=')),
                         line => line.Substring(line.IndexOf('=') + 1));
-                Enum.TryParse(cloudConfig["sasl.mechanisms"], out SaslMechanism saslMechanism);
-                Enum.TryParse(cloudConfig["security.protocol"], out SecurityProtocol securityProtocol);
-                var clientConfig = new ClientConfig
-                {
-                    BootstrapServers = cloudConfig["bootstrap.servers"].Replace("\\", ""),
-                    SaslMechanism = saslMechanism,
-                    SecurityProtocol = securityProtocol,
-                    SaslUsername = cloudConfig["sasl.username"],
-                    SaslPassword = cloudConfig["sasl.password"],
-                };
+
+                var clientConfig = new ClientConfig(cloudConfig);
 
                 if (certDir != null)
                 {


### PR DESCRIPTION
This PR originally motivated by the example code not being able to correctly parse `librdkafka.config` as suggested by docs.  `Enum.TryParse` is silently failing and returning false, as the config keys in `librdkafka.config` don't match the enum values.

`ClientConfig` has a dictionary constructor which is able to parse these values, so the fix is to just use that.

Along the way improvements (could be separately applied in a different PR if preferred, but I only tested with these in-place due to environment constraints):

- Added a `.gitignore` for `bin/`, `obj/` and `*.swp`.
- Updated to `netcoreapp3.1` and lang `8.0` so I could test this easily on Mac.
- Upgraded to latest GA `Confluent.Kafka` version `1.4.0`.
- Upgraded `Newtonsoft.Json` to current `12.0.3`.
- Fixed 2 LOC with new deprecation warnings with `Confluent.Kafka` upgrade.

Thanks @mhowlett for the dictionary tip.