### PR TITLE
 DEVX-2219: Add validate.sh for quick validation of example: multi-datacenter

### DIFF
--- a/multi-datacenter/start.sh
+++ b/multi-datacenter/start.sh
@@ -49,6 +49,7 @@ echo
 MAX_WAIT=300
 echo "Waiting up to $MAX_WAIT seconds for Confluent Control Center to start"
 retry $MAX_WAIT check_control_center_up control-center || exit 1
-echo "Control Center has started!"
 
-./read-topics.sh
+echo -e "\n\n\n******************************************************************"
+echo -e "DONE! Connect to Confluent Control Center at http://localhost:9021"
+echo -e "******************************************************************\n"

--- a/multi-datacenter/validate/validate-topics.sh
+++ b/multi-datacenter/validate/validate-topics.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+echo -e "multi-datacenter example: validate that the script at ${DIR}/../read-topics.sh completes"
+
+${DIR}/../read-topics.sh

--- a/multi-datacenter/validate/validate-topics.sh
+++ b/multi-datacenter/validate/validate-topics.sh
@@ -2,6 +2,6 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-echo -e "multi-datacenter example: validate that the script at ${DIR}/../read-topics.sh completes"
+echo -e "Validate that the script at ${DIR}/../read-topics.sh completes"
 
 ${DIR}/../read-topics.sh


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2219

_What behavior does this PR change, and why?_


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
- [x] multi-datacenter
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

No need to validate, just review the concept.  This is the first of a few that we will implement for all demos.  Note: the validation is meant to be simple with low investment.  cc: @sdanduConf WDYT?

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->
