### PR TITLE
DEVX-1956: 5.5.x : pin confluent CLI release validation to bundled version 0.265.0

### DIFF
--- a/utils/helper.sh
+++ b/utils/helper.sh
@@ -51,7 +51,7 @@ function validate_version_confluent_cli_v2() {
   if version_gt $CONFLUENT_CLI_VER $MAX_CONFLUENT_CLI_VER ; then
     echo "ERROR: Confluent Platform ${CONFLUENT} is compatible with Confluent CLI versions 0.265.0 through ${MAX_CONFLUENT_CLI_VER}, but current reported Confluent CLI version is ${CONFLUENT_CLI_VER}"
     echo "Reference: https://docs.confluent.io/current/installation/versions-interoperability.html#confluent-cli"
-    echo -e "Install the required Confluent CLI version with the command ->\n  curl -sL https://cnfl.io/cli | sh -s -- -b $CONFLUENT_HOME/bin v${MAX_CONFLUENT_CLI_VER}"
+    echo -e "Install the required Confluent CLI version and try again."
     exit 1
   fi
 

--- a/utils/helper.sh
+++ b/utils/helper.sh
@@ -45,12 +45,13 @@ function validate_version_confluent_cli_v2() {
     exit 1
   fi
 
-  REQUIRED_CONFLUENT_CLI_VER=${1:-"0.265.0"}
+  MAX_CONFLUENT_CLI_VER=${1:-"1.7.0"}
   CONFLUENT_CLI_VER=$(get_version_confluent_cli)
 
-  if version_gt $REQUIRED_CONFLUENT_CLI_VER $CONFLUENT_CLI_VER; then
-    echo "ERROR: demos require Confluent CLI version ${REQUIRED_CONFLUENT_CLI_VER} which is bundled with ${CONFLUENT}. Current reported version: ${CONFLUENT_CLI_VER}"
-    echo -e "Install the required Confluent CLI version with the command ->\n  curl -sL https://cnfl.io/cli | sh -s -- -b $CONFLUENT_HOME/bin v0.265.0"
+  if version_gt $CONFLUENT_CLI_VER $MAX_CONFLUENT_CLI_VER ; then
+    echo "ERROR: Confluent Platform ${CONFLUENT} is compatible with Confluent CLI versions 0.265.0 through ${MAX_CONFLUENT_CLI_VER}, but current reported Confluent CLI version is ${CONFLUENT_CLI_VER}"
+    echo "Reference: https://docs.confluent.io/current/installation/versions-interoperability.html#confluent-cli"
+    echo -e "Install the required Confluent CLI version with the command ->\n  curl -sL https://cnfl.io/cli | sh -s -- -b $CONFLUENT_HOME/bin v${MAX_CONFLUENT_CLI_VER}"
     exit 1
   fi
 

--- a/utils/helper.sh
+++ b/utils/helper.sh
@@ -30,10 +30,27 @@ function check_env() {
   return 0
 }
 
+function get_version_confluent_cli() {
+  confluent version | grep "^Version:" | cut -d':' -f2 | cut -d'v' -f2
+}
+
+function version_gt() {
+  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1";
+}
+
 function validate_version_confluent_cli_v2() {
 
   if [[ -z $(confluent version | grep "Go") ]]; then
     echo "This demo requires the new Confluent CLI. Please update your version and try again."
+    exit 1
+  fi
+
+  REQUIRED_CONFLUENT_CLI_VER=${1:-"0.265.0"}
+  CONFLUENT_CLI_VER=$(get_version_confluent_cli)
+
+  if version_gt $REQUIRED_CONFLUENT_CLI_VER $CONFLUENT_CLI_VER; then
+    echo "confluent version ${REQUIRED_CONFLUENT_CLI_VER} is required. Current reported version: ${CONFLUENT_CLI_VER}"
+    echo -e "Install the precise version with the command ->\n  curl -sL https://cnfl.io/cli | sh -s -- v0.265.0 && mv bin/confluent $CONFLUENT_HOME/bin/."
     exit 1
   fi
 

--- a/utils/helper.sh
+++ b/utils/helper.sh
@@ -50,7 +50,7 @@ function validate_version_confluent_cli_v2() {
 
   if version_gt $REQUIRED_CONFLUENT_CLI_VER $CONFLUENT_CLI_VER; then
     echo "ERROR: demos require Confluent CLI version ${REQUIRED_CONFLUENT_CLI_VER} which is bundled with ${CONFLUENT}. Current reported version: ${CONFLUENT_CLI_VER}"
-    echo -e "Install the required Confluent CLI version with the command ->\n  curl -sL https://cnfl.io/cli | sh -s -- v0.265.0 && mv bin/confluent $CONFLUENT_HOME/bin/."
+    echo -e "Install the required Confluent CLI version with the command ->\n  curl -sL https://cnfl.io/cli | sh -s -- -b $CONFLUENT_HOME/bin v0.265.0"
     exit 1
   fi
 

--- a/utils/helper.sh
+++ b/utils/helper.sh
@@ -49,8 +49,8 @@ function validate_version_confluent_cli_v2() {
   CONFLUENT_CLI_VER=$(get_version_confluent_cli)
 
   if version_gt $REQUIRED_CONFLUENT_CLI_VER $CONFLUENT_CLI_VER; then
-    echo "confluent version ${REQUIRED_CONFLUENT_CLI_VER} is required. Current reported version: ${CONFLUENT_CLI_VER}"
-    echo -e "Install the precise version with the command ->\n  curl -sL https://cnfl.io/cli | sh -s -- v0.265.0 && mv bin/confluent $CONFLUENT_HOME/bin/."
+    echo "ERROR: demos require Confluent CLI version ${REQUIRED_CONFLUENT_CLI_VER} which is bundled with ${CONFLUENT}. Current reported version: ${CONFLUENT_CLI_VER}"
+    echo -e "Install the required Confluent CLI version with the command ->\n  curl -sL https://cnfl.io/cli | sh -s -- v0.265.0 && mv bin/confluent $CONFLUENT_HOME/bin/."
     exit 1
   fi
 


### PR DESCRIPTION
@rspurgeon this PR is a proposal for how to address the CLI version issue.