### PR TITLE
Update Microservice-orders to latest ksqlDB syntax

### DIFF
--- a/microservices-orders/docker-compose.yml
+++ b/microservices-orders/docker-compose.yml
@@ -270,7 +270,6 @@ services:
       - "5601:5601"
     environment:
       xpack.security.enabled: "false"
-      XPACK_SECURITY_ENABLED: "false"
       xpack.monitoring.enabled: "false"
       discovery.type: "single-node"
       elasticsearch.url: http://elasticsearch:9200

--- a/microservices-orders/statements.sql
+++ b/microservices-orders/statements.sql
@@ -11,7 +11,7 @@ CREATE STREAM customers_with_wrong_format_key WITH (kafka_topic='customers', val
 CREATE STREAM customers_with_proper_key WITH (KAFKA_TOPIC='customers-with-proper-key') AS SELECT CAST(id as BIGINT) as customerid, firstname, lastname, email, address, level FROM customers_with_wrong_format_key PARTITION BY CAST(id as BIGINT);
 
 --3. Create the table on the properly keyed stream
-CREATE TABLE customers_table (rowkey bigint KEY, customerid bigint, firstname varchar, lastname varchar, email varchar, address varchar, level varchar) WITH (KAFKA_TOPIC='customers-with-proper-key', VALUE_FORMAT='AVRO', KEY='customerid');
+CREATE TABLE customers_table (customerid bigint PRIMARY KEY, firstname varchar, lastname varchar, email varchar, address varchar, level varchar) WITH (KAFKA_TOPIC='customers-with-proper-key', VALUE_FORMAT='AVRO');
 
 --Join customer information based on customer id
 CREATE STREAM orders_cust1_joined AS SELECT customers_table.customerid AS customerid, firstname, lastname, state, product, quantity, price FROM orders LEFT JOIN customers_table ON orders.customerid = customers_table.customerid;


### PR DESCRIPTION
**NOT TESTED**: as docker-compose up not working on 6.0.x or 5.5.x branches, and non-docker version requires to many hoops to be jumped through.

However, have updated the SQL statements inline with the latest syntax. Should be good to go.

Note: the `orders_cust1_joined` stream will now have the `customerid` in the key, not the value. Likewise, the `FRAUD_ORDER` table will have the `CUSTOMERID`, `LASTNAME`, `FIRSTNAME` in the key, not the value.   You can use `AS_VALUE` to copy into the value if needed.  See example in https://github.com/confluentinc/examples/pull/671 for more info.