### PR TITLE
fixes for replicator-security

### DIFF
--- a/replicator-security/.env
+++ b/replicator-security/.env
@@ -1,0 +1,1 @@
+../utils/config.env

--- a/replicator-security/unsecure/docker-compose.yml
+++ b/replicator-security/unsecure/docker-compose.yml
@@ -13,7 +13,7 @@
 ---
 version: "2.2"
 services:
-srcZookeeper:
+  srcZookeeper:
     image: ${REPOSITORY}/cp-zookeeper:${CONFLUENT_DOCKER_TAG}
     restart: always
     hostname: srcZookeeper


### PR DESCRIPTION
Hit a couple issues in testing replicator-security on 6.0.x (it is possible this needs to be merged to earlier branches).

1) unsecure wasn't working because of a missing indent for services -> srcZookeeper
2) Generally I needed to have the .env symbolic link in the main replicator-security folder in order to run the commands successfully in the README, otherwise they weren't able to find the environment variables (CONFLUENT_DOCKER_TAG, etc..)