### PR TITLE
adding ccloud::create_ccloud_stack_sub

### DIFF
--- a/ccloud/docker-compose.yml
+++ b/ccloud/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: ${REPOSITORY}/cp-enterprise-kafka:${CONFLUENT_DOCKER_TAG}
+    image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: kafka
     container_name: kafka
     ports:
@@ -91,29 +91,6 @@ services:
       CONTROL_CENTER_METRICS_TOPIC_MAX_MESSAGE_BYTES: 8388608
       CONFLUENT_METRICS_TOPIC_REPLICATION: 3
       PORT: 9021
-
-
-  # This "container" is a workaround to pre-create topics
-  kafka-create-topics:
-    image: ${REPOSITORY}/cp-kafka:${CONFLUENT_DOCKER_TAG}
-    hostname: kafka-create-topics
-    container_name: kafka-create-topics
-    depends_on:
-      - kafka
-    # We defined a dependency on "kafka", but `depends_on` will NOT wait for the
-    # dependencies to be "ready" before starting the "kafka-create-topics"
-    # container;  it waits only until the dependencies have started.  Hence we
-    # must control startup order more explicitly.
-    # See https://docs.docker.com/compose/startup-order/
-    command: "bash -c 'echo Waiting for Kafka to be ready... && \
-                       cub kafka-ready -b kafka:29092 1 20 && \
-                       kafka-topics --zookeeper zookeeper:2181 --create --topic pageviews --partitions 6 --replication-factor 1 && \
-                       sleep infinity'"
-    environment:
-      # The following settings are listed here only to satisfy the image's requirements.
-      # We override the image's `command` anyways, hence this container will not start a broker.
-      KAFKA_BROKER_ID: ignored
-      KAFKA_ZOOKEEPER_CONNECT: ignored
 
   connect-local:
     image: cnfldemos/cp-server-connect-datagen:${KAFKA_CONNECT_DATAGEN_DOCKER_TAG}

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -737,6 +737,16 @@ function ccloud::create_ccloud_stack() {
   CLUSTER_NAME=demo-kafka-cluster-$SERVICE_ACCOUNT_ID
   CLUSTER_CLOUD="${CLUSTER_CLOUD:-aws}"
   CLUSTER_REGION="${CLUSTER_REGION:-us-west-2}"
+  KSQL_NAME="demo-ksql-$SERVICE_ACCOUNT_ID"
+
+  mkdir -p stack-configs
+  CLIENT_CONFIG="stack-configs/java-service-account-$SERVICE_ACCOUNT_ID.config"
+
+  ccloud::create_ccloud_stack_sub
+}
+
+function ccloud::create_ccloud_stack_sub() {
+  
   CLUSTER=$(ccloud::create_and_use_cluster $CLUSTER_NAME $CLUSTER_CLOUD $CLUSTER_REGION)
   if [[ "$CLUSTER" == "" ]] ; then
     echo "Kafka cluster id is empty"
@@ -759,7 +769,6 @@ function ccloud::create_ccloud_stack() {
   SCHEMA_REGISTRY_CREDS=$(ccloud::create_credentials_resource $SERVICE_ACCOUNT_ID $SCHEMA_REGISTRY)
 
   if $enable_ksql ; then
-    KSQL_NAME="demo-ksql-$SERVICE_ACCOUNT_ID"
     KSQL=$(ccloud::create_ksql_app $KSQL_NAME $CLUSTER)
     KSQL_ENDPOINT=$(ccloud ksql app describe $KSQL -o json | jq -r ".endpoint")
     KSQL_CREDS=$(ccloud::create_credentials_resource $SERVICE_ACCOUNT_ID $KSQL)
@@ -768,8 +777,7 @@ function ccloud::create_ccloud_stack() {
 
   ccloud::create_acls_all_resources_full_access $SERVICE_ACCOUNT_ID
 
-  mkdir -p stack-configs
-  CLIENT_CONFIG="stack-configs/java-service-account-$SERVICE_ACCOUNT_ID.config"
+  
   cat <<EOF > $CLIENT_CONFIG
 # ------------------------------
 # Confluent Cloud connection information for demo purposes only

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -721,6 +721,16 @@ function ccloud::create_ccloud_stack() {
   CLUSTER_NAME=demo-kafka-cluster-$SERVICE_ACCOUNT_ID
   CLUSTER_CLOUD="${CLUSTER_CLOUD:-aws}"
   CLUSTER_REGION="${CLUSTER_REGION:-us-west-2}"
+  KSQL_NAME="demo-ksql-$SERVICE_ACCOUNT_ID"
+
+  mkdir -p stack-configs
+  CLIENT_CONFIG="stack-configs/java-service-account-$SERVICE_ACCOUNT_ID.config"
+
+  ccloud::create_ccloud_stack_sub
+}
+
+function ccloud::create_ccloud_stack_sub() {
+  
   CLUSTER=$(ccloud::create_and_use_cluster $CLUSTER_NAME $CLUSTER_CLOUD $CLUSTER_REGION)
   if [[ "$CLUSTER" == "" ]] ; then
     print_error "Kafka cluster id is empty"
@@ -743,7 +753,6 @@ function ccloud::create_ccloud_stack() {
   SCHEMA_REGISTRY_CREDS=$(ccloud::create_credentials_resource $SERVICE_ACCOUNT_ID $SCHEMA_REGISTRY)
 
   if $enable_ksql ; then
-    KSQL_NAME="demo-ksql-$SERVICE_ACCOUNT_ID"
     KSQL=$(ccloud::create_ksql_app $KSQL_NAME $CLUSTER)
     KSQL_ENDPOINT=$(ccloud ksql app describe $KSQL -o json | jq -r ".endpoint")
     KSQL_CREDS=$(ccloud::create_credentials_resource $SERVICE_ACCOUNT_ID $KSQL)
@@ -752,8 +761,7 @@ function ccloud::create_ccloud_stack() {
 
   ccloud::create_acls_all_resources_full_access $SERVICE_ACCOUNT_ID
 
-  mkdir -p stack-configs
-  CLIENT_CONFIG="stack-configs/java-service-account-$SERVICE_ACCOUNT_ID.config"
+  
   cat <<EOF > $CLIENT_CONFIG
 # ------------------------------
 # Confluent Cloud connection information for demo purposes only

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -739,7 +739,7 @@ function ccloud::create_ccloud_stack() {
   CLUSTER_REGION="${CLUSTER_REGION:-us-west-2}"
   CLUSTER=$(ccloud::create_and_use_cluster $CLUSTER_NAME $CLUSTER_CLOUD $CLUSTER_REGION)
   if [[ "$CLUSTER" == "" ]] ; then
-    print_error "Kafka cluster id is empty"
+    echo "Kafka cluster id is empty"
     echo "ERROR: Could not create cluster. Please troubleshoot"
     exit 1
   fi

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -708,29 +708,26 @@ function ccloud::set_kafka_cluster_use() {
 function ccloud::create_ccloud_stack() {
   enable_ksql=$1
 
-  RANDOM_NUM=$((1 + RANDOM % 1000000))
-  #echo "RANDOM_NUM: $RANDOM_NUM"
+  if [[ -z "$SERVICE_ACCOUNT_ID" ]]; then
+    # Service Account is not received so it will be created
+    local RANDOM_NUM=$((1 + RANDOM % 1000000))
+    SERVICE_NAME=${SERVICE_NAME:-"demo-app-$RANDOM_NUM"}
+    SERVICE_ACCOUNT_ID=$(ccloud::create_service_account $SERVICE_NAME)
+    
+  fi
 
-  SERVICE_NAME="demo-app-$RANDOM_NUM"
-  SERVICE_ACCOUNT_ID=$(ccloud::create_service_account $SERVICE_NAME)
   echo "Creating Confluent Cloud stack for new service account id $SERVICE_ACCOUNT_ID of name $SERVICE_NAME"
 
-  ENVIRONMENT_NAME="demo-env-$SERVICE_ACCOUNT_ID"
-  ENVIRONMENT=$(ccloud::create_and_use_environment $ENVIRONMENT_NAME)
-
-  CLUSTER_NAME=demo-kafka-cluster-$SERVICE_ACCOUNT_ID
+  if [[ -z "$ENVIRONMENT" ]]; then
+    # Environment is not received so it will be created
+    echo "You need to specify a demo Type!"
+    ENVIRONMENT_NAME=${ENVIRONMENT_NAME:-"demo-env-$SERVICE_ACCOUNT_ID"}
+    ENVIRONMENT=$(ccloud::create_and_use_environment $ENVIRONMENT_NAME) 
+  fi
+  
+  CLUSTER_NAME=${CLUSTER_NAME:-"demo-kafka-cluster-$SERVICE_ACCOUNT_ID"}
   CLUSTER_CLOUD="${CLUSTER_CLOUD:-aws}"
   CLUSTER_REGION="${CLUSTER_REGION:-us-west-2}"
-  KSQL_NAME="demo-ksql-$SERVICE_ACCOUNT_ID"
-
-  mkdir -p stack-configs
-  CLIENT_CONFIG="stack-configs/java-service-account-$SERVICE_ACCOUNT_ID.config"
-
-  ccloud::create_ccloud_stack_sub
-}
-
-function ccloud::create_ccloud_stack_sub() {
-  
   CLUSTER=$(ccloud::create_and_use_cluster $CLUSTER_NAME $CLUSTER_CLOUD $CLUSTER_REGION)
   if [[ "$CLUSTER" == "" ]] ; then
     print_error "Kafka cluster id is empty"
@@ -753,6 +750,7 @@ function ccloud::create_ccloud_stack_sub() {
   SCHEMA_REGISTRY_CREDS=$(ccloud::create_credentials_resource $SERVICE_ACCOUNT_ID $SCHEMA_REGISTRY)
 
   if $enable_ksql ; then
+    KSQL_NAME=${KSQL_NAME:-"demo-ksql-$SERVICE_ACCOUNT_ID"}
     KSQL=$(ccloud::create_ksql_app $KSQL_NAME $CLUSTER)
     KSQL_ENDPOINT=$(ccloud ksql app describe $KSQL -o json | jq -r ".endpoint")
     KSQL_CREDS=$(ccloud::create_credentials_resource $SERVICE_ACCOUNT_ID $KSQL)
@@ -761,6 +759,11 @@ function ccloud::create_ccloud_stack_sub() {
 
   ccloud::create_acls_all_resources_full_access $SERVICE_ACCOUNT_ID
 
+  if [[ -z "$CLIENT_CONFIG" ]]; then
+    mkdir -p stack-configs
+    CLIENT_CONFIG="stack-configs/java-service-account-$SERVICE_ACCOUNT_ID.config"
+    
+  fi
   
   cat <<EOF > $CLIENT_CONFIG
 # ------------------------------

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -544,6 +544,22 @@ function ccloud::validate_ccloud_cluster_ready() {
   return $?
 }
 
+function ccloud::validate_topic_exists() {
+  topic=$1
+
+  ccloud kafka topic describe $topic &>/dev/null
+  return $?
+}
+
+function ccloud::validate_subject_exists() {
+  subject=$1
+  sr_url=$2
+  sr_credentials=$3
+
+  curl --silent -u $sr_credentials $sr_url/subjects/$subject/versions/latest | jq -r ".subject" | grep $subject > /dev/null
+  return $?
+}
+
 function ccloud::login_ccloud_cli(){
 
   URL=$1

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -729,14 +729,17 @@ function ccloud::create_ccloud_stack() {
     local RANDOM_NUM=$((1 + RANDOM % 1000000))
     SERVICE_NAME=${SERVICE_NAME:-"demo-app-$RANDOM_NUM"}
     SERVICE_ACCOUNT_ID=$(ccloud::create_service_account $SERVICE_NAME)
-    
   fi
 
-  echo "Creating Confluent Cloud stack for new service account id $SERVICE_ACCOUNT_ID of name $SERVICE_NAME"
+  if [[ "$SERVICE_NAME" == "" ]]; then
+    echo "ERROR: SERVICE_NAME it's not defined for $SERVICE_ACCOUNT_ID. If you are providing the SERVICE_ACCOUNT_ID to this function please also provide the SERVICE_NAME"
+    exit 1
+  fi
+
+  echo "Creating Confluent Cloud stack for service account $SERVICE_NAME, ID: $SERVICE_ACCOUNT_ID."
 
   if [[ -z "$ENVIRONMENT" ]]; then
     # Environment is not received so it will be created
-    echo "You need to specify a demo Type!"
     ENVIRONMENT_NAME=${ENVIRONMENT_NAME:-"demo-env-$SERVICE_ACCOUNT_ID"}
     ENVIRONMENT=$(ccloud::create_and_use_environment $ENVIRONMENT_NAME) 
   fi
@@ -778,7 +781,6 @@ function ccloud::create_ccloud_stack() {
   if [[ -z "$CLIENT_CONFIG" ]]; then
     mkdir -p stack-configs
     CLIENT_CONFIG="stack-configs/java-service-account-$SERVICE_ACCOUNT_ID.config"
-    
   fi
   
   cat <<EOF > $CLIENT_CONFIG

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -724,29 +724,26 @@ function ccloud::set_kafka_cluster_use() {
 function ccloud::create_ccloud_stack() {
   enable_ksql=$1
 
-  RANDOM_NUM=$((1 + RANDOM % 1000000))
-  #echo "RANDOM_NUM: $RANDOM_NUM"
+  if [[ -z "$SERVICE_ACCOUNT_ID" ]]; then
+    # Service Account is not received so it will be created
+    local RANDOM_NUM=$((1 + RANDOM % 1000000))
+    SERVICE_NAME=${SERVICE_NAME:-"demo-app-$RANDOM_NUM"}
+    SERVICE_ACCOUNT_ID=$(ccloud::create_service_account $SERVICE_NAME)
+    
+  fi
 
-  SERVICE_NAME="demo-app-$RANDOM_NUM"
-  SERVICE_ACCOUNT_ID=$(ccloud::create_service_account $SERVICE_NAME)
   echo "Creating Confluent Cloud stack for new service account id $SERVICE_ACCOUNT_ID of name $SERVICE_NAME"
 
-  ENVIRONMENT_NAME="demo-env-$SERVICE_ACCOUNT_ID"
-  ENVIRONMENT=$(ccloud::create_and_use_environment $ENVIRONMENT_NAME)
-
-  CLUSTER_NAME=demo-kafka-cluster-$SERVICE_ACCOUNT_ID
+  if [[ -z "$ENVIRONMENT" ]]; then
+    # Environment is not received so it will be created
+    echo "You need to specify a demo Type!"
+    ENVIRONMENT_NAME=${ENVIRONMENT_NAME:-"demo-env-$SERVICE_ACCOUNT_ID"}
+    ENVIRONMENT=$(ccloud::create_and_use_environment $ENVIRONMENT_NAME) 
+  fi
+  
+  CLUSTER_NAME=${CLUSTER_NAME:-"demo-kafka-cluster-$SERVICE_ACCOUNT_ID"}
   CLUSTER_CLOUD="${CLUSTER_CLOUD:-aws}"
   CLUSTER_REGION="${CLUSTER_REGION:-us-west-2}"
-  KSQL_NAME="demo-ksql-$SERVICE_ACCOUNT_ID"
-
-  mkdir -p stack-configs
-  CLIENT_CONFIG="stack-configs/java-service-account-$SERVICE_ACCOUNT_ID.config"
-
-  ccloud::create_ccloud_stack_sub
-}
-
-function ccloud::create_ccloud_stack_sub() {
-  
   CLUSTER=$(ccloud::create_and_use_cluster $CLUSTER_NAME $CLUSTER_CLOUD $CLUSTER_REGION)
   if [[ "$CLUSTER" == "" ]] ; then
     echo "Kafka cluster id is empty"
@@ -769,6 +766,7 @@ function ccloud::create_ccloud_stack_sub() {
   SCHEMA_REGISTRY_CREDS=$(ccloud::create_credentials_resource $SERVICE_ACCOUNT_ID $SCHEMA_REGISTRY)
 
   if $enable_ksql ; then
+    KSQL_NAME=${KSQL_NAME:-"demo-ksql-$SERVICE_ACCOUNT_ID"}
     KSQL=$(ccloud::create_ksql_app $KSQL_NAME $CLUSTER)
     KSQL_ENDPOINT=$(ccloud ksql app describe $KSQL -o json | jq -r ".endpoint")
     KSQL_CREDS=$(ccloud::create_credentials_resource $SERVICE_ACCOUNT_ID $KSQL)
@@ -777,6 +775,11 @@ function ccloud::create_ccloud_stack_sub() {
 
   ccloud::create_acls_all_resources_full_access $SERVICE_ACCOUNT_ID
 
+  if [[ -z "$CLIENT_CONFIG" ]]; then
+    mkdir -p stack-configs
+    CLIENT_CONFIG="stack-configs/java-service-account-$SERVICE_ACCOUNT_ID.config"
+    
+  fi
   
   cat <<EOF > $CLIENT_CONFIG
 # ------------------------------

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -300,7 +300,7 @@ function ccloud::create_and_use_cluster() {
   CLUSTER_CLOUD=$2
   CLUSTER_REGION=$3
 
-  OUTPUT=$(ccloud kafka cluster create $CLUSTER_NAME --cloud $CLUSTER_CLOUD --region $CLUSTER_REGION)
+  OUTPUT=$(ccloud kafka cluster create "$CLUSTER_NAME" --cloud $CLUSTER_CLOUD --region $CLUSTER_REGION)
   CLUSTER=$(echo "$OUTPUT" | grep '| Id' | awk '{print $4;}')
   ccloud kafka cluster use $CLUSTER
 
@@ -349,7 +349,7 @@ function ccloud::create_ksql_app() {
   KSQL_NAME=$1
   CLUSTER=$2
 
-  KSQL=$(ccloud ksql app create --cluster $CLUSTER -o json $KSQL_NAME | jq -r ".id")
+  KSQL=$(ccloud ksql app create --cluster $CLUSTER -o json "$KSQL_NAME" | jq -r ".id")
   echo $KSQL
 
   return 0


### PR DESCRIPTION
extracting logic from  ccloud::create_ccloud_stack into reusable function for my demo (ccloud::create_ccloud_stack_sub)

I have moved the definition of the variables up, so I can change them for my demo.
The name of the function is not great, happy to change that.
In general consider this a newbie contribution, so if anything sounds off let me know!!
Thank you @rspurgeon 