### PR TITLE
DEVX-2197: ccloud-stack should not create ksqlDB by default

### DIFF
--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -31,8 +31,10 @@ Caution
 
 This utility uses real |ccloud| resources.
 It is intended to be a quick way to create resources in |ccloud| with correct credentials and permissions, useful as a starting point from which you can then use for learning, extending, and building other examples.
-If you just run ``ccloud-stack`` without enabling |ccloud| ksqlDB, then there is no billing charge until you produce data to the |ak| cluster or provision any other fully-managed services.
-If you run ``ccloud-stack`` with enabling |ccloud| ksqlDB, then you will begin to accrue charges immediately.
+
+- If you just run ``ccloud-stack`` without explicitly enabling |ccloud| ksqlDB, then there is no billing charge until you produce data to the |ak| cluster or provision any other fully-managed services.
+- If you run ``ccloud-stack`` with enabling |ccloud| ksqlDB, then you will begin to accrue charges immediately.
+
 To avoid unexpected charges, carefully evaluate the cost of resources before launching the utility and ensure all resources are destroyed after you are done running it.
 
 Here is a list of |ccloud| CLI commands issued by the utility that create resources in |ccloud| (function ``ccloud::create_ccloud_stack()`` source code is in :devx-examples:`ccloud_library|utils/ccloud_library.sh`).
@@ -102,7 +104,7 @@ Create a ccloud-stack
 
       ./ccloud_stack_create.sh
 
-#. You will be prompted twice. Note the second prompt which is where you can optionally enable Confluent Cloud ksqlDB.
+#. You will be prompted twice. Note the second prompt which is where you can optionally enable |ccloud| ksqlDB.
 
    .. code-block:: text
 
@@ -264,16 +266,29 @@ If you don't want to create and destroy a ``ccloud-stack`` using the provided ba
 
       source ./ccloud_library.sh
 
-#. Run the bash functions directly from the command line. To create the ``cloud-stack``:
+#. Optionally set the ``CLUSTER_CLOUD`` and ``CLUSTER_REGION``.
 
    .. code:: bash
 
       CLUSTER_CLOUD=aws
       CLUSTER_REGION=us-west-2 
+
+#. Run the bash function directly from the command line.
+
+   To create the ``cloud-stack`` without |ccloud| ksqlDB:
+
+   .. code:: bash
+
       ccloud::create_ccloud_stack
 
+   To create the ``cloud-stack`` with |ccloud| ksqlDB:
 
-   To destroy the ``ccloud-stack``:
+   .. code:: bash
+
+      ccloud::create_ccloud_stack true
+
+
+#. To destroy the ``ccloud-stack``:
 
    .. code:: bash
 

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -266,7 +266,7 @@ If you don't want to create and destroy a ``ccloud-stack`` using the provided ba
 
       source ./ccloud_library.sh
 
-#. Optionally set the ``CLUSTER_CLOUD`` and ``CLUSTER_REGION``.
+#. Optionally override the ``CLUSTER_CLOUD`` and ``CLUSTER_REGION`` configuration parameters.
 
    .. code:: bash
 

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -856,7 +856,7 @@ function ccloud::set_kafka_cluster_use() {
 function ccloud::create_ccloud_stack() {
   QUIET="${QUIET:-true}"
   REPLICATION_FACTOR=${REPLICATION_FACTOR:-3}
-  enable_ksqldb=$1
+  enable_ksqldb=${1:-false}
 
   if [[ -z "$SERVICE_ACCOUNT_ID" ]]; then
     # Service Account is not received so it will be created


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2197

_What behavior does this PR change, and why?_

`ccloud-stack` default behavior, when run from bash, should be to NOT create ksqlDB app in CCloud

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [x] Documentation
- [x] ccloud/ccloud-stack
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

- [ ] Documentation
- [ ] ccloud/ccloud-stack
