### PR TITLE
DEVX-2101: Remove links to best practices white paper and replace

### DIFF
--- a/ccloud/docs/beginner-cloud.rst
+++ b/ccloud/docs/beginner-cloud.rst
@@ -942,10 +942,7 @@ Here are the variables and their default values:
 Additional Resources
 ---------------------
 
--  See the `Best Practices for Developing Kafka Applications on
-   Confluent Cloud
-   <https://assets.confluent.io/m/14397e757459a58d/original/20200205-WP-Best_Practices_for_Developing_Apache_Kafka_Applications_on_Confluent_Cloud.pdf?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.ccloud>`__
-   white paper for a guide to configuring, monitoring, and optimizing
-   your |ak| client applications when using |ccloud|.
+-  See :ref:`ccloud-best-practices` for a guide to configuring, monitoring, and
+   optimizing your |ak| client applications when using |ccloud|.
 
 - See other :ref:`ccloud-demos-overview`.

--- a/ccloud/docs/beginner-cloud.rst
+++ b/ccloud/docs/beginner-cloud.rst
@@ -945,4 +945,4 @@ Additional Resources
 -  See :ref:`ccloud-best-practices` for a guide to configuring, monitoring, and
    optimizing your |ak| client applications when using |ccloud|.
 
-- See other :ref:`ccloud-demos-overview`.
+-  See other :ref:`ccloud-demos-overview`.

--- a/ccloud/docs/ccloud-demos-overview.rst
+++ b/ccloud/docs/ccloud-demos-overview.rst
@@ -239,8 +239,12 @@ You can build any example with a mix of fully-managed services in |ccloud| and s
 Additional Resources
 ====================
 
--  For a practical guide to configuring, monitoring, and optimizing your |ak| client applications, see the `Best Practices for Developing Kafka Applications on Confluent Cloud <https://assets.confluent.io/m/14397e757459a58d/original/20200205-WP-Best_Practices_for_Developing_Apache_Kafka_Applications_on_Confluent_Cloud.pdf>`__ whitepaper.
--  Learn how to use |crep-full| to copy Kafka data to |ccloud|, in different configurations that allow |kconnect-long| to be backed to |ccloud| or to your origin Kafka cluster. See :ref:`replicator-to-cloud-configurations` for more information.
+-  For a practical guide to configuring, monitoring, and optimizing your |ak|
+   client applications, see :ref:`ccloud-best-practices`.
+-  Learn how to use |crep-full| to copy Kafka data to |ccloud|, in different
+   configurations that allow |kconnect-long| to be backed to |ccloud| or to your
+   origin Kafka cluster. See :ref:`replicator-to-cloud-configurations` for more
+   information.
 
 
 .. toctree::

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -178,6 +178,7 @@ If you don't want to create and destroy a ``ccloud-stack`` using the provided ba
 Additional Resources
 ====================
 
--  Refer to `Best Practices for Developing Kafka Applications on Confluent Cloud <https://assets.confluent.io/m/14397e757459a58d/original/20200205-WP-Best_Practices_for_Developing_Apache_Kafka_Applications_on_Confluent_Cloud.pdf?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.ccloud>`__ whitepaper for a practical guide to configuring, monitoring, and optimizing your Kafka client applications when using Confluent Cloud.
+- For a practical guide to configuring, monitoring, and optimizing your Kafka
+  client applications when using |ccloud| see :ref:`ccloud-best-practices`.
 - Read this blog post about `using Confluent Cloud to manage data pipelines that use both on-premise and cloud deployments <https://www.confluent.io/blog/multi-cloud-integration-across-distributed-systems-with-kafka-connect/>`__.
--  For sample usage of ``ccloud-stack``, see :ref:`ccloud-demos-overview` .
+- For sample usage of ``ccloud-stack``, see :ref:`ccloud-demos-overview` .

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -179,6 +179,6 @@ Additional Resources
 ====================
 
 - For a practical guide to configuring, monitoring, and optimizing your Kafka
-  client applications when using |ccloud| see :ref:`ccloud-best-practices`.
+  client applications when using |ccloud|, see :ref:`ccloud-best-practices`.
 - Read this blog post about `using Confluent Cloud to manage data pipelines that use both on-premise and cloud deployments <https://www.confluent.io/blog/multi-cloud-integration-across-distributed-systems-with-kafka-connect/>`__.
 - For sample usage of ``ccloud-stack``, see :ref:`ccloud-demos-overview` .

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -178,7 +178,6 @@ If you don't want to create and destroy a ``ccloud-stack`` using the provided ba
 Additional Resources
 ====================
 
-- For a practical guide to configuring, monitoring, and optimizing your Kafka
-  client applications when using |ccloud| see :ref:`ccloud-best-practices`.
+- For a practical guide to configuring, monitoring, and optimizing your Kafka client applications when using |ccloud| see :ref:`ccloud-best-practices`.
 - Read this blog post about `using Confluent Cloud to manage data pipelines that use both on-premise and cloud deployments <https://www.confluent.io/blog/multi-cloud-integration-across-distributed-systems-with-kafka-connect/>`__.
 - For sample usage of ``ccloud-stack``, see :ref:`ccloud-demos-overview` .

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -178,6 +178,7 @@ If you don't want to create and destroy a ``ccloud-stack`` using the provided ba
 Additional Resources
 ====================
 
-- For a practical guide to configuring, monitoring, and optimizing your Kafka client applications when using |ccloud| see :ref:`ccloud-best-practices`.
+- For a practical guide to configuring, monitoring, and optimizing your Kafka
+  client applications when using |ccloud| see :ref:`ccloud-best-practices`.
 - Read this blog post about `using Confluent Cloud to manage data pipelines that use both on-premise and cloud deployments <https://www.confluent.io/blog/multi-cloud-integration-across-distributed-systems-with-kafka-connect/>`__.
 - For sample usage of ``ccloud-stack``, see :ref:`ccloud-demos-overview` .

--- a/ccloud/docs/replicator-to-cloud-configuration-types.rst
+++ b/ccloud/docs/replicator-to-cloud-configuration-types.rst
@@ -206,7 +206,12 @@ Additional Resources
 ====================
 
 - For additional considerations on running |crep| to |ccloud|, refer to :ref:`cloud-migrate-topics`.
-- To run a |ccloud| demo that showcases a hybrid |ak| cluster: one cluster is a self-managed |ak| cluster running locally, the other is a |ccloud| cluster, see :ref:`quickstart-demos-ccloud`..
+- To run a |ccloud| demo that showcases a hybrid |ak| cluster: one cluster is a
+  self-managed |ak| cluster running locally, the other is a |ccloud| cluster, see
+  :ref:`quickstart-demos-ccloud`.
 - To find additional |ccloud| demos, see :ref:`Confluent Cloud Demos Overview<ccloud-demos-overview>`.
-- For a practical guide to configuring, monitoring, and optimizing your |ak| client applications, see the `Best Practices for Developing Kafka Applications on Confluent Cloud <https://assets.confluent.io/m/14397e757459a58d/original/20200205-WP-Best_Practices_for_Developing_Apache_Kafka_Applications_on_Confluent_Cloud.pdf>`__ whitepaper.
-- To run a |crep| tutorial with an active-active multi-datacenter design, with two instances of |crep-full| that copy data bidirectionally between the datacenters, see :ref:`replicator`.
+- For a practical guide to configuring, monitoring, and optimizing your |ak|
+  client applications, see :ref:`ccloud-best-practices`.
+- To run a |crep| tutorial with an active-active multi-datacenter design, with
+  two instances of |crep-full| that copy data bidirectionally between the
+  datacenters, see :ref:`replicator`.

--- a/clients/cloud/README.md
+++ b/clients/cloud/README.md
@@ -35,5 +35,5 @@ The following subset includes examples with Schema Registry and Avro data:
 # Additional Resources
 
 
-* For clusters in Confluent Cloud: refer to [Best Practices for Developing Kafka Applications on Confluent Cloud](https://assets.confluent.io/m/14397e757459a58d/original/20200205-WP-Best_Practices_for_Developing_Apache_Kafka_Applications_on_Confluent_Cloud.pdf?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients) whitepaper for a practical guide to configuring, monitoring, and optimizing your Kafka client applications.
+* For clusters in Confluent Cloud: refer to [Developing Client Applications on Confluent Cloud](https://docs.confluent.io/current/cloud/best-practices/index.html) for a practical guide to configuring, monitoring, and optimizing your Kafka client applications.
 * For on-prem clusters: refer to [Optimizing Your Apache Kafka Deployment](https://www.confluent.io/white-paper/optimizing-your-apache-kafka-deployment?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients) whitepaper for a practical guide to optimizing your Apache Kafka deployment for various services goals including throughput, latency, durability and availability, and useful metrics to monitor for performance and cluster health.


### PR DESCRIPTION
Remove links to best practices white paper and replaces with links to new page in Docs.