### PR TITLE
SEC-1034: log4j migration to confluent repackaged version

### DIFF
--- a/clients/avro/pom.xml
+++ b/clients/avro/pom.xml
@@ -75,7 +75,12 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-log4j12</artifactId>
-     </dependency>
+   </dependency>
+   <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+    <dependency>
+        <groupId>io.confluent</groupId>
+        <artifactId>confluent-log4j</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/clients/cloud/java/pom.xml
+++ b/clients/cloud/java/pom.xml
@@ -103,6 +103,11 @@
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j-api.version}</version>
         </dependency>
+        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/connect-streams-pipeline/pom.xml
+++ b/connect-streams-pipeline/pom.xml
@@ -72,7 +72,12 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-log4j12</artifactId>
-     </dependency>
+    </dependency>
+   <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+    <dependency>
+       <groupId>io.confluent</groupId>
+       <artifactId>confluent-log4j</artifactId>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
@sdanduConf pointed out that the demo is broken because of missing class definitions for log4j. The cause was that log4j is explicitly blacklisted in common. This PR fixes the broken dependencies.