### PR TITLE
Update ccloud to latest ksqlDB syntax

### DIFF
--- a/ccloud/statements.sql
+++ b/ccloud/statements.sql
@@ -1,5 +1,5 @@
 CREATE STREAM pageviews_original WITH (kafka_topic='pageviews', value_format='AVRO');
-CREATE TABLE users_original (userId STRING PRIMARY KEY) WITH (kafka_topic='users', value_format='AVRO');
+CREATE TABLE users_original (key_userId STRING PRIMARY KEY) WITH (kafka_topic='users', value_format='AVRO');
 CREATE STREAM pageviews_female AS SELECT users_original.userid AS userid, pageid, regionid, gender FROM pageviews_original LEFT JOIN users_original ON pageviews_original.userid = users_original.userid WHERE gender = 'FEMALE';
 CREATE STREAM pageviews_female_like_89 AS SELECT * FROM pageviews_female WHERE regionid LIKE '%_8' OR regionid LIKE '%_9';
 CREATE TABLE pageviews_regions AS SELECT gender, regionid , COUNT(*) AS numusers FROM pageviews_female WINDOW TUMBLING (size 30 second) GROUP BY gender, regionid HAVING COUNT(*) > 1;

--- a/ccloud/statements.sql
+++ b/ccloud/statements.sql
@@ -1,5 +1,5 @@
 CREATE STREAM pageviews_original WITH (kafka_topic='pageviews', value_format='AVRO');
-CREATE TABLE users_original (userId_key STRING PRIMARY KEY) WITH (kafka_topic='users', value_format='AVRO');
-CREATE STREAM pageviews_female AS SELECT users_original.userId_key AS userid, pageid, regionid, gender FROM pageviews_original LEFT JOIN users_original ON pageviews_original.userid = users_original.userId_key WHERE gender = 'FEMALE';
+CREATE TABLE users_original (id STRING PRIMARY KEY) WITH (kafka_topic='users', value_format='AVRO');
+CREATE STREAM pageviews_female AS SELECT users_original.id AS userid, pageid, regionid, gender FROM pageviews_original LEFT JOIN users_original ON pageviews_original.userid = users_original.id WHERE gender = 'FEMALE';
 CREATE STREAM pageviews_female_like_89 AS SELECT * FROM pageviews_female WHERE regionid LIKE '%_8' OR regionid LIKE '%_9';
 CREATE TABLE pageviews_regions AS SELECT gender, regionid , COUNT(*) AS numusers FROM pageviews_female WINDOW TUMBLING (size 30 second) GROUP BY gender, regionid HAVING COUNT(*) > 1;

--- a/ccloud/statements.sql
+++ b/ccloud/statements.sql
@@ -1,5 +1,5 @@
 CREATE STREAM pageviews_original WITH (kafka_topic='pageviews', value_format='AVRO');
-CREATE TABLE users_original WITH (kafka_topic='users', value_format='AVRO', key = 'userid');
+CREATE TABLE users_original (userId STRING PRIMARY KEY) WITH (kafka_topic='users', value_format='AVRO');
 CREATE STREAM pageviews_female AS SELECT users_original.userid AS userid, pageid, regionid, gender FROM pageviews_original LEFT JOIN users_original ON pageviews_original.userid = users_original.userid WHERE gender = 'FEMALE';
 CREATE STREAM pageviews_female_like_89 AS SELECT * FROM pageviews_female WHERE regionid LIKE '%_8' OR regionid LIKE '%_9';
 CREATE TABLE pageviews_regions AS SELECT gender, regionid , COUNT(*) AS numusers FROM pageviews_female WINDOW TUMBLING (size 30 second) GROUP BY gender, regionid HAVING COUNT(*) > 1;

--- a/ccloud/statements.sql
+++ b/ccloud/statements.sql
@@ -1,5 +1,5 @@
 CREATE STREAM pageviews_original WITH (kafka_topic='pageviews', value_format='AVRO');
-CREATE TABLE users_original (key_userId STRING PRIMARY KEY) WITH (kafka_topic='users', value_format='AVRO');
-CREATE STREAM pageviews_female AS SELECT users_original.userid AS userid, pageid, regionid, gender FROM pageviews_original LEFT JOIN users_original ON pageviews_original.userid = users_original.userid WHERE gender = 'FEMALE';
+CREATE TABLE users_original (userId_key STRING PRIMARY KEY) WITH (kafka_topic='users', value_format='AVRO');
+CREATE STREAM pageviews_female AS SELECT users_original.userId_key AS userid, pageid, regionid, gender FROM pageviews_original LEFT JOIN users_original ON pageviews_original.userid = users_original.userId_key WHERE gender = 'FEMALE';
 CREATE STREAM pageviews_female_like_89 AS SELECT * FROM pageviews_female WHERE regionid LIKE '%_8' OR regionid LIKE '%_9';
 CREATE TABLE pageviews_regions AS SELECT gender, regionid , COUNT(*) AS numusers FROM pageviews_female WINDOW TUMBLING (size 30 second) GROUP BY gender, regionid HAVING COUNT(*) > 1;


### PR DESCRIPTION
**NOT TESTED** 

However, this looks like the only change needed.

Unfortunately, as the value schema contains a `userId` field and we're pulling the schema from the schema registry, we must name the key something other than `userId`, hence I've named it `id`.  To avoid unnecessary repartitions, I've used `id` in later queries.

Moving forward, it would be good to use a source that doesn't have the `userId` column in both the key and the value.  This will void the clash and allow the tables primary key to be called `userId`.

You may run into issues if the example expects JOIN and GROUP BY columns in the value. With 0.10 of ksqlDB such columns are stored in the key.  Use `AS_VALUE` to take a copy and store it in the value. For example:

```sql
-- Pre-0.10 statement:
-- key column is `ROWKEY`, which is a copy of `userId`.
-- `userId` is a value column.
CREATE STREAM pageviews_female AS 
    SELECT 
        users_original.userid AS userid, 
        pageid, 
        regionid, 
        gender 
    FROM pageviews_original
      LEFT JOIN users_original ON pageviews_original.userid = users_original.userid 
   WHERE gender = 'FEMALE';

-- 0.10 statement (unchanged)
-- key column is `userId`. There is no `userId` in the value.
CREATE STREAM pageviews_female AS 
    SELECT 
        users_original.userid AS userid, 
        pageid, 
        regionid, 
        gender 
    FROM pageviews_original
      LEFT JOIN users_original ON pageviews_original.userid = users_original.userid 
   WHERE gender = 'FEMALE';

-- Equivalent 0.10 statement:
-- key column is `K`, which is a copy of `userId`.
-- `userId` is a value column.
CREATE STREAM pageviews_female AS 
    SELECT 
        users_original.userid AS K,  -- rename to avoid naming clash
        AS_VALUE(users_original.userid) AS userid, -- copy into value and set name
        pageid, 
        regionid, 
        gender 
    FROM pageviews_original
      LEFT JOIN users_original ON pageviews_original.userid = users_original.userid 
   WHERE gender = 'FEMALE';
```
