### PR TITLE
DEVX-2147: Remove all references to deprecated GitHub repo configurat…

### DIFF
--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerAvroExample.java
@@ -44,7 +44,7 @@ public class ConsumerAvroExample {
     // Load properties from a local configuration file
     // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
     // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
-    // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
+    // Follow these instructions to create this file: https://docs.confluent.io/current/tutorials/examples/clients/docs/java.html
     final Properties props = loadConfig(args[0]);
 
     // Add additional properties.

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
@@ -44,7 +44,8 @@ public class ConsumerExample {
     // Load properties from a local configuration file
     // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
     // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
-    // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
+    // Follow these instructions to create this file: https://docs.confluent.io/current/tutorials/examples/clients/docs/java.html
+
     final Properties props = loadConfig(args[0]);
 
     // Add additional properties.

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExamplePageviews.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExamplePageviews.java
@@ -44,7 +44,8 @@ public class ConsumerExamplePageviews {
     // Load properties from a local configuration file
     // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
     // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
-    // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
+    // Follow these instructions to create this file: https://docs.confluent.io/current/tutorials/examples/clients/docs/java.html
+
     final Properties props = loadConfig(args[0]);
 
     // Add additional properties.

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerAvroExample.java
@@ -66,7 +66,7 @@ public class ProducerAvroExample {
     // Load properties from a local configuration file
     // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
     // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
-    // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
+    // Follow these instructions to create this file: https://docs.confluent.io/current/tutorials/examples/clients/docs/java.html
     final Properties props = loadConfig(args[0]);
 
     // Create topic if needed

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerExample.java
@@ -66,7 +66,7 @@ public class ProducerExample {
     // Load properties from a local configuration file
     // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
     // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
-    // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
+    // Follow these instructions to create this file: https://docs.confluent.io/current/tutorials/examples/clients/docs/java.html
     final Properties props = loadConfig(args[0]);
 
     // Create topic if needed

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsAvroExample.java
@@ -62,7 +62,7 @@ public class StreamsAvroExample {
         // Load properties from a local configuration file
         // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
         // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
-        // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
+        // Follow these instructions to create this file: https://docs.confluent.io/current/tutorials/examples/clients/docs/java.html
         final Properties props = loadConfig(args[0]);
 
         // Add additional properties.

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsExample.java
@@ -64,7 +64,7 @@ public class StreamsExample {
         // Load properties from a local configuration file
         // Create the configuration file (e.g. at '$HOME/.confluent/java.config') with configuration parameters
         // to connect to your Kafka cluster, which can be on your local host, Confluent Cloud, or any other cluster.
-        // Follow these detailed instructions to properly create this file: https://github.com/confluentinc/configuration-templates/tree/master/README.md
+        // Follow these instructions to create this file: https://docs.confluent.io/current/tutorials/examples/clients/docs/java.html
         final Properties props = loadConfig(args[0]);
 
         // Add additional properties.


### PR DESCRIPTION
…ion-templates

https://github.com/confluentinc/configuration-templates/ is deprecated, so update link in the comments in Java source code.

Validated: `mvn clean compile` and new link works https://docs.confluent.io/current/tutorials/examples/clients/docs/java.html
