### PR TITLE
DEVX-2251 & DEVX-2252: ccloud_stack_destroy.sh did not delete basic cluster as claimed; re-use env

### DIFF
--- a/ccloud/ccloud-stack/ccloud_stack_create.sh
+++ b/ccloud/ccloud-stack/ccloud_stack_create.sh
@@ -24,6 +24,12 @@ then
   enable_ksqldb=true
 fi
 
+if [[ -z "$ENVIRONMENT" ]]; then
+  STMT=""
+else
+  STMT="PRESERVE_ENVIRONMENT=true"
+fi
+
 echo
 ccloud::create_ccloud_stack $enable_ksqldb || exit 1
 
@@ -53,7 +59,7 @@ echo
 
 echo
 echo "To destroy this Confluent Cloud stack run ->"
-echo "    ./ccloud_stack_destroy.sh $CONFIG_FILE"
+echo "    $STMT ./ccloud_stack_destroy.sh $CONFIG_FILE"
 echo
 
 echo

--- a/ccloud/ccloud-stack/ccloud_stack_destroy.sh
+++ b/ccloud/ccloud-stack/ccloud_stack_destroy.sh
@@ -19,9 +19,9 @@ fi
 
 PRESERVE_ENVIRONMENT="${PRESERVE_ENVIRONMENT:-false}"
 if [[ $PRESERVE_ENVIRONMENT == "false" ]]; then
-  read -p "This script will destroy all the resources (including the environment itself) in $CONFIG_FILE.  Do you want to proceed? [y/n] " -n 1 -r
+  read -p "This script will destroy all the resources (including the Confluent Cloud environment) in $CONFIG_FILE.  Do you want to proceed? [y/n] " -n 1 -r
 else
-  read -p "This script will destroy all the resources (except the environment) in $CONFIG_FILE.  Do you want to proceed? [y/n] " -n 1 -r
+  read -p "This script will destroy all the resources (except the Confluent Cloud environment) in $CONFIG_FILE.  Do you want to proceed? [y/n] " -n 1 -r
 fi
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]

--- a/ccloud/ccloud-stack/ccloud_stack_destroy.sh
+++ b/ccloud/ccloud-stack/ccloud_stack_destroy.sh
@@ -17,7 +17,12 @@ else
   CONFIG_FILE=$1
 fi
 
-read -p "This script will destroy the entire environment specified in $CONFIG_FILE.  Do you want to proceed? [y/n] " -n 1 -r
+PRESERVE_ENVIRONMENT="${PRESERVE_ENVIRONMENT:-false}"
+if [[ $PRESERVE_ENVIRONMENT == "false" ]]; then
+  read -p "This script will destroy all the resources (including the environment itself) in $CONFIG_FILE.  Do you want to proceed? [y/n] " -n 1 -r
+else
+  read -p "This script will destroy all the resources (except the environment) in $CONFIG_FILE.  Do you want to proceed? [y/n] " -n 1 -r
+fi
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -249,16 +249,18 @@ Use Existing Environment
 ------------------------
 
 By default, a new ``ccloud-stack`` assumes a new environment.
-This means that, by default, ``./ccloud_stack_create.sh`` creates a new environment and ``./ccloud_stack_destroy.sh`` deletes the environment specified in the configuration file.
+This means that ``./ccloud_stack_create.sh`` creates a new environment and ``./ccloud_stack_destroy.sh`` deletes the environment specified in the configuration file.
 However, due to |ccloud| `environment limits per organization <https://docs.confluent.io/cloud/features.html#resource-limits-for-ccloud>`__, it may be desirable to work within an existing environment.
 
-To reuse an existing environment when creating a new ``ccloud-stack``, override the parameter ``ENVIRONMENT`` with an existing environment ID, as shown in the following example:
+By default, ``./ccloud_stack_create.sh`` creates a new environment.
+To reuse an existing environment when creating a new ``ccloud-stack``, set the parameter ``ENVIRONMENT`` with an existing environment ID, as shown in the example:
 
 .. code-block:: bash
 
    ENVIRONMENT=env-oxv5x ./ccloud_stack_create.sh
 
-To preserve the environment when destroying the ``ccloud-stack``, override set the parameter ``PRESERVE_ENVIRONMENT=true``, as shown in the following example:
+By default, ``./ccloud_stack_destroy.sh`` deletes the environment in the configuration file.
+To preserve the environment when destroying all the other resources in the ``ccloud-stack``, set the parameter ``PRESERVE_ENVIRONMENT=true``, as shown in the following example:
 
 .. code-block:: bash
 

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -245,7 +245,6 @@ By default, the ``cloud-stack`` utility creates resources in the cloud provider 
 
       CLUSTER_CLOUD=aws CLUSTER_REGION=us-west-2 ./ccloud_stack_create.sh
 
-
 Use Existing Environment
 ------------------------
 

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -245,14 +245,26 @@ By default, the ``cloud-stack`` utility creates resources in the cloud provider 
 
       CLUSTER_CLOUD=aws CLUSTER_REGION=us-west-2 ./ccloud_stack_create.sh
 
+
 Use Existing Environment
 ------------------------
 
-By default, a new ``ccloud-stack`` creates a new environment. To reuse an existing environment, create the ``ccloud-stack`` and override the parameter ``ENVIRONMENT`` with an existing environment ID, as shown in the following example:
+By default, a new ``ccloud-stack`` assumes a new environment.
+This means that, by default, ``./ccloud_stack_create.sh`` creates a new environment and ``./ccloud_stack_destroy.sh`` deletes the environment specified in the configuration file.
+However, due to |ccloud| `environment limits per organization <https://docs.confluent.io/cloud/features.html#resource-limits-for-ccloud>`__, it may be desirable to work within an existing environment.
+
+To reuse an existing environment when creating a new ``ccloud-stack``, override the parameter ``ENVIRONMENT`` with an existing environment ID, as shown in the following example:
 
 .. code-block:: bash
 
    ENVIRONMENT=env-oxv5x ./ccloud_stack_create.sh
+
+To preserve the environment when destroying the ``ccloud-stack``, override set the parameter ``PRESERVE_ENVIRONMENT=true``, as shown in the following example:
+
+.. code-block:: bash
+
+   PRESERVE_ENVIRONMENT=true ./ccloud_stack_destroy.sh stack-configs/java-service-account-<SERVICE_ACCOUNT_ID>.config
+
 
 
 ===================

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -215,7 +215,7 @@ Create a ccloud-stack
 Destroy a ccloud-stack
 ----------------------
 
-#. To destroy a ``cloud-stack`` created in the previous step, call the bash script :devx-examples:`ccloud_stack_destroy.sh|ccloud/ccloud-stack/ccloud_stack_destroy.sh` and pass in the client properties file auto-generated in the step above.
+#. To destroy a ``cloud-stack`` created in the previous step, call the bash script :devx-examples:`ccloud_stack_destroy.sh|ccloud/ccloud-stack/ccloud_stack_destroy.sh` and pass in the client properties file auto-generated in the step above. By default, this deletes all resources, including the |ccloud| environment specified by the service account ID in the configuration file.
 
    .. code:: bash
 
@@ -248,29 +248,25 @@ By default, the ``cloud-stack`` utility creates resources in the cloud provider 
 Use Existing Environment
 ------------------------
 
-By default, a new ``ccloud-stack`` assumes a new environment.
-This means that ``./ccloud_stack_create.sh`` creates a new environment and ``./ccloud_stack_destroy.sh`` deletes the environment specified in the configuration file.
+By default, a new ``ccloud-stack`` creates a new environment.
+This means that, by default, ``./ccloud_stack_create.sh`` creates a new environment and ``./ccloud_stack_destroy.sh`` deletes the environment specified in the configuration file.
 However, due to |ccloud| `environment limits per organization <https://docs.confluent.io/cloud/features.html#resource-limits-for-ccloud>`__, it may be desirable to work within an existing environment.
 
-By default, ``./ccloud_stack_create.sh`` creates a new environment.
 To reuse an existing environment when creating a new ``ccloud-stack``, set the parameter ``ENVIRONMENT`` with an existing environment ID, as shown in the example:
 
 .. code-block:: bash
 
    ENVIRONMENT=env-oxv5x ./ccloud_stack_create.sh
 
-By default, ``./ccloud_stack_destroy.sh`` deletes the environment in the configuration file.
-To preserve the environment when destroying all the other resources in the ``ccloud-stack``, set the parameter ``PRESERVE_ENVIRONMENT=true``, as shown in the following example:
+To preserve the environment when destroying all the other resources in the ``ccloud-stack``, set the parameter ``PRESERVE_ENVIRONMENT=true``, as shown in the following example.
+If you do not specify ``PRESERVE_ENVIRONMENT=true``, then the default behavior is that the environment specified by the service account ID in the configuration file is deleted.
 
 .. code-block:: bash
 
    PRESERVE_ENVIRONMENT=true ./ccloud_stack_destroy.sh stack-configs/java-service-account-<SERVICE_ACCOUNT_ID>.config
 
-
-
-===================
 Automated Workflows
-===================
+-------------------
 
 If you don't want to create and destroy a ``ccloud-stack`` using the provided bash scripts :devx-examples:`ccloud_stack_create.sh|ccloud/ccloud-stack/ccloud_stack_create.sh` and :devx-examples:`ccloud_stack_destroy.sh|ccloud/ccloud-stack/ccloud_stack_destroy.sh`, you may pull in the :devx-examples:`ccloud_library|utils/ccloud_library.sh` and call the functions ``ccloud::create_ccloud_stack()`` and ``ccloud::destroy_ccloud_stack()`` directly.
 
@@ -308,7 +304,7 @@ If you don't want to create and destroy a ``ccloud-stack`` using the provided ba
       ccloud::create_ccloud_stack true
 
 
-#. To destroy the ``ccloud-stack``:
+#. To destroy the ``ccloud-stack``, run the following command. By default, it deletes all resources, including the |ccloud| environment specified by the service account ID in the configuration file.
 
    .. code:: bash
 

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -975,6 +975,8 @@ EOF
 function ccloud::destroy_ccloud_stack() {
   SERVICE_ACCOUNT_ID=$1
 
+  PRESERVE_ENVIRONMENT="${PRESERVE_ENVIRONMENT:-false}"
+
   ENVIRONMENT_NAME=${ENVIRONMENT_NAME:-"demo-env-$SERVICE_ACCOUNT_ID"}
   CLUSTER_NAME=${CLUSTER_NAME:-"demo-kafka-cluster-$SERVICE_ACCOUNT_ID"}
   CLIENT_CONFIG=${CLIENT_CONFIG:-"stack-configs/java-service-account-$SERVICE_ACCOUNT_ID.config"}
@@ -1004,9 +1006,11 @@ function ccloud::destroy_ccloud_stack() {
   echo "Deleting CLUSTER: $CLUSTER_NAME : $cluster_id"
   ccloud kafka cluster delete $cluster_id &> "$REDIRECT_TO"
 
-  local environment_id=$(ccloud environment list -o json | jq -r 'map(select(.name == "'"$ENVIRONMENT_NAME"'")) | .[].id')
-  echo "Deleting ENVIRONMENT: $ENVIRONMENT_NAME : $environment_id"
-  ccloud environment delete $environment_id &> "$REDIRECT_TO"
+  if [[ $PRESERVE_ENVIRONMENT == "false" ]]; then
+    local environment_id=$(ccloud environment list -o json | jq -r 'map(select(.name == "'"$ENVIRONMENT_NAME"'")) | .[].id')
+    echo "Deleting ENVIRONMENT: $ENVIRONMENT_NAME : $environment_id"
+    ccloud environment delete $environment_id &> "$REDIRECT_TO"
+  fi
   
   rm -f $CLIENT_CONFIG
 

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -286,8 +286,8 @@ function ccloud::validate_schema_registry_up() {
 function ccloud::create_and_use_environment() {
   ENVIRONMENT_NAME=$1
 
-  OUTPUT=$(ccloud environment create $ENVIRONMENT_NAME -o json) || \
-    echo "ERROR: Failed to create environment $ENVIRONMENT_NAME. Please troubleshoot (maybe run ./clean.sh) and run again" && exit 1
+  OUTPUT=$(ccloud environment create $ENVIRONMENT_NAME -o json)
+  (($? != 0)) && { echo "ERROR: Failed to create environment $ENVIRONMENT_NAME. Please troubleshoot (maybe run ./clean.sh) and run again"; exit 1; }
   ENVIRONMENT=$(echo "$OUTPUT" | jq -r ".id")
   ccloud environment use $ENVIRONMENT &>/dev/null
 
@@ -880,8 +880,8 @@ function ccloud::create_ccloud_stack() {
   then
     # Environment is not received so it will be created
     ENVIRONMENT_NAME=${ENVIRONMENT_NAME:-"demo-env-$SERVICE_ACCOUNT_ID"}
-    ENVIRONMENT=$(ccloud::create_and_use_environment $ENVIRONMENT_NAME) || \
-      echo "$ENVIRONMENT" && exit 1
+    ENVIRONMENT=$(ccloud::create_and_use_environment $ENVIRONMENT_NAME)
+    (($? != 0)) && { echo "$ENVIRONMENT"; exit 1; }
   else
     ccloud environment use $ENVIRONMENT &>/dev/null
   fi

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -885,7 +885,6 @@ function ccloud::create_ccloud_stack() {
   else
     ccloud environment use $ENVIRONMENT &>/dev/null
   fi
-  exit 1
   
   CLUSTER_NAME=${CLUSTER_NAME:-"demo-kafka-cluster-$SERVICE_ACCOUNT_ID"}
   CLUSTER_CLOUD="${CLUSTER_CLOUD:-aws}"

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -1008,8 +1008,12 @@ function ccloud::destroy_ccloud_stack() {
 
   if [[ $PRESERVE_ENVIRONMENT == "false" ]]; then
     local environment_id=$(ccloud environment list -o json | jq -r 'map(select(.name == "'"$ENVIRONMENT_NAME"'")) | .[].id')
-    echo "Deleting ENVIRONMENT: $ENVIRONMENT_NAME : $environment_id"
-    ccloud environment delete $environment_id &> "$REDIRECT_TO"
+    if [[ "$environment_id" == "" ]]; then
+      echo "WARNING: Could not find environment with name $ENVIRONMENT_NAME (did you create this ccloud-stack reusing an existing environment?)"
+    else
+      echo "Deleting ENVIRONMENT: $ENVIRONMENT_NAME : $environment_id"
+      ccloud environment delete $environment_id &> "$REDIRECT_TO"
+    fi
   fi
   
   rm -f $CLIENT_CONFIG


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2251
https://confluentinc.atlassian.net/browse/DEVX-2252

_What behavior does this PR change, and why?_

- catch env errors on creation
- make deletion output more verbose
- preserve env on deletion


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation: see https://github.com/confluentinc/docs/pull/5974
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
- [ ] ccloud/ccloud-stack
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation: see https://github.com/confluentinc/docs/pull/5974
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
- [ ] ccloud/ccloud-stack
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->
