### PR TITLE
DEVX-2212: Improves ccloud-stack usage of ccloud api-key list

### DIFF
--- a/ccloud/ccloud-stack/ccloud_stack_destroy.sh
+++ b/ccloud/ccloud-stack/ccloud_stack_destroy.sh
@@ -28,7 +28,7 @@ ccloud::validate_ccloud_config $CONFIG_FILE || exit 1
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 $DIR/../ccloud-generate-cp-configs.sh $CONFIG_FILE > /dev/null
 source delta_configs/env.delta
-SERVICE_ACCOUNT_ID=$(ccloud::get_service_account $CLOUD_KEY $CONFIG_FILE) || exit 1
+SERVICE_ACCOUNT_ID=$(ccloud::get_service_account $CLOUD_KEY) || exit 1
 
 echo
 ccloud::destroy_ccloud_stack $SERVICE_ACCOUNT_ID

--- a/ccloud/start-docker.sh
+++ b/ccloud/start-docker.sh
@@ -43,7 +43,7 @@ retry $MAX_WAIT ccloud::validate_ccloud_ksqldb_endpoint_ready $KSQLDB_ENDPOINT |
 ccloud::validate_ccloud_stack_up $CLOUD_KEY $CONFIG_FILE || exit 1
 
 echo ====== Set Kafka cluster and service account
-ccloud::set_kafka_cluster_use $CLOUD_KEY $CONFIG_FILE || exit 1
+ccloud::set_kafka_cluster_use_from_api_key $CLOUD_KEY || exit 1
 serviceAccount=$(ccloud::get_service_account $CLOUD_KEY) || exit 1
 
 echo ====== Set ACLs for Confluent Control Center and Kafka Connect

--- a/ccloud/start-docker.sh
+++ b/ccloud/start-docker.sh
@@ -44,7 +44,7 @@ ccloud::validate_ccloud_stack_up $CLOUD_KEY $CONFIG_FILE || exit 1
 
 echo ====== Set Kafka cluster and service account
 ccloud::set_kafka_cluster_use $CLOUD_KEY $CONFIG_FILE || exit 1
-serviceAccount=$(ccloud::get_service_account $CLOUD_KEY $CONFIG_FILE) || exit 1
+serviceAccount=$(ccloud::get_service_account $CLOUD_KEY) || exit 1
 
 echo ====== Set ACLs for Confluent Control Center and Kafka Connect
 ccloud::create_acls_control_center $serviceAccount

--- a/ccloud/start.sh
+++ b/ccloud/start.sh
@@ -79,7 +79,7 @@ printf "\n"
 
 echo ====== Set current Confluent Cloud 
 # Set Kafka cluster and service account
-ccloud::set_kafka_cluster_use $CLOUD_KEY $CONFIG_FILE || exit 1
+ccloud::set_kafka_cluster_use_from_api_key $CLOUD_KEY || exit 1
 serviceAccount=$(ccloud::get_service_account $CLOUD_KEY) || exit 1
 printf "\n"
 

--- a/ccloud/start.sh
+++ b/ccloud/start.sh
@@ -80,7 +80,7 @@ printf "\n"
 echo ====== Set current Confluent Cloud 
 # Set Kafka cluster and service account
 ccloud::set_kafka_cluster_use $CLOUD_KEY $CONFIG_FILE || exit 1
-serviceAccount=$(ccloud::get_service_account $CLOUD_KEY $CONFIG_FILE) || exit 1
+serviceAccount=$(ccloud::get_service_account $CLOUD_KEY) || exit 1
 printf "\n"
 
 echo ====== Validate Schema Registry credentials

--- a/cloud-etl/start.sh
+++ b/cloud-etl/start.sh
@@ -58,7 +58,7 @@ retry $MAX_WAIT ccloud::validate_ccloud_ksqldb_endpoint_ready $KSQLDB_ENDPOINT |
 ccloud::validate_ccloud_stack_up $CLOUD_KEY $CONFIG_FILE || exit 1
 
 # Set Kafka cluster
-ccloud::set_kafka_cluster_use $CLOUD_KEY $CONFIG_FILE || exit 1
+ccloud::set_kafka_cluster_use_from_api_key $CLOUD_KEY || exit 1
 
 #################################################################
 # Source: create and populate source endpoints

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -699,16 +699,19 @@ END
 }
 
 function ccloud::get_service_account() {
-  CLOUD_KEY=$1
-  CONFIG_FILE=$2
 
-  if [[ "$CLOUD_KEY" == "" ]]; then
-    echo "ERROR: could not parse the broker credentials from $CONFIG_FILE. Verify your credentials and try again."
-    exit 1
-  fi
-  serviceAccount=$(ccloud api-key list | grep "$CLOUD_KEY" | awk '{print $3;}')
+	[ -z "$1" ] && {
+		echo "ccloud::get_service_account expects one parameter (API Key)"
+		exit 1
+	}
+
+	[ $# -gt 1 ] && echo "WARN: ccloud::get_service_account function expects one parameter, received two"
+
+  local key="$1"
+
+  serviceAccount=$(ccloud api-key list -o json | jq -r -c 'map(select((.key == "'"$key"'"))) | .[].owner')
   if [[ "$serviceAccount" == "" ]]; then
-    echo "ERROR: Could not associate key $CLOUD_KEY to a service account. Verify your credentials, ensure the API key has a set resource type, and try again."
+    echo "ERROR: Could not associate key $key to a service account. Verify your credentials, ensure the API key has a set resource type, and try again."
     exit 1
   fi
   if ! [[ "$serviceAccount" =~ ^-?[0-9]+$ ]]; then


### PR DESCRIPTION
### Description 

Updates ccloud-stack usage of `ccloud api-key list` to use JSON output instead of row text parsing for increased reliability in output parsing.

Also includes some minor cleanup and naming changes with simple compatibilty and warning messages for functions.

https://confluentinc.atlassian.net/browse/DEVX-2212

### Author Validation

Individual commits have validation completed by manual execution of bash functions.

- [X] ccloud
- [X] ccloud/ccloud-stack

### Reviewer Tasks

- [ ] cloud-etl If someone would like to validate this demo with the changes, but not required
