### PR TITLE
DEVX-2073: Default REPLICATION_FACTOR for CCloud should be 3

### DIFF
--- a/microservices-orders/start-ccloud.sh
+++ b/microservices-orders/start-ccloud.sh
@@ -14,7 +14,7 @@ ccloud::validate_logged_in_ccloud_cli \
 
 printf "\n====== Create new Confluent Cloud stack\n"
 [[ -z "$NO_PROMPT" ]] && ccloud::prompt_continue_ccloud_demo
-REPLICATION_FACTOR=3 ccloud::create_ccloud_stack true
+ccloud::create_ccloud_stack true
 
 SERVICE_ACCOUNT_ID=$(ccloud kafka cluster list -o json | jq -r '.[0].name' | awk -F'-' '{print $4;}')
 if [[ "$SERVICE_ACCOUNT_ID" == "" ]]; then

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -855,7 +855,7 @@ function ccloud::set_kafka_cluster_use() {
 #
 function ccloud::create_ccloud_stack() {
   QUIET="${QUIET:-true}"
-  REPLICATION_FACTOR=${REPLICATION_FACTOR:-1}
+  REPLICATION_FACTOR=${REPLICATION_FACTOR:-3}
   enable_ksqldb=$1
 
   if [[ -z "$SERVICE_ACCOUNT_ID" ]]; then


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2073

This PR proposes we change the default for ccloud replication factor to be 3. We had set the RF in ```ccloud::create_ccloud_stack``` to default to 1. Multiple tutorials use this function, yet I don't see how this config change would impact anything except confluent cloud configs.  


### Author Validation

I have run the following examples, some cloud, local and docker. All behavior appeared as expected. Please let me know if there are any additional demos you would like me to validate, can attach screenshots as well. 
- [x]  ccloud/beginner-cloud
- [x] ccloud/ccloud-stack 
- [x] [ccloud hybrid](https://docs.confluent.io/current/tutorials/examples/ccloud/docs/index.html#quickstart-demos-ccloud) (docker, local, cloud)
- [x] microservices-orders (docker, cloud w/ screenshot of replicas)
<img width="1792" alt="Screen Shot 2020-10-16 at 9 17 50 AM" src="https://user-images.githubusercontent.com/12937975/96279199-96d3bc80-0f93-11eb-9549-10deea2c01bf.png">



### Reviewer Tasks

Reviewing either microservices-order or some demo that uses both ccloud and local/docker would be a good check and/or reviewing the context where ```ccloud::create_ccloud_stack```  is used to confirm that this change would only affect ccloud. 
- [] microservices-orders
- [] verify context of use of  ```ccloud::create_ccloud_stack```
