### PR TITLE
DEVX-2070: Update default datagen version in Dockerfile-local to 6.0.0

### DIFF
--- a/ccloud/Dockerfile-local
+++ b/ccloud/Dockerfile-local
@@ -17,7 +17,7 @@ ARG CP_VERSION
 
 FROM confluentinc/cp-server-connect-base:$CP_VERSION
 
-ARG CONNECTOR_VERSION=6.0.0-SNAPSHOT
+ARG CONNECTOR_VERSION=6.0.0
 
 ENV CONNECT_PLUGIN_PATH: "/usr/share/java,/connect-plugins,/usr/share/confluent-hub-components"
 

--- a/ccloud/Dockerfile-local
+++ b/ccloud/Dockerfile-local
@@ -17,7 +17,7 @@ ARG CP_VERSION
 
 FROM confluentinc/cp-server-connect-base:$CP_VERSION
 
-ARG CONNECTOR_VERSION=5.5.0-SNAPSHOT
+ARG CONNECTOR_VERSION=6.0.0-SNAPSHOT
 
 ENV CONNECT_PLUGIN_PATH: "/usr/share/java,/connect-plugins,/usr/share/confluent-hub-components"
 


### PR DESCRIPTION
Updating the default only, this has no material affect on the current demo behavior as it is set in script by start-docker.sh