### PR TITLE
DEVX-2039: Microservices Orders demo fails on Ubuntu 18.04	

### DIFF
--- a/microservices-orders/docker-compose.yml
+++ b/microservices-orders/docker-compose.yml
@@ -262,6 +262,7 @@ services:
       - "9200:9200"
       - "9300:9300"
     environment:
+      discovery.type: "single-node"
       xpack.security.enabled: "false"
       XPACK_SECURITY_ENABLED: "false"
       xpack.monitoring.enabled: "false"

--- a/microservices-orders/scripts/run-services.sh
+++ b/microservices-orders/scripts/run-services.sh
@@ -12,6 +12,12 @@ ADDITIONAL_ARGS=${ADDITIONAL_ARGS:-""}
 LOG_DIR=${LOG_DIR:="logs"}
 PIDS_FILE=${PIDS_FILE:=".microservices.pids"}
 
+# check if we can write to the log directory
+if [ ! -w $LOG_DIR ]; then
+  echo "Unable to write to the logs dir with uid `id -u`. Logging to /tmp."
+  LOG_DIR=/tmp
+fi
+
 echo "Config File arg: $CONFIG_FILE_ARG"
 echo "Additional Args: $ADDITIONAL_ARGS"
 echo "Starting microservices from $JAR"


### PR DESCRIPTION
Problem 1: elasticsearch container exits with a bootstrap check failure.  Easy fix: set discovery.type: "single-node".

Problem 2: getting a permission denied writing to the logs folder in `run-services.sh`.  This one comes down to different permissions for bind mounts in Docker on Linux and macOS.  More on the way macOS docker works [here](https://docs.docker.com/docker-for-mac/osxfs/#ownership).

On MacOS the `streams` user is the owner:
```
$ docker-compose exec microservices bash
streams@ac2c18b87e83:/build$ ls -la /opt/docker/
total 12
drwxr-xr-x  5 root    root    4096 Sep  3 03:04 .
drwxr-xr-x  1 root    root    4096 Sep  3 03:04 ..
drwxr-xr-x  2 root    root    4096 Sep  3 03:04 config
drwxr-xr-x 11 streams streams  352 Sep  1 03:38 logs
drwxr-xr-x  7 streams streams  224 Aug 31 04:08 scripts
```
On Linux the host user's id is the owner:
```
$ docker-compose exec microservices bash
streams@c07c5d12fa0b:/build$ ls -la /opt/docker/
total 20
drwxr-xr-x 5 root root 4096 Sep  3 02:53 .
drwxr-xr-x 1 root root 4096 Sep  3 02:53 ..
drwxr-xr-x 2 root root 4096 Sep  3 02:53 config
drwxrwxr-x 2 1001 1001 4096 Sep  3 02:46 logs
drwxrwxr-x 2 1001 1001 4096 Sep  3 00:43 scripts
```

Including a step to change the ownership of the logs folder on the host would fix it i.e.

```
cd examples/microservices-orders
git checkout 5.5.1-post
# If you are working on a Linux host change the ownership of the logs folder to allow the user in the microservices container
chown 999 logs 
```

I've also added a test to the `run-services.sh` to check permissions and send logs to `/tmp` if needed.  These two commits will get the demo working on Linux.  The `chown 999 logs` change to the instructions is up for debate.

Was an interesting thing to dig into!  This will happen anywhere we have a non-root user container trying to write to a bind mount. We hit the same issue in training with the UBI containers.