### PR TITLE
Quick fix for quoted params

### DIFF
--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -300,7 +300,7 @@ function ccloud::create_and_use_cluster() {
   CLUSTER_CLOUD=$2
   CLUSTER_REGION=$3
 
-  OUTPUT=$(ccloud kafka cluster create $CLUSTER_NAME --cloud $CLUSTER_CLOUD --region $CLUSTER_REGION)
+  OUTPUT=$(ccloud kafka cluster create "$CLUSTER_NAME" --cloud $CLUSTER_CLOUD --region $CLUSTER_REGION)
   CLUSTER=$(echo "$OUTPUT" | grep '| Id' | awk '{print $4;}')
   ccloud kafka cluster use $CLUSTER
 

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -349,7 +349,7 @@ function ccloud::create_ksql_app() {
   KSQL_NAME=$1
   CLUSTER=$2
 
-  KSQL=$(ccloud ksql app create --cluster $CLUSTER -o json $KSQL_NAME | jq -r ".id")
+  KSQL=$(ccloud ksql app create --cluster $CLUSTER -o json "$KSQL_NAME" | jq -r ".id")
   echo $KSQL
 
   return 0


### PR DESCRIPTION
Kafka Cluster and ksqlDB app name can contain spaces, so quoting the variables at the execution point of the command allows this.

Before this, names with spaces would have produced an error.