### PR TITLE
SEC-1307: Backport "log4j replacement with confluent repackaged version"

### DIFF
--- a/clients/avro/pom.xml
+++ b/clients/avro/pom.xml
@@ -75,7 +75,12 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-log4j12</artifactId>
-     </dependency>
+   </dependency>
+   <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+    <dependency>
+        <groupId>io.confluent</groupId>
+        <artifactId>confluent-log4j</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/clients/cloud/java/pom.xml
+++ b/clients/cloud/java/pom.xml
@@ -103,6 +103,11 @@
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j-api.version}</version>
         </dependency>
+        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/connect-streams-pipeline/pom.xml
+++ b/connect-streams-pipeline/pom.xml
@@ -72,7 +72,12 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-log4j12</artifactId>
-     </dependency>
+    </dependency>
+   <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+    <dependency>
+       <groupId>io.confluent</groupId>
+       <artifactId>confluent-log4j</artifactId>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
This pull request cherry-picks a commit from `master` to add explicit `io.confluent:confluent-log4j` dependency, because we blacklist the (vulnerable) tranistive dependency `log4j:log4j` of `org.slf4j:slf4j-log4j12` explicitly in `common`. `io.confluent:confluent-log4j` is a drop-in replacement of `log4j:log4j` with a fix for the vulnerability.