### PR TITLE
DEVX-2069: update microservices Docker image to latest official one

### DIFF
--- a/microservices-orders/docker-compose-ccloud.yml
+++ b/microservices-orders/docker-compose-ccloud.yml
@@ -17,7 +17,7 @@ volumes:
 services:
 
   microservices:
-    image: cnfldemos/kafka-streams-examples:5.5.1-DEVX-1881-PR346
+    image: ${REPOSITORY}/kafka-streams-examples:${CONFLUENT_DOCKER_TAG}
     container_name: microservices
     ports:
       - "18894:18894"

--- a/microservices-orders/docker-compose.yml
+++ b/microservices-orders/docker-compose.yml
@@ -222,7 +222,7 @@ services:
         /opt/docker/dashboard/docker-combined.sh
   
   microservices:
-    image: cnfldemos/kafka-streams-examples:5.5.1-DEVX-1881-PR346
+    image: ${REPOSITORY}/kafka-streams-examples:${CONFLUENT_DOCKER_TAG}
     container_name: microservices
     depends_on:
       - broker

--- a/utils/config.env
+++ b/utils/config.env
@@ -5,7 +5,7 @@
 # over time to construct other
 # values required by this repository
 #####################################################
-CONFLUENT=6.0.0
+CONFLUENT=6.0.0-SNAPSHOT
 CONFLUENT_DOCKER_TAG=6.0.x-latest
 CONFLUENT_SHORT=6.0
 CONFLUENT_PREVIOUS=""

--- a/utils/config.env
+++ b/utils/config.env
@@ -5,7 +5,7 @@
 # over time to construct other
 # values required by this repository
 #####################################################
-CONFLUENT=6.0.0-SNAPSHOT
+CONFLUENT=6.0.0
 CONFLUENT_DOCKER_TAG=6.0.x-latest
 CONFLUENT_SHORT=6.0
 CONFLUENT_PREVIOUS=""


### PR DESCRIPTION
microservices orders can now use the kafka-streams-examples 6.0 image as microservice app changes were built