### PR TITLE
DEVX-1778: replace deprecated methods AbstractKafkaAvroSerDeConfig and argument to poll()

### DIFF
--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsAvroExample.java
@@ -35,7 +35,7 @@ import org.apache.kafka.streams.state.KeyValueStore;
 
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerializer;
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 
@@ -75,7 +75,7 @@ public class StreamsAvroExample {
         final Serde<DataRecordAvro> dataRecordAvroSerde = new SpecificAvroSerde<>();
         final boolean isKeySerde = false;
         Map<String, Object> SRconfig = new HashMap<>();
-        SRconfig.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, props.getProperty(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG));
+        SRconfig.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, props.getProperty(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG));
         SRconfig.put("schema.registry.basic.auth.user.info", props.getProperty("schema.registry.basic.auth.user.info"));
         SRconfig.put("basic.auth.credentials.source", props.getProperty("basic.auth.credentials.source"));
         dataRecordAvroSerde.configure(

--- a/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/javaproducer/Driver.java
+++ b/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/javaproducer/Driver.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Properties;
 
 import io.confluent.examples.connectandstreams.avro.Location;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 
 
@@ -72,7 +72,7 @@ public class Driver {
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class);
-    props.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl);
+    props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl);
     final KafkaProducer<Long, Location>
         locationProducer =
         new KafkaProducer<Long, Location>(props);

--- a/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/javaproducer/StreamsIngest.java
+++ b/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/javaproducer/StreamsIngest.java
@@ -35,7 +35,7 @@ import java.util.Collections;
 import java.util.Properties;
 
 import io.confluent.examples.connectandstreams.avro.Location;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
 
 public class StreamsIngest {
@@ -73,7 +73,7 @@ public class StreamsIngest {
     final Serde<Location> locationSerde = new SpecificAvroSerde<>();
     final boolean isKeySerde = false;
     locationSerde.configure(
-        Collections.singletonMap(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL),
+        Collections.singletonMap(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL),
         isKeySerde);
 
     final KStream<Long, Location> locations = builder.stream(INPUT_TOPIC, Consumed.with(Serdes.Long(), locationSerde));

--- a/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/jdbcgenericavro/StreamsIngest.java
+++ b/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/jdbcgenericavro/StreamsIngest.java
@@ -33,7 +33,7 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import java.util.Properties;
 
 import io.confluent.examples.connectandstreams.avro.Location;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
 
 public class StreamsIngest {
@@ -68,7 +68,7 @@ public class StreamsIngest {
     streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
     streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, GenericAvroSerde.class);
-    streamsConfiguration.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL);
+    streamsConfiguration.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL);
 
     final KStream<String, GenericRecord> locationsGeneric = builder.stream(INPUT_TOPIC);
     locationsGeneric.print(Printed.toSysOut());

--- a/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/jdbcspecificavro/StreamsIngest.java
+++ b/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/jdbcspecificavro/StreamsIngest.java
@@ -35,7 +35,7 @@ import java.util.Collections;
 import java.util.Properties;
 
 import io.confluent.examples.connectandstreams.avro.Location;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
 
 public class StreamsIngest {
@@ -72,7 +72,7 @@ public class StreamsIngest {
     final Serde<Location> locationSerde = new SpecificAvroSerde<>();
     final boolean isKeySerde = false;
     locationSerde.configure(
-        Collections.singletonMap(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL),
+        Collections.singletonMap(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL),
         isKeySerde);
 
     final KStream<String, Location>

--- a/multi-datacenter/src/main/java/io/confluent/examples/clients/ConsumerMultiDatacenterExample.java
+++ b/multi-datacenter/src/main/java/io/confluent/examples/clients/ConsumerMultiDatacenterExample.java
@@ -1,6 +1,6 @@
 package io.confluent.examples.clients;
 
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -38,7 +38,7 @@ public class ConsumerMultiDatacenterExample {
         props.put(ConsumerConfig.GROUP_ID_CONFIG, "java-consumer-" + topic);
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
         props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
-        props.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl);
+        props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class);
 
@@ -57,7 +57,7 @@ public class ConsumerMultiDatacenterExample {
             consumer.subscribe(Collections.singletonList(topic));
 
             while (true) {
-                final ConsumerRecords<String, GenericRecord> records = consumer.poll(100);
+                final ConsumerRecords<String, GenericRecord> records = consumer.poll(Duration.ofMillis(100));
                 for (final ConsumerRecord<String, GenericRecord> record : records) {
                     final String key = record.key();
                     final GenericRecord value = record.value();


### PR DESCRIPTION
Update references to deprecated serde to non-deprecated counter part. Minor change to consumer poll to use Java Duration rather than long in multi-datacenter example. 

Testing:
- ran connect-streams-pipeline along and clients/cloud/java/.../StreamsAvroExample against local CP 
- ran multi-datacenter against docker-compose CP
ran demos prior to changes and after, same behavior   