### PR TITLE
DEVX-1865 silences some feedback output from ccloud

### DIFF
--- a/cp-quickstart/start-docker-cloud.sh
+++ b/cp-quickstart/start-docker-cloud.sh
@@ -6,6 +6,10 @@
 #########################################
 
 NAME=`basename "$0"`
+QUIET="${QUIET:-true}"
+[ -z $QUIET ] && 
+  REDIRECT_TO="/dev/stdout" ||
+  REDIRECT_TO="/dev/null"
 
 # Source library
 source ../utils/helper.sh
@@ -68,17 +72,17 @@ ccloud::validate_ccloud_stack_up $CLOUD_KEY $CONFIG_FILE || exit 1
 printf "\n";print_process_start "====== Pre-creating topics"
 
 CMD="ccloud kafka topic create _confluent-monitoring"
-$CMD \
+$CMD &>"$REDIRECT_TO" \
   && print_code_pass -c "$CMD" \
   || exit_with_error -c $? -n "$NAME" -m "$CMD" -l $(($LINENO -3))
 
 CMD="ccloud kafka topic create pageviews"
-$CMD \
+$CMD &>"$REDIRECT_TO" \
   && print_code_pass -c "$CMD" \
   || exit_with_error -c $? -n "$NAME" -m "$CMD" -l $(($LINENO -3)) 
 
 CMD="ccloud kafka topic create users"
-$CMD \
+$CMD &>"$REDIRECT_TO" \
   && print_code_pass -c "$CMD" \
   || exit_with_error -c $? -n "$NAME" -m "$CMD" -l $(($LINENO -3))
 

--- a/cp-quickstart/start-docker-cloud.sh
+++ b/cp-quickstart/start-docker-cloud.sh
@@ -7,9 +7,9 @@
 
 NAME=`basename "$0"`
 QUIET="${QUIET:-true}"
-[ -z $QUIET ] && 
-  REDIRECT_TO="/dev/stdout" ||
-  REDIRECT_TO="/dev/null"
+[[ $QUIET == "true" ]] && 
+  REDIRECT_TO="/dev/null" ||
+  REDIRECT_TO="/dev/stdout"
 
 # Source library
 source ../utils/helper.sh

--- a/cp-quickstart/stop-docker-cloud.sh
+++ b/cp-quickstart/stop-docker-cloud.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# Source library 
-source ../utils/helper.sh
-source ../utils/ccloud_library.sh
-
 docker-compose down -v
 
 if [ -z "$1" ]; then

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -362,9 +362,9 @@ function ccloud::create_ksqldb_app() {
 
 function ccloud::create_acls_all_resources_full_access() {
   SERVICE_ACCOUNT_ID=$1
-  [ -z $QUIET ] && 
-    local REDIRECT_TO="/dev/stdout" ||
-    local REDIRECT_TO="/dev/null"
+  [[ $QUIET == "true" ]] && 
+    local REDIRECT_TO="/dev/null" ||
+    local REDIRECT_TO="/dev/stdout"
 
   ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --topic '*' &>"$REDIRECT_TO"
   ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic '*' &>"$REDIRECT_TO"
@@ -385,9 +385,9 @@ function ccloud::create_acls_all_resources_full_access() {
 function ccloud::delete_acls_ccloud_stack() {
   SERVICE_ACCOUNT_ID=$1
 
-  [ -z $QUIET ] && 
-    local REDIRECT_TO="/dev/stdout" ||
-    local REDIRECT_TO="/dev/null"
+  [[ $QUIET == "true" ]] && 
+    local REDIRECT_TO="/dev/null" ||
+    local REDIRECT_TO="/dev/stdout"
 
   ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --topic '*' &>"$REDIRECT_TO"
   ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic '*' &>"$REDIRECT_TO"
@@ -845,9 +845,9 @@ function ccloud::destroy_ccloud_stack() {
   SERVICE_ACCOUNT_ID=$1
   
   QUIET="${QUIET:-true}"
-  [ -z $QUIET ] && 
-    local REDIRECT_TO="/dev/stdout" ||
-    local REDIRECT_TO="/dev/null"
+  [[ $QUIET == "true" ]] && 
+    local REDIRECT_TO="/dev/null" ||
+    local REDIRECT_TO="/dev/stdout"
 
   echo "Destroying Confluent Cloud stack associated to service account id $SERVICE_ACCOUNT_ID"
 

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -844,7 +844,7 @@ EOF
 function ccloud::destroy_ccloud_stack() {
   SERVICE_ACCOUNT_ID=$1
   
-	QUIET="${QUIET:-true}"
+  QUIET="${QUIET:-true}"
   [ -z $QUIET ] && 
     local REDIRECT_TO="/dev/stdout" ||
     local REDIRECT_TO="/dev/null"

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -29,7 +29,6 @@
 # --------------------------------------------------------------
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-
 # --------------------------------------------------------------
 # Library
 # --------------------------------------------------------------
@@ -62,7 +61,6 @@ function ccloud::validate_ccloud_cli_installed() {
 }
 
 function ccloud::validate_ccloud_cli_v2() {
-
   ccloud::validate_ccloud_cli_installed || exit 1
 
   if [[ -z $(ccloud version | grep "Go") ]]; then
@@ -307,7 +305,7 @@ function ccloud::create_and_use_cluster() {
   CLUSTER_CLOUD=$2
   CLUSTER_REGION=$3
 
-  OUTPUT=$(ccloud kafka cluster create "$CLUSTER_NAME" --cloud $CLUSTER_CLOUD --region $CLUSTER_REGION)
+  OUTPUT=$(ccloud kafka cluster create "$CLUSTER_NAME" --cloud $CLUSTER_CLOUD --region $CLUSTER_REGION 2>/dev/null)
   CLUSTER=$(echo "$OUTPUT" | grep '| Id' | awk '{print $4;}')
   ccloud kafka cluster use $CLUSTER
 
@@ -364,19 +362,22 @@ function ccloud::create_ksqldb_app() {
 
 function ccloud::create_acls_all_resources_full_access() {
   SERVICE_ACCOUNT_ID=$1
+  [ -z $QUIET ] && 
+    local REDIRECT_TO="/dev/stdout" ||
+    local REDIRECT_TO="/dev/null"
 
-  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --topic '*'
-  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic '*'
-  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation READ --topic '*'
-  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --topic '*'
-  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE_CONFIGS --topic '*'
+  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --topic '*' &>"$REDIRECT_TO"
+  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic '*' &>"$REDIRECT_TO"
+  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation READ --topic '*' &>"$REDIRECT_TO"
+  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --topic '*' &>"$REDIRECT_TO"
+  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE_CONFIGS --topic '*' &>"$REDIRECT_TO"
 
-  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation READ --consumer-group '*'
-  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --consumer-group '*'
-  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --consumer-group '*'
+  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation READ --consumer-group '*' &>"$REDIRECT_TO"
+  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --consumer-group '*' &>"$REDIRECT_TO"
+  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --consumer-group '*' &>"$REDIRECT_TO"
 
-  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --transactional-id '*'
-  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --transactional-id '*'
+  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --transactional-id '*' &>"$REDIRECT_TO"
+  ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --transactional-id '*' &>"$REDIRECT_TO"
 
   return 0
 }
@@ -384,15 +385,22 @@ function ccloud::create_acls_all_resources_full_access() {
 function ccloud::delete_acls_ccloud_stack() {
   SERVICE_ACCOUNT_ID=$1
 
-  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --topic '*'
-  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic '*'
-  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation READ --topic '*'
-  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --topic '*'
-  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE_CONFIGS --topic '*'
+  [ -z $QUIET ] && 
+    local REDIRECT_TO="/dev/stdout" ||
+    local REDIRECT_TO="/dev/null"
 
-  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation READ --consumer-group '*'
-  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --consumer-group '*'
-  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --consumer-group '*'
+  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --topic '*' &>"$REDIRECT_TO"
+  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic '*' &>"$REDIRECT_TO"
+  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation READ --topic '*' &>"$REDIRECT_TO"
+  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --topic '*' &>"$REDIRECT_TO"
+  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE_CONFIGS --topic '*' &>"$REDIRECT_TO"
+
+  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation READ --consumer-group '*' &>"$REDIRECT_TO"
+  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --consumer-group '*' &>"$REDIRECT_TO"
+  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --consumer-group '*' &>"$REDIRECT_TO"
+
+  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --transactional-id '*' &>"$REDIRECT_TO"
+  ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --transactional-id '*' &>"$REDIRECT_TO"
 
   return 0
 }
@@ -729,6 +737,7 @@ function ccloud::set_kafka_cluster_use() {
 }
 
 function ccloud::create_ccloud_stack() {
+  QUIET="${QUIET:-true}"
   enable_ksqldb=$1
 
   if [[ -z "$SERVICE_ACCOUNT_ID" ]]; then
@@ -834,25 +843,30 @@ EOF
 
 function ccloud::destroy_ccloud_stack() {
   SERVICE_ACCOUNT_ID=$1
+  
+	QUIET="${QUIET:-true}"
+  [ -z $QUIET ] && 
+    local REDIRECT_TO="/dev/stdout" ||
+    local REDIRECT_TO="/dev/null"
 
   echo "Destroying Confluent Cloud stack associated to service account id $SERVICE_ACCOUNT_ID"
 
   if [[ $KSQLDB_ENDPOINT != "" ]]; then
     KSQLDB=$(ccloud ksql app list | grep demo-ksqldb-$SERVICE_ACCOUNT_ID | awk '{print $1;}')
     echo "KSQLDB: $KSQLDB"
-    ccloud ksql app delete $KSQLDB
+    ccloud ksql app delete $KSQLDB &>"$REDIRECT_TO"
   fi
 
   ccloud::delete_acls_ccloud_stack $SERVICE_ACCOUNT_ID
-  ccloud service-account delete $SERVICE_ACCOUNT_ID 
+  ccloud service-account delete $SERVICE_ACCOUNT_ID &>"$REDIRECT_TO" 
 
   CLUSTER=$(ccloud kafka cluster list | grep demo-kafka-cluster-$SERVICE_ACCOUNT_ID | tr -d '\*' | awk '{print $1;}')
   echo "CLUSTER: $CLUSTER"
-  ccloud kafka cluster delete $CLUSTER
+  ccloud kafka cluster delete $CLUSTER &> "$REDIRECT_TO"
 
   ENVIRONMENT=$(ccloud environment list | grep demo-env-$SERVICE_ACCOUNT_ID | tr -d '\*' | awk '{print $1;}')
   echo "ENVIRONMENT: $ENVIRONMENT"
-  ccloud environment delete $ENVIRONMENT
+  ccloud environment delete $ENVIRONMENT &> "$REDIRECT_TO"
 
   CLIENT_CONFIG="stack-configs/java-service-account-$SERVICE_ACCOUNT_ID.config"
   rm -f $CLIENT_CONFIG


### PR DESCRIPTION
The objective here is to get the demo output back to where it was before
the change to nudge users for feedback from ccloud CLI.  We can expand
on the QUIET and redirection method over time if useful.