### PR TITLE
for ccloud validation, redirect stderr to stdout to handle both

### DIFF
--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -62,7 +62,7 @@ function ccloud::validate_ccloud_cli_installed() {
 function ccloud::validate_ccloud_cli_v2() {
   ccloud::validate_ccloud_cli_installed || exit 1
 
-  if [[ -z $(ccloud version | grep "Go") ]]; then
+  if [[ -z $(ccloud version 2>&1 | grep "Go") ]]; then
     echo "This demo requires the new Confluent Cloud CLI. Please update your version and try again."
     exit 1
   fi


### PR DESCRIPTION
Handles change in ccloud cli which redirected `ccloud version` to stderr