### PR TITLE
Removes a missing function from ccloud create stack

### DIFF
--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -723,7 +723,7 @@ function ccloud::create_ccloud_stack() {
   CLUSTER_REGION="${CLUSTER_REGION:-us-west-2}"
   CLUSTER=$(ccloud::create_and_use_cluster $CLUSTER_NAME $CLUSTER_CLOUD $CLUSTER_REGION)
   if [[ "$CLUSTER" == "" ]] ; then
-    print_error "Kafka cluster id is empty"
+    echo "Kafka cluster id is empty"
     echo "ERROR: Could not create cluster. Please troubleshoot"
     exit 1
   fi


### PR DESCRIPTION
When the utils/helper.sh was removed as a source for this file
this function no longer became available.