### PR TITLE
DEVX-1825 k8s updates operator docker image

### DIFF
--- a/kubernetes/gke-base/cfg/client-console-pod.yaml
+++ b/kubernetes/gke-base/cfg/client-console-pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: client-console
-    image: docker.io/confluentinc/cp-server-operator:5.4.1.0
+    image: docker.io/confluentinc/cp-server-operator:5.5.0.0
     command: [sleep, "86400"]
     volumeMounts:
     - name: kafka-client-properties

--- a/kubernetes/replicator-gke-cc/cfg/client-console-pod.yaml
+++ b/kubernetes/replicator-gke-cc/cfg/client-console-pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: client-console
-    image: docker.io/confluentinc/cp-server-operator:5.3.0.0
+    image: docker.io/confluentinc/cp-server-operator:5.5.0.0
     command: [sleep, "86400"]
     volumeMounts:
     - name: kafka-client-properties


### PR DESCRIPTION
for the client-console pod. For now this is statically defined
until the best templating or environment solution is determined