### PR TITLE
DEVX-1873: Update CCloud link in READMEs

### DIFF
--- a/ccloud/beginner-cloud/README.md
+++ b/ccloud/beginner-cloud/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-You can use [Confluent Cloud CLI](https://docs.confluent.io/current/cloud/cli/install.html#ccloud-install-cli?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.beginner-cloud) to interact with your [Confluent Cloud](https://confluent.cloud/?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.beginner-cloud) cluster.
+You can use [Confluent Cloud CLI](https://docs.confluent.io/current/cloud/cli/install.html#install-the-ccloud-cli) to interact with your [Confluent Cloud](https://www.confluent.io/confluent-cloud/) cluster.
 
 
 # Documentation

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -36,7 +36,7 @@ To avoid unexpected charges, carefully evaluate the cost of resources before lau
 Prerequisites
 =============
 
-- Create a user account in `Confluent Cloud <https://confluent.cloud/>`__ 
+- Create a user account in `Confluent Cloud <https://www.confluent.io/confluent-cloud/>`__
 - Local install of :ref:`Confluent Cloud CLI <ccloud-install-cli>` v1.13.0 or later.
 - ``jq`` tool
 

--- a/ccloud/docs/index.rst
+++ b/ccloud/docs/index.rst
@@ -43,7 +43,7 @@ To avoid unexpected charges, carefully evaluate the cost of resources before lau
 Prerequisites
 =============
 
-#. An initialized `Confluent Cloud cluster <https://confluent.cloud/>`__
+#. An initialized `Confluent Cloud cluster <https://www.confluent.io/confluent-cloud/>`__
 
 #. Local install of `Confluent Cloud CLI <https://docs.confluent.io/current/quickstart/cloud-quickstart/index.html#step-2-install-the-ccloud-cli>`__ v1.7.0 or later
 

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -3,7 +3,7 @@
 ################################################################
 # ccloud_library.sh
 # --------------------------------------------------------------
-# This library of functions automates common tasks with Confluent Cloud https://confluent.cloud/ 
+# This library of functions automates common tasks with Confluent Cloud https://www.confluent.io/confluent-cloud/
 #
 # Example usage in https://github.com/confluentinc/examples
 #


### PR DESCRIPTION
Updated CCloud link in READMEs in the following files:

- ccloud/beginner-cloud/README.md
- ccloud/docs/index.rst
- ccloud/docs/ccloud-stack.rst
- utils/ccloud_library.sh

Looks like the _security/acls/README.md_ file was updated already.