### PR TITLE
REP-1233 fix for slow start up due to cpus restriction

### DIFF
--- a/replicator-schema-translation/docker-compose.yml
+++ b/replicator-schema-translation/docker-compose.yml
@@ -39,7 +39,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafka1
     container_name: srcKafka1
-    cpus: 0.3
     depends_on:
       - srcZookeeper
     ports:
@@ -60,7 +59,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafka1
     container_name: destKafka1
-    cpus: 0.3
     depends_on:
       - destZookeeper
     ports:
@@ -79,7 +77,6 @@ services:
   connect:
     image: ${REPOSITORY}/cp-server-connect:${CONFLUENT_DOCKER_TAG}
     container_name: connect
-    cpus: 0.2
     restart: always
     ports:
       - "8083:8083"
@@ -110,7 +107,6 @@ services:
   srcSchemaregistry:
     image: ${REPOSITORY}/cp-schema-registry:${CONFLUENT_DOCKER_TAG}
     container_name: srcSchemaregistry
-    cpus: 0.4
     restart: always
     depends_on:
       - srcKafka1
@@ -126,7 +122,6 @@ services:
   destSchemaregistry:
     image: ${REPOSITORY}/cp-schema-registry:${CONFLUENT_DOCKER_TAG}
     container_name: destSchemaregistry
-    cpus: 0.4
     restart: always
     depends_on:
       - destKafka1
@@ -150,7 +145,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: kafka-client
     container_name: kafka-client
-    cpus: 0.1
     depends_on:
       - srcKafka1
       - connect
@@ -161,7 +155,7 @@ services:
                        cub kafka-ready -b srcKafka1:10091 1 60 --config /etc/kafka/kafka.properties && \
                        cub kafka-ready -b destKafka1:11091 1 60 --config /etc/kafka/kafka.properties && \
                        sleep 30 && \
-                       kafka-topics --bootstrap-server srcKafka:10091 --topic testTopic --create --replication-factor 1 --partitions 6 && \
+                       kafka-topics --bootstrap-server srcKafka1:10091 --topic testTopic --create --replication-factor 1 --partitions 6 && \
                        echo submitting test subjects && \
                        /etc/kafka/scripts/submit_source_subjects.sh && \
                        echo submitted source_subjects'"

--- a/replicator-security/dest_sasl_plain_auth/docker-compose.yml
+++ b/replicator-security/dest_sasl_plain_auth/docker-compose.yml
@@ -44,7 +44,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafka1
     container_name: srcKafka1
-    cpus: 0.3
     depends_on:
       - srcZookeeper
     ports:
@@ -65,7 +64,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafka1
     container_name: destKafka1
-    cpus: 0.3
     depends_on:
       - destZookeeper
     ports:
@@ -89,7 +87,6 @@ services:
   connect:
     image: ${REPOSITORY}/cp-server-connect:${CONFLUENT_DOCKER_TAG}
     container_name: connect
-    cpus: 0.2
     restart: always
     ports:
       - "8083:8083"
@@ -143,7 +140,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafkaClient
     container_name: srcKafkaClient
-    cpus: 0.1
     depends_on:
       - srcKafka1
     volumes:
@@ -165,7 +161,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafkaClient
     container_name: destKafkaClient
-    cpus: 0.1
     depends_on:
       - destKafka1
       - connect

--- a/replicator-security/dest_ssl_auth/docker-compose.yml
+++ b/replicator-security/dest_ssl_auth/docker-compose.yml
@@ -39,7 +39,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafka1
     container_name: srcKafka1
-    cpus: 0.3
     depends_on:
       - srcZookeeper
     ports:
@@ -60,7 +59,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafka1
     container_name: destKafka1
-    cpus: 0.3
     depends_on:
       - destZookeeper
     ports:
@@ -88,7 +86,6 @@ services:
   connect:
     image: ${REPOSITORY}/cp-server-connect:${CONFLUENT_DOCKER_TAG}
     container_name: connect
-    cpus: 0.2
     restart: always
     ports:
       - "8083:8083"
@@ -140,7 +137,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafkaClient
     container_name: srcKafkaClient
-    cpus: 0.1
     depends_on:
       - srcKafka1
     volumes:
@@ -161,7 +157,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafkaClient
     container_name: destKafkaClient
-    cpus: 0.1
     depends_on:
       - destKafka1
       - connect

--- a/replicator-security/dest_ssl_encryption/docker-compose.yml
+++ b/replicator-security/dest_ssl_encryption/docker-compose.yml
@@ -39,7 +39,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafka1
     container_name: srcKafka1
-    cpus: 0.3
     depends_on:
       - srcZookeeper
     ports:
@@ -60,7 +59,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafka1
     container_name: destKafka1
-    cpus: 0.3
     depends_on:
       - destZookeeper
     ports:
@@ -86,7 +84,6 @@ services:
   connect:
     image: ${REPOSITORY}/cp-server-connect:${CONFLUENT_DOCKER_TAG}
     container_name: connect
-    cpus: 0.2
     restart: always
     ports:
       - "8083:8083"
@@ -138,7 +135,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafkaClient
     container_name: srcKafkaClient
-    cpus: 0.1
     depends_on:
       - srcKafka1
     volumes:
@@ -159,7 +155,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafkaClient
     container_name: destKafkaClient
-    cpus: 0.1
     depends_on:
       - destKafka1
       - connect

--- a/replicator-security/source_sasl_plain_auth/docker-compose.yml
+++ b/replicator-security/source_sasl_plain_auth/docker-compose.yml
@@ -44,7 +44,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafka1
     container_name: srcKafka1
-    cpus: 0.3
     depends_on:
       - srcZookeeper
     ports:
@@ -70,7 +69,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafka1
     container_name: destKafka1
-    cpus: 0.3
     depends_on:
       - destZookeeper
     ports:
@@ -89,7 +87,6 @@ services:
   connect:
     image: ${REPOSITORY}/cp-server-connect:${CONFLUENT_DOCKER_TAG}
     container_name: connect
-    cpus: 0.2
     restart: always
     ports:
       - "8083:8083"
@@ -128,7 +125,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafkaClient
     container_name: srcKafkaClient
-    cpus: 0.1
     depends_on:
       - srcKafka1
     volumes:
@@ -157,7 +153,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafkaClient
     container_name: destKafkaClient
-    cpus: 0.1
     depends_on:
       - destKafka1
       - connect

--- a/replicator-security/source_ssl_auth/docker-compose.yml
+++ b/replicator-security/source_ssl_auth/docker-compose.yml
@@ -39,7 +39,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafka1
     container_name: srcKafka1
-    cpus: 0.3
     depends_on:
       - srcZookeeper
     ports:
@@ -69,7 +68,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafka1
     container_name: destKafka1
-    cpus: 0.3
     depends_on:
       - destZookeeper
     ports:
@@ -88,7 +86,6 @@ services:
   connect:
     image: ${REPOSITORY}/cp-server-connect:${CONFLUENT_DOCKER_TAG}
     container_name: connect
-    cpus: 0.2
     restart: always
     ports:
       - "8083:8083"
@@ -127,7 +124,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafkaClient
     container_name: srcKafkaClient
-    cpus: 0.1
     depends_on:
       - srcKafka1
     volumes:
@@ -154,7 +150,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafkaClient
     container_name: destKafkaClient
-    cpus: 0.1
     depends_on:
       - destKafka1
       - connect

--- a/replicator-security/source_ssl_encryption/docker-compose.yml
+++ b/replicator-security/source_ssl_encryption/docker-compose.yml
@@ -39,7 +39,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafka1
     container_name: srcKafka1
-    cpus: 0.3
     depends_on:
       - srcZookeeper
     ports:
@@ -67,7 +66,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafka1
     container_name: destKafka1
-    cpus: 0.3
     depends_on:
       - destZookeeper
     ports:
@@ -86,7 +84,6 @@ services:
   connect:
     image: ${REPOSITORY}/cp-server-connect:${CONFLUENT_DOCKER_TAG}
     container_name: connect
-    cpus: 0.2
     restart: always
     ports:
       - "8083:8083"
@@ -125,7 +122,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafkaClient
     container_name: srcKafkaClient
-    cpus: 0.1
     depends_on:
       - srcKafka1
     volumes:
@@ -152,7 +148,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafkaClient
     container_name: destKafkaClient
-    cpus: 0.1
     depends_on:
       - destKafka1
       - connect

--- a/replicator-security/unsecure/docker-compose.yml
+++ b/replicator-security/unsecure/docker-compose.yml
@@ -39,7 +39,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: srcKafka1
     container_name: srcKafka1
-    cpus: 0.3
     depends_on:
       - srcZookeeper
     ports:
@@ -60,7 +59,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: destKafka1
     container_name: destKafka1
-    cpus: 0.3
     depends_on:
       - destZookeeper
     ports:
@@ -79,7 +77,6 @@ services:
   connect:
     image: ${REPOSITORY}/cp-server-connect:${CONFLUENT_DOCKER_TAG}
     container_name: connect
-    cpus: 0.2
     restart: always
     ports:
       - "8083:8083"
@@ -117,7 +114,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: kafka-client
     container_name: kafka-client
-    cpus: 0.1
     depends_on:
       - srcKafka1
       - connect


### PR DESCRIPTION
CPU limits were causing brokers to start too slowly for the embedded HTTP server. This Pr removes these restriction. 

All of these demos have been run locally.