### PR TITLE
DEVX-2175: Address issues in Java Spring client example

### DIFF
--- a/ccloud/ccloud-generate-cp-configs.sh
+++ b/ccloud/ccloud-generate-cp-configs.sh
@@ -122,8 +122,9 @@ BOOTSTRAP_SERVERS=${BOOTSTRAP_SERVERS/\\/}
 SASL_JAAS_CONFIG=$( grep "^sasl.jaas.config" $CONFIG_FILE | cut -d'=' -f2- )
 SASL_JAAS_CONFIG_PROPERTY_FORMAT=${SASL_JAAS_CONFIG/username\\=/username=}
 SASL_JAAS_CONFIG_PROPERTY_FORMAT=${SASL_JAAS_CONFIG_PROPERTY_FORMAT/password\\=/password=}
-CLOUD_KEY=$( echo $SASL_JAAS_CONFIG | awk '{print $3}' | awk -F'"' '$0=$2' )
-CLOUD_SECRET=$( echo $SASL_JAAS_CONFIG | awk '{print $4}' | awk -F'"' '$0=$2' )
+echo "SASL_JAAS_CONFIG: $SASL_JAAS_CONFIG"
+CLOUD_KEY=$( echo $SASL_JAAS_CONFIG | awk '{print $3}' | awk -F[\"\'] '$0=$2' )
+CLOUD_SECRET=$( echo $SASL_JAAS_CONFIG | awk '{print $4}' | awk -F[\"\'] '$0=$2' )
 
 # Schema Registry
 BASIC_AUTH_CREDENTIALS_SOURCE=$( grep "^basic.auth.credentials.source" $SR_CONFIG_FILE | awk -F'=' '{print $2;}' )

--- a/ccloud/ccloud-generate-cp-configs.sh
+++ b/ccloud/ccloud-generate-cp-configs.sh
@@ -59,7 +59,7 @@
 #   bootstrap.servers=<BROKER ENDPOINT>
 #   security.protocol=SASL_SSL
 #   sasl.mechanism=PLAIN
-#   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="<API KEY>" password\="<API SECRET>";
+#   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='<API KEY>' password='<API SECRET>';
 #
 # If you are using Confluent Cloud Schema Registry, add the following configuration parameters
 # either to file above (arg 1 CONFIG_FILE) or to a separate file (arg 2 SR_CONFIG_FILE)

--- a/ccloud/ccloud-generate-cp-configs.sh
+++ b/ccloud/ccloud-generate-cp-configs.sh
@@ -122,7 +122,6 @@ BOOTSTRAP_SERVERS=${BOOTSTRAP_SERVERS/\\/}
 SASL_JAAS_CONFIG=$( grep "^sasl.jaas.config" $CONFIG_FILE | cut -d'=' -f2- )
 SASL_JAAS_CONFIG_PROPERTY_FORMAT=${SASL_JAAS_CONFIG/username\\=/username=}
 SASL_JAAS_CONFIG_PROPERTY_FORMAT=${SASL_JAAS_CONFIG_PROPERTY_FORMAT/password\\=/password=}
-echo "SASL_JAAS_CONFIG: $SASL_JAAS_CONFIG"
 CLOUD_KEY=$( echo $SASL_JAAS_CONFIG | awk '{print $3}' | awk -F[\"\'] '$0=$2' )
 CLOUD_SECRET=$( echo $SASL_JAAS_CONFIG | awk '{print $4}' | awk -F[\"\'] '$0=$2' )
 

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -88,7 +88,7 @@ Create a ccloud-stack
       security.protocol=SASL_SSL
       sasl.mechanism=PLAIN
       bootstrap.servers=<BROKER ENDPOINT>
-      sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="<API KEY>" password\="<API SECRET>";
+      sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='<API KEY>' password='<API SECRET>';
       basic.auth.credentials.source=USER_INFO
       schema.registry.basic.auth.user.info=<SR API KEY>:<SR API SECRET>
       schema.registry.url=https://<SR ENDPOINT>

--- a/clients/cloud/clojure/src/io/confluent/examples/clients/clj/producer.clj
+++ b/clients/cloud/clojure/src/io/confluent/examples/clients/clj/producer.clj
@@ -28,7 +28,7 @@
 (defn producer! [config-fname topic]
   (let [props (build-properties config-fname)
         print-ex (comp println (partial str "Failed to deliver message: "))
-        print-metadata #(printf "Produced record to topic %s partiton [%d] @ offest %d\n"
+        print-metadata #(printf "Produced record to topic %s partition [%d] @ offest %d\n"
                                 (.topic %)
                                 (.partition %)
                                 (.offset %))

--- a/clients/cloud/java-springboot/src/main/resources/application.properties
+++ b/clients/cloud/java-springboot/src/main/resources/application.properties
@@ -5,22 +5,20 @@ io.confluent.developer.config.topic.partitions=6
 
 # common configs 
 spring.kafka.properties.sasl.mechanism=PLAIN
-spring.kafka.properties.request.timeout.ms=20000
 spring.kafka.properties.bootstrap.servers=${BOOTSTRAP_SERVERS}
-spring.kafka.properties.retry.backoff.ms=500
 spring.kafka.properties.sasl.jaas.config=${SASL_JAAS_CONFIG}
 spring.kafka.properties.security.protocol=SASL_SSL
 
-# Cloud SR Config
+# Confluent Cloud Schema Registry configuration
 spring.kafka.properties.basic.auth.credentials.source=USER_INFO
 spring.kafka.properties.schema.registry.basic.auth.user.info=${SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO}
 spring.kafka.properties.schema.registry.url=${SCHEMA_REGISTRY_URL}
 
-# producer configuration
+# Producer configuration
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
 
-# consumer configuration 
+# Consumer configuration 
 spring.kafka.consumer.group-id=java-springboot
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 spring.kafka.consumer.value-deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer

--- a/clients/cloud/java-springboot/src/main/resources/application.properties
+++ b/clients/cloud/java-springboot/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # topic config
-io.confluent.developer.config.topic.name=test
+io.confluent.developer.config.topic.name=test2
 io.confluent.developer.config.topic.replicas=3
 io.confluent.developer.config.topic.partitions=6
 

--- a/clients/cloud/java-springboot/src/main/resources/application.properties
+++ b/clients/cloud/java-springboot/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # topic config
-io.confluent.developer.config.topic.name=test2
+io.confluent.developer.config.topic.name=test
 io.confluent.developer.config.topic.replicas=3
 io.confluent.developer.config.topic.partitions=6
 

--- a/clients/cloud/java-springboot/startProducerConsumer.sh
+++ b/clients/cloud/java-springboot/startProducerConsumer.sh
@@ -10,7 +10,7 @@ source ../../../utils/ccloud_library.sh
 
 echo -e "\n${BLUE}\t☁️  Generating a config from Confluent Cloud properties... ${NC}\n"
 
-export CONFIG_FILE=~/.confluent/springboot.config
+export CONFIG_FILE=~/.confluent/java.config
 ccloud::validate_ccloud_config $CONFIG_FILE || exit
 
 SCHEMA_REGISTRY_CONFIG_FILE=$CONFIG_FILE

--- a/clients/cloud/java-springboot/startProducerConsumer.sh
+++ b/clients/cloud/java-springboot/startProducerConsumer.sh
@@ -13,9 +13,7 @@ echo -e "\n${BLUE}\t☁️  Generating a config from Confluent Cloud properties.
 export CONFIG_FILE=~/.confluent/java.config
 ccloud::validate_ccloud_config $CONFIG_FILE || exit
 
-SCHEMA_REGISTRY_CONFIG_FILE=$CONFIG_FILE
-
-../../../ccloud/ccloud-generate-cp-configs.sh $CONFIG_FILE $SCHEMA_REGISTRY_CONFIG_FILE
+../../../ccloud/ccloud-generate-cp-configs.sh $CONFIG_FILE
 
 DELTA_CONFIGS_DIR=delta_configs
 source $DELTA_CONFIGS_DIR/env.delta

--- a/clients/cloud/java-springboot/startProducerConsumer.sh
+++ b/clients/cloud/java-springboot/startProducerConsumer.sh
@@ -10,10 +10,10 @@ source ../../../utils/ccloud_library.sh
 
 echo -e "\n${BLUE}\t☁️  Generating a config from Confluent Cloud properties... ${NC}\n"
 
-export CONFIG_FILE=~/.ccloud/java.config
+export CONFIG_FILE=~/.confluent/springboot.config
 ccloud::validate_ccloud_config $CONFIG_FILE || exit
 
-SCHEMA_REGISTRY_CONFIG_FILE=$HOME/.ccloud/config
+SCHEMA_REGISTRY_CONFIG_FILE=$CONFIG_FILE
 
 ../../../ccloud/ccloud-generate-cp-configs.sh $CONFIG_FILE $SCHEMA_REGISTRY_CONFIG_FILE
 

--- a/clients/cloud/java-springboot/startStreams.sh
+++ b/clients/cloud/java-springboot/startStreams.sh
@@ -10,7 +10,7 @@ source ../../../utils/ccloud_library.sh
 
 echo -e "\n${BLUE}\t☁️  Generating a config from Confluent Cloud properties... ${NC}\n"
 
-export CONFIG_FILE=~/.confluent/springboot.config
+export CONFIG_FILE=~/.confluent/java.config
 ccloud::validate_ccloud_config $CONFIG_FILE || exit
 
 SCHEMA_REGISTRY_CONFIG_FILE=$CONFIG_FILE

--- a/clients/cloud/java-springboot/startStreams.sh
+++ b/clients/cloud/java-springboot/startStreams.sh
@@ -13,9 +13,7 @@ echo -e "\n${BLUE}\t☁️  Generating a config from Confluent Cloud properties.
 export CONFIG_FILE=~/.confluent/java.config
 ccloud::validate_ccloud_config $CONFIG_FILE || exit
 
-SCHEMA_REGISTRY_CONFIG_FILE=$CONFIG_FILE
-
-../../../ccloud/ccloud-generate-cp-configs.sh $CONFIG_FILE $SCHEMA_REGISTRY_CONFIG_FILE
+../../../ccloud/ccloud-generate-cp-configs.sh $CONFIG_FILE
 
 DELTA_CONFIGS_DIR=delta_configs
 source $DELTA_CONFIGS_DIR/env.delta

--- a/clients/cloud/java-springboot/startStreams.sh
+++ b/clients/cloud/java-springboot/startStreams.sh
@@ -10,10 +10,10 @@ source ../../../utils/ccloud_library.sh
 
 echo -e "\n${BLUE}\t☁️  Generating a config from Confluent Cloud properties... ${NC}\n"
 
-export CONFIG_FILE=~/.ccloud/java.config
+export CONFIG_FILE=~/.confluent/springboot.config
 ccloud::validate_ccloud_config $CONFIG_FILE || exit
 
-SCHEMA_REGISTRY_CONFIG_FILE=$HOME/.ccloud/config
+SCHEMA_REGISTRY_CONFIG_FILE=$CONFIG_FILE
 
 ../../../ccloud/ccloud-generate-cp-configs.sh $CONFIG_FILE $SCHEMA_REGISTRY_CONFIG_FILE
 

--- a/clients/docs/clojure.rst
+++ b/clients/docs/clojure.rst
@@ -68,21 +68,21 @@ Produce Records
          Producing record: alice     {"count":2}
          Producing record: alice     {"count":3}
          Producing record: alice     {"count":4}
-         Produced record to topic test1 partiton [0] @ offest 0
-         Produced record to topic test1 partiton [0] @ offest 1
-         Produced record to topic test1 partiton [0] @ offest 2
-         Produced record to topic test1 partiton [0] @ offest 3
-         Produced record to topic test1 partiton [0] @ offest 4
+         Produced record to topic test1 partition [0] @ offest 0
+         Produced record to topic test1 partition [0] @ offest 1
+         Produced record to topic test1 partition [0] @ offest 2
+         Produced record to topic test1 partition [0] @ offest 3
+         Produced record to topic test1 partition [0] @ offest 4
          Producing record: alice     {"count":5}
          Producing record: alice     {"count":6}
          Producing record: alice     {"count":7}
          Producing record: alice     {"count":8}
          Producing record: alice     {"count":9}
-         Produced record to topic test1 partiton [0] @ offest 5
-         Produced record to topic test1 partiton [0] @ offest 6
-         Produced record to topic test1 partiton [0] @ offest 7
-         Produced record to topic test1 partiton [0] @ offest 8
-         Produced record to topic test1 partiton [0] @ offest 9
+         Produced record to topic test1 partition [0] @ offest 5
+         Produced record to topic test1 partition [0] @ offest 6
+         Produced record to topic test1 partition [0] @ offest 7
+         Produced record to topic test1 partition [0] @ offest 8
+         Produced record to topic test1 partition [0] @ offest 9
          10 messages were produced to topic test1!
 
 

--- a/clients/docs/includes/client-example-create-file-java.rst
+++ b/clients/docs/includes/client-example-create-file-java.rst
@@ -4,7 +4,7 @@ configuration parameters to connect to your |ak| cluster. Starting with one of
 the templates below, customize the file with connection information to your
 cluster. Substitute your values for ``{{ BROKER_ENDPOINT }}``,
 ``{{CLUSTER_API_KEY }}``, and ``{{ CLUSTER_API_SECRET }}`` (see
-`Configure Confluent Cloud Clients <https://docs.confluent.io/cloud/using/config-client.html>`__ for instructions on how to create or find those
+`Configure Confluent Cloud Clients <https://docs.confluent.io/current/cloud/using/config-client.html>`__ for instructions on how to create or find those
 values).
 
 - Template configuration file for |ccloud|

--- a/clients/docs/includes/client-example-create-file-java.rst
+++ b/clients/docs/includes/client-example-create-file-java.rst
@@ -3,9 +3,9 @@ Create a local file (for example, at ``$HOME/.confluent/java.config``) with
 configuration parameters to connect to your |ak| cluster. Starting with one of
 the templates below, customize the file with connection information to your
 cluster. Substitute your values for ``{{ BROKER_ENDPOINT }}``,
-``{{CLUSTER_API_KEY }}``, and ``{{ CLUSTER_API_SECRET }}`` (see
-`Configure Confluent Cloud Clients <https://docs.confluent.io/current/cloud/using/config-client.html>`__ for instructions on how to create or find those
-values).
+``{{CLUSTER_API_KEY }}``, and ``{{ CLUSTER_API_SECRET }}``
+(see `Configure Confluent Cloud Clients <https://docs.confluent.io/current/cloud/using/config-client.html>`__
+for instructions on how to manually find these values, or use the :ref:`ccloud-stack` to automatically create them).
 
 - Template configuration file for |ccloud|
 

--- a/clients/docs/includes/client-example-create-file-librdkafka.rst
+++ b/clients/docs/includes/client-example-create-file-librdkafka.rst
@@ -4,7 +4,7 @@ with configuration parameters to connect to your |ak| cluster. Starting with one
 of the templates below, customize the file with connection information to your
 cluster. Substitute your values for ``{{ BROKER_ENDPOINT }}``,
 ``{{CLUSTER_API_KEY }}``, and ``{{ CLUSTER_API_SECRET }}`` (see
-`Configure Confluent Cloud Clients <https://docs.confluent.io/cloud/using/config-client.html>`__ for instructions on how to create or find those
+`Configure Confluent Cloud Clients <https://docs.confluent.io/current/cloud/using/config-client.html>`__ for instructions on how to create or find those
 values).
 
 - Template configuration file for |ccloud|

--- a/clients/docs/includes/client-example-create-file-librdkafka.rst
+++ b/clients/docs/includes/client-example-create-file-librdkafka.rst
@@ -3,9 +3,9 @@ Create a local file (for example, at ``$HOME/.confluent/librdkafka.config``)
 with configuration parameters to connect to your |ak| cluster. Starting with one
 of the templates below, customize the file with connection information to your
 cluster. Substitute your values for ``{{ BROKER_ENDPOINT }}``,
-``{{CLUSTER_API_KEY }}``, and ``{{ CLUSTER_API_SECRET }}`` (see
-`Configure Confluent Cloud Clients <https://docs.confluent.io/current/cloud/using/config-client.html>`__ for instructions on how to create or find those
-values).
+``{{CLUSTER_API_KEY }}``, and ``{{ CLUSTER_API_SECRET }}`` 
+(see `Configure Confluent Cloud Clients <https://docs.confluent.io/current/cloud/using/config-client.html>`__ 
+for instructions on how to manually find these values, or use the :ref:`ccloud-stack` to automatically create them).
 
 - Template configuration file for |ccloud|
 

--- a/clients/docs/includes/client-example-create-file-springboot.rst
+++ b/clients/docs/includes/client-example-create-file-springboot.rst
@@ -4,7 +4,7 @@ with configuration parameters to connect to your |ak| cluster. Starting with one
 of the templates below, customize the file with connection information to your
 cluster. Substitute your values for ``{{ BROKER_ENDPOINT }}``,
 ``{{CLUSTER_API_KEY }}``, and ``{{ CLUSTER_API_SECRET }}`` (see
-`Configure Confluent Cloud Clients <https://docs.confluent.io/cloud/using/config-client.html>`__ for instructions on how to create or find those
+`Configure Confluent Cloud Clients <https://docs.confluent.io/current/cloud/using/config-client.html>`__ for instructions on how to create or find those
 values).
 
 - Template configuration file for |ccloud|

--- a/clients/docs/includes/client-example-create-file-springboot.rst
+++ b/clients/docs/includes/client-example-create-file-springboot.rst
@@ -3,9 +3,9 @@ Create a local file (for example, at ``$HOME/.confluent/springboot.config``)
 with configuration parameters to connect to your |ak| cluster. Starting with one
 of the templates below, customize the file with connection information to your
 cluster. Substitute your values for ``{{ BROKER_ENDPOINT }}``,
-``{{CLUSTER_API_KEY }}``, and ``{{ CLUSTER_API_SECRET }}`` (see
-`Configure Confluent Cloud Clients <https://docs.confluent.io/current/cloud/using/config-client.html>`__ for instructions on how to create or find those
-values).
+``{{CLUSTER_API_KEY }}``, and ``{{ CLUSTER_API_SECRET }}`` 
+(see `Configure Confluent Cloud Clients <https://docs.confluent.io/current/cloud/using/config-client.html>`__ 
+for instructions on how to manually find these values, or use the :ref:`ccloud-stack` to automatically create them).
 
 - Template configuration file for |ccloud|
 

--- a/clients/docs/includes/configs/cloud/java-sr.config
+++ b/clients/docs/includes/configs/cloud/java-sr.config
@@ -1,7 +1,7 @@
 # Kafka
 bootstrap.servers={{ BROKER_ENDPOINT }}
 security.protocol=SASL_SSL
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
 sasl.mechanism=PLAIN
 
 # Confluent Cloud Schema Registry

--- a/clients/docs/includes/configs/cloud/java.config
+++ b/clients/docs/includes/configs/cloud/java.config
@@ -1,5 +1,5 @@
 # Kafka
 bootstrap.servers={{ BROKER_ENDPOINT }}
 security.protocol=SASL_SSL
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
 sasl.mechanism=PLAIN

--- a/clients/docs/includes/configs/cloud/springboot-sr.config
+++ b/clients/docs/includes/configs/cloud/springboot-sr.config
@@ -1,15 +1,10 @@
 # Kafka
 spring.kafka.properties.sasl.mechanism=PLAIN
 spring.kafka.properties.bootstrap.servers={{ BROKER_ENDPOINT }}
-spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
+spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
 spring.kafka.properties.security.protocol=SASL_SSL
-# Schema Registry 
+
+# Confluent Cloud Schema Registry
 spring.kafka.properties.basic.auth.credentials.source=USER_INFO
 spring.kafka.properties.schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
 spring.kafka.properties.schema.registry.url=https://{{ SR_ENDPOINT }}
-# producer configuration
-spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
-spring.kafka.producer.value-serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
-# consumer configuration 
-spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.consumer.value-deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer

--- a/clients/docs/includes/configs/cloud/springboot.config
+++ b/clients/docs/includes/configs/cloud/springboot.config
@@ -1,5 +1,5 @@
 # Kafka
 spring.kafka.properties.sasl.mechanism=PLAIN
 spring.kafka.properties.bootstrap.servers={{ BROKER_ENDPOINT }}
-spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
+spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
 spring.kafka.properties.security.protocol=SASL_SSL

--- a/clients/docs/java-springboot.rst
+++ b/clients/docs/java-springboot.rst
@@ -34,7 +34,7 @@ Setup
 
       cd clients/cloud/java-springboot/
 
-#. .. include:: includes/client-example-create-file-springboot.rst
+#. .. include:: includes/client-example-create-file-java.rst
 
 
 Avro and Confluent Cloud Schema Registry
@@ -46,9 +46,9 @@ Avro and Confluent Cloud Schema Registry
 
 #. .. include:: includes/client-example-vpc.rst
 
-#. .. include:: includes/schema-registry-springboot.rst
+#. .. include:: includes/schema-registry-java.rst
 
-#. .. include:: includes/client-example-schema-registry-2-springboot.rst
+#. .. include:: includes/client-example-schema-registry-2-java.rst
 
 
 Produce and Consume Records

--- a/kubernetes/docs/includes/replicator-cc-demo/ccloud-setup.rst
+++ b/kubernetes/docs/includes/replicator-cc-demo/ccloud-setup.rst
@@ -3,7 +3,7 @@
 
 This demonstration requires that you have a |ccloud| account and a |ak| cluster ready for use.  The `Confluent Cloud <https://www.confluent.io/confluent-cloud/>`__ home page can help you get setup with your own account if you do not yet have access.   
 
-.. note:: This demonstration highlights a multi-cloud replication strategy using |crep-full|.  One benefit of |crep| is that the destination cluster topics and partitions will be identicial in message offsets, timestamps, keys, and values.   If you re-use a cluster with an existing ``stock-trades`` topic, the messages will be appeneded to the end of the existing topic data and the offsets will not match the source cluster.  It's advised to build a new cluster for each run of this example, or delete the ``stock-trades`` |ak| topic in the destination cluster prior to running.  See: `ccloud kafka topic delete <https://docs.confluent.io/ccloud-cli/current/command-reference/kafka/topic/ccloud_kafka_topic_delete.html>`__ for instructions on deleting |ccloud| topics.
+.. note:: This demonstration highlights a multi-cloud replication strategy using |crep-full|.  One benefit of |crep| is that the destination cluster topics and partitions will be identical in message offsets, timestamps, keys, and values.   If you re-use a cluster with an existing ``stock-trades`` topic, the messages will be appended to the end of the existing topic data and the offsets will not match the source cluster.  It's advised to build a new cluster for each run of this example, or delete the ``stock-trades`` |ak| topic in the destination cluster prior to running.  See: `ccloud kafka topic delete <https://docs.confluent.io/ccloud-cli/current/command-reference/kafka/topic/ccloud_kafka_topic_delete.html>`__ for instructions on deleting |ccloud| topics.
 
 |ak| Cluster Setup
 +++++++++++++++++++
@@ -67,7 +67,7 @@ You can use the ``ccloud`` CLI to retrieve the bootstrap server value for your c
 
         ccloud kafka cluster describe lkc-3r3vj
 
-    This will produce a detailed view of the cluster.  The ``Endpoint`` field contains the Boostrap Server value
+    This will produce a detailed view of the cluster.  The ``Endpoint`` field contains the bootstrap server value
 
     ::
 

--- a/kubernetes/docs/includes/replicator-cc-demo/demo-execution.rst
+++ b/kubernetes/docs/includes/replicator-cc-demo/demo-execution.rst
@@ -4,7 +4,7 @@ To run the automated demo (estimated running time, 8 minutes):
 
     make demo
 
-The demo will deploy |cp| leverging |co-long|.   As the various components are deployed, the demonstration will echo the various commands as executing them so you can observe the process.  For example, the deployment message for |ak| will look similar to:
+The demo will deploy |cp| leveraging |co-long|.   As the various components are deployed, the demonstration will echo the various commands as executing them so you can observe the process.  For example, the deployment message for |ak| will look similar to:
 
 .. codewithvars:: bash
 

--- a/kubernetes/docs/includes/replicator-cc-demo/highlight-connector-deployment.rst
+++ b/kubernetes/docs/includes/replicator-cc-demo/highlight-connector-deployment.rst
@@ -1,7 +1,7 @@
 Deploying Kafka Connectors with Helm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following highlights a simple Helm chart that can be used to deploy |kconnect-long| Connector configurations using the standard `Kafka Connect REST Interface <https://docs.confluent.io/current/connect/references/restapi.html>`__.  This is how this demonstration deploys the |crep-full| configuration, however, the same method could be used to deploy any |kconnect-long| configuration.  In future versions of |co-long|, |kconnect-long| connectors wil be managed by the Operator `Controller <https://kubernetes.io/docs/concepts/architecture/controller/>`__.
+The following highlights a simple Helm chart that can be used to deploy |kconnect-long| Connector configurations using the standard `Kafka Connect REST Interface <https://docs.confluent.io/current/connect/references/restapi.html>`__.  This is how this demonstration deploys the |crep-full| configuration, however, the same method could be used to deploy any |kconnect-long| configuration.  In future versions of |co-long|, |kconnect-long| connectors will be managed by the Operator `Controller <https://kubernetes.io/docs/concepts/architecture/controller/>`__.
 
 The Helm chart is located in the ``kubernetes/common/helm/replicator-cc`` folder of this demonstration.  The ``templates/replicator-configmap.yaml`` file contains a ``data`` section with a templated JSON value that conforms to the |kconnect-long| `connectors API <https://docs.confluent.io/current/connect/references/restapi.html#post--connectors>`__.  The Destination and Source cluster configuration values are filled in at runtime by the ``helm`` templating system, and are proivded by your ``my-values.yaml`` file created in the demo instructions above.
 

--- a/kubernetes/docs/includes/replicator-cc-demo/verify-demo.rst
+++ b/kubernetes/docs/includes/replicator-cc-demo/verify-demo.rst
@@ -57,7 +57,7 @@ To view the ``stock-trades`` topic data streaming on both clusters, you can open
         CreateTime:1572380698577        ZJZZT
         CreateTime:1572380699340        ZVZZT
 
-    And in terminal 2 shortly after identicial messages:
+    And in terminal 2 shortly after identical messages:
 
     ::
 

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -948,7 +948,7 @@ EOF
 sasl.mechanism=PLAIN
 security.protocol=SASL_SSL
 bootstrap.servers=${BOOTSTRAP_SERVERS}
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="${CLOUD_API_KEY}" password\="${CLOUD_API_SECRET}";
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='${CLOUD_API_KEY}' password='${CLOUD_API_SECRET}';
 basic.auth.credentials.source=USER_INFO
 schema.registry.url=${SCHEMA_REGISTRY_ENDPOINT}
 schema.registry.basic.auth.user.info=`echo $SCHEMA_REGISTRY_CREDS | awk -F: '{print $1}'`:`echo $SCHEMA_REGISTRY_CREDS | awk -F: '{print $2}'`


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2175

Java spring code example was out of sync with the [documentation](https://docs.confluent.io/current/tutorials/examples/clients/docs/java-springboot.html?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud) for running it, so it just didn't work.   Note that the java spring code does not use the springboot.config provided in the includes, so it uses java.config and converts it in the [application.properties](https://github.com/confluentinc/examples/blob/6.0.0-post/clients/cloud/java-springboot/src/main/resources/application.properties) file.

This PR also changes the syntax of the ccloud config that gets auto-generated with `ccloud-stack` (note: removal of `\` and replace double quotes with single quotes), so it's important to validate that it continues to work for other examples as well.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation (blocked by documentation migration)
- [x] ccloud/ccloud-stack
- [x] clients/cloud/java-spring
- [x] clients/cloud/java
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

- [ ] Documentation
- [x] ccloud/ccloud-stack
- [x] clients/cloud/java-spring
- [x] clients/cloud/java
