### PR TITLE
DEVX-1725: clickstream demo continues even if docker-compose up fails

### DIFF
--- a/clickstream/docker-compose.yml
+++ b/clickstream/docker-compose.yml
@@ -93,6 +93,7 @@ services:
       KSQL_CONNECT_LOG4J_APPENDER_STDOUT_LAYOUT_CONVERSIONPATTERN: '[%d] %p %X{connector.context}%m (%c:%L)%n'
       KSQL_CONNECT_PLUGIN_PATH: '/usr/share/java,/usr/share/confluent-hub-components/,/data/connect-jars'
 
+      KSQL_KSQL_SERVICE_ID: "ksql-cluster"
       CONNECT_HOST: ksqldb-server
       ELASTIC_HOST: elasticsearch
       GRAFANA_HOST: grafana

--- a/utils/helper.sh
+++ b/utils/helper.sh
@@ -387,6 +387,15 @@ check_connect_up_logFile() {
   return 0
 }
 
+host_check_ksqlDBserver_up()
+{
+  KSQLDB_CLUSTER_ID=$(curl -s http://localhost:8088/info | jq -r ".KsqlServerInfo.ksqlServiceId")
+  if [ "$KSQLDB_CLUSTER_ID" == "ksql-cluster" ]; then
+    return 0
+  fi
+  return 1
+}
+
 check_connect_up() {
   containerName=$1
 


### PR DESCRIPTION
Description: Fail fast if Connect fails or ksqlDB server cannot serve requests.

Validated demo works in pass scenarios and fail scenarios (conflicting containers running from another demo).

Request of review just to review code