### PR TITLE
Cleanup Streams init

### DIFF
--- a/microservices-orders/exercises/EmailService.java
+++ b/microservices-orders/exercises/EmailService.java
@@ -21,9 +21,6 @@ import org.apache.kafka.streams.kstream.Consumed;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.kstream.GlobalKTable;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KStream;
@@ -58,23 +55,10 @@ public class EmailService implements Service {
                     final Properties defaultConfig) {
     streams = processStreams(bootstrapServers, stateDir, defaultConfig);
     streams.cleanUp(); //don't do this in prod as it clears your state stores
-    final CountDownLatch startLatch = new CountDownLatch(1);
-    streams.setStateListener((newState, oldState) -> {
-      if (newState == State.RUNNING && oldState != KafkaStreams.State.RUNNING) {
-        startLatch.countDown();
-      }
 
-    });
     streams.start();
-    try {
-      if (!startLatch.await(60, TimeUnit.SECONDS)) {
-        throw new RuntimeException("Streams never finished rebalancing on startup");
-      }
-    } catch (final InterruptedException e) {
-       Thread.currentThread().interrupt();
-    }
-    log.info("Started Service " + SERVICE_APP_ID);
 
+    log.info("Started Service " + SERVICE_APP_ID);
   }
 
   private KafkaStreams processStreams(final String bootstrapServers,

--- a/microservices-orders/exercises/FraudService.java
+++ b/microservices-orders/exercises/FraudService.java
@@ -8,15 +8,12 @@ import io.confluent.examples.streams.microservices.domain.Schemas;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import org.apache.commons.cli.*;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.KafkaStreams.State;
 
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -61,22 +58,8 @@ public class FraudService implements Service {
                     final Properties defaultConfig) {
     streams = processStreams(bootstrapServers, stateDir, defaultConfig);
     streams.cleanUp(); //don't do this in prod as it clears your state stores
-    final CountDownLatch startLatch = new CountDownLatch(1);
-    streams.setStateListener((newState, oldState) -> {
-      if (newState == State.RUNNING && oldState != KafkaStreams.State.RUNNING) {
-        startLatch.countDown();
-      }
 
-    });
     streams.start();
-
-    try {
-      if (!startLatch.await(60, TimeUnit.SECONDS)) {
-        throw new RuntimeException("Streams never finished rebalancing on startup");
-      }
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
 
     log.info("Started Service " + getClass().getSimpleName());
   }

--- a/microservices-orders/exercises/InventoryService.java
+++ b/microservices-orders/exercises/InventoryService.java
@@ -3,15 +3,12 @@ package io.confluent.examples.streams.microservices;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import io.confluent.examples.streams.microservices.domain.Schemas;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import org.apache.commons.cli.*;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -64,22 +61,9 @@ public class InventoryService implements Service {
                     final Properties defaultConfig) {
     streams = processStreams(bootstrapServers, stateDir, defaultConfig);
     streams.cleanUp(); //don't do this in prod as it clears your state stores
-    final CountDownLatch startLatch = new CountDownLatch(1);
-    streams.setStateListener((newState, oldState) -> {
-      if (newState == State.RUNNING && oldState != KafkaStreams.State.RUNNING) {
-        startLatch.countDown();
-      }
 
-    });
     streams.start();
 
-    try {
-      if (!startLatch.await(60, TimeUnit.SECONDS)) {
-        throw new RuntimeException("Streams never finished rebalancing on startup");
-      }
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
     log.info("Started Service " + getClass().getSimpleName());
   }
 

--- a/microservices-orders/exercises/OrdersService.java
+++ b/microservices-orders/exercises/OrdersService.java
@@ -2,8 +2,6 @@ package io.confluent.examples.streams.microservices;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import org.apache.commons.cli.*;
@@ -16,7 +14,6 @@ import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.Consumed;
-import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Predicate;
@@ -342,22 +339,9 @@ public class OrdersService implements Service {
         config(bootstrapServers, defaultConfig));
     metadataService = new MetadataService(streams);
     streams.cleanUp(); //don't do this in prod as it clears your state stores
-    final CountDownLatch startLatch = new CountDownLatch(1);
-    streams.setStateListener((newState, oldState) -> {
-      if (newState == State.RUNNING && oldState != KafkaStreams.State.RUNNING) {
-        startLatch.countDown();
-      }
 
-    });
     streams.start();
 
-    try {
-      if (!startLatch.await(60, TimeUnit.SECONDS)) {
-        throw new RuntimeException("Streams never finished rebalancing on startup");
-      }
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
     return streams;
   }
 


### PR DESCRIPTION
Remove handling of "Streams never finished rebalancing on startup" as it's no longer required (I believe it is some relict to prevent a bug that existed in Kafka v0.x)