### PR TITLE
DOCS-5150: Update link to CCloud API keys anchor

### DIFF
--- a/kubernetes/replicator-gke-cc/docs/index.rst
+++ b/kubernetes/replicator-gke-cc/docs/index.rst
@@ -183,7 +183,7 @@ API Key and Secret Configuration
 
 The ``ccloud`` CLI allows you to create API Keys to be used with client applications.
 
-.. tip:: You can also create the API Key using the :ref:`Confluent Cloud UI <cloud-quick-create-api-key>`.
+.. tip:: You can also create the API Key using the :ref:`Confluent Cloud UI <create-api-key-ui>`.
 
 #.  To create a new API Key:
 


### PR DESCRIPTION
In [Google Kubernetes Engine to Confluent Cloud with Confluent Replicator](https://docs.confluent.io/current/tutorials/examples/kubernetes/replicator-gke-cc/docs/index.html#api-key-and-secret-configuration), the "API keys" anchor no longer exists in the updated CCloud quick start. The new target is [Create Kafka API Keys in the UI](https://docs.confluent.io/current/cloud/using/api-keys.html#create-ak-api-keys-in-the-ui).