### PR TITLE
DEVX-2157: Some docs rst files missing link back to GitHub (at git cl…

### DIFF
--- a/ccloud/docs/beginner-cloud.rst
+++ b/ccloud/docs/beginner-cloud.rst
@@ -69,7 +69,7 @@ To run this tutorial, complete the following steps:
    ``~/.netrc`` file.
 
 
-#. Clone the Confluent examples repository:
+#. Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__ GitHub repository.
 
    .. code-block:: bash
 

--- a/ccloud/docs/index.rst
+++ b/ccloud/docs/index.rst
@@ -61,7 +61,7 @@ Setup
 
 #. This example creates a new |ccloud| environment with required resources to run this example. As a reminder, this example uses real |ccloud| resources and you may incur charges.
 
-#. Clone the `examples GitHub repository <https://github.com/confluentinc/examples>`__ and check out the :litwithvars:`|release|-post` branch.
+#. Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__ GitHub repository, and check out the :litwithvars:`|release|-post` branch..
 
    .. codewithvars:: bash
 

--- a/clickstream/docs/index.rst
+++ b/clickstream/docs/index.rst
@@ -28,7 +28,7 @@ Docker images with the required networking and dependencies. The images
 are quite large and depending on your network connection may take 
 10-15 minutes to download.
 
-#. Clone the Confluent examples repository.
+#. Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__ GitHub repository.
 
    .. code:: bash
 

--- a/clients/docs/includes/clients-checkout.rst
+++ b/clients/docs/includes/clients-checkout.rst
@@ -1,5 +1,5 @@
-Clone the `confluentinc/examples GitHub repository
-<https://github.com/confluentinc/examples>`__ and check out the
+Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__
+GitHub repository and check out the
 :litwithvars:`|release|-post` branch.
 
 .. codewithvars:: bash

--- a/cloud-etl/docs/index.rst
+++ b/cloud-etl/docs/index.rst
@@ -125,7 +125,7 @@ Because this example interacts with real resources in Kinesis or RDS PostgreSQL,
 
 #. This example creates a new |ccloud| environment with required resources to run this example. As a reminder, this example uses real |ccloud| resources and you may incur charges so carefully evaluate the cost of resources before launching the example.
 
-#. Clone the `examples GitHub repository <https://github.com/confluentinc/examples>`__ and check out the :litwithvars:`|release|-post` branch.
+#. Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__ GitHub repository, and check out the :litwithvars:`|release|-post` branch..
 
    .. codewithvars:: bash
 

--- a/kubernetes/gke-base/docs/index.rst
+++ b/kubernetes/gke-base/docs/index.rst
@@ -35,7 +35,7 @@ Running the Example
 Setup
 *****
 
-Clone the Confluent examples repository and change directories on your terminal into the ``gke-base`` directory.
+Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__ GitHub repository, and change directories to the ``kubernetes/gke-base`` directory.
 
 .. sourcecode:: bash
 

--- a/kubernetes/replicator-gke-cc/docs/index.rst
+++ b/kubernetes/replicator-gke-cc/docs/index.rst
@@ -48,7 +48,7 @@ Running the Example
 
 .. warning:: This example consumes real cloud resources on both |ccloud| and |gcp-long|.  To avoid unexpected charges, carefully evaluate the cost of resources before launching the example and ensure all :ref:`resources are destroyed <quickstart-demos-operator-replicator-gke-cc-destroy>` after you are done evaluating the demonstration.  Refer to `Confluent Cloud <https://www.confluent.io/confluent-cloud/>`__ and `Google Cloud <https://cloud.google.com/pricing/>`__ pricing data for more information.  The |co| :ref:`Sizing Recommendations <co-env-sizing>` document contains information on required sizing for |co-long|.
 
-Clone the `Confluent examples repository <https://github.com/confluentinc/examples>`__ and change directories on your terminal into the ``kubernetes/replicator-gke-cc`` directory.
+Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__ GitHub repository, and change directories to the ``kubernetes/replicator-gke-cc`` directory.
 
 .. sourcecode:: bash
 

--- a/microservices-orders/docs/index.rst
+++ b/microservices-orders/docs/index.rst
@@ -173,7 +173,7 @@ Setup the Tutorial
 
 #. Follow the "Environment Setup" instructions.
 
-#. Clone the `examples GitHub repository <https://github.com/confluentinc/examples>`__:
+#. Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__ GitHub repository.
 
    .. codewithvars:: bash
 

--- a/multiregion/docs/multiregion.rst
+++ b/multiregion/docs/multiregion.rst
@@ -102,8 +102,7 @@ Topic
 Download and run the tutorial
 -----------------------------
 
-#. Clone the `confluentinc/examples GitHub repo
-   <https://github.com/confluentinc/examples>`__ by running the following command:
+#. Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__ GitHub repository, and check out the :litwithvars:`|release|-post` branch.
 
    .. codewithvars:: bash
 

--- a/replicator-schema-translation/docs/index.rst
+++ b/replicator-schema-translation/docs/index.rst
@@ -25,7 +25,7 @@ Prerequisites
 Run Example
 ===========
 
-1. Clone the `examples GitHub repository <https://github.com/confluentinc/examples>`__.
+#. Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__ GitHub repository.
 
    .. sourcecode:: bash
 

--- a/security/rbac/docs/index.rst
+++ b/security/rbac/docs/index.rst
@@ -39,7 +39,7 @@ Prerequisites
 Run example
 -----------
 
-#. Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__ repository from GitHub and check out the :litwithvars:`|release|-post` branch.
+#. Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__ GitHub repository, and check out the :litwithvars:`|release|-post` branch.
 
    .. codewithvars:: bash
 

--- a/security/secret-protection/docs/secret-protection.rst
+++ b/security/secret-protection/docs/secret-protection.rst
@@ -21,7 +21,7 @@ Prerequisites
 Setup
 -----
 
-#. Clone the Confluent examples repository.
+#. Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__ GitHub repository.
 
    .. code:: bash
 


### PR DESCRIPTION
…one step)

Description: consistency in linking back to the GitHub repo at the `git clone` step in rst docs.  This PR impacts documentation only.

Validation:

- [x] local docs build.