### PR TITLE
DEVX-2257: Fix collateral damage from DOCS-5317 (lines to include)

### DIFF
--- a/ccloud/docs/includes/connect-worker-to-destination-ccloud.rst
+++ b/ccloud/docs/includes/connect-worker-to-destination-ccloud.rst
@@ -6,14 +6,14 @@ Set the management topics to replication factor of 3 as required by |ccloud|.
 The |kconnect| worker's admin client requires connection information to the destination |ccloud|.
 
 .. literalinclude:: config/connect-ccloud-destination.delta
-   :lines: 6-11
+   :lines: 6-10
 
 The |kconnect| worker's embedded producer requires connection information to the destination |ccloud|.
 
 .. literalinclude:: config/connect-ccloud-destination.delta
-   :lines: 14-17
+   :lines: 12-15
 
 If you are using |c3| and doing stream monitoring then the embedded producer's monitoring interceptors require connection information to the destination |ccloud|.
 
 .. literalinclude:: config/connect-ccloud-destination.delta
-   :lines: 26-29
+   :lines: 22-25

--- a/ccloud/docs/includes/connect-worker-to-origin-ccloud.rst
+++ b/ccloud/docs/includes/connect-worker-to-origin-ccloud.rst
@@ -6,14 +6,14 @@ Set the management topics to replication factor of 3 as required by |ccloud|.
 The |kconnect| worker's admin client requires connection information to the origin |ccloud|.
 
 .. literalinclude:: config/connect-ccloud-origin.delta
-   :lines: 6-11
+   :lines: 6-10
 
 The |kconnect| worker's embedded producer requires connection information to the origin |ccloud|.
 
 .. literalinclude:: config/connect-ccloud-origin.delta
-   :lines: 14-17
+   :lines: 12-15
 
 If you are using |c3| and doing stream monitoring then the embedded producer's monitoring interceptors require connection information to the origin |ccloud|.
 
 .. literalinclude:: config/connect-ccloud-origin.delta
-   :lines: 26-29
+   :lines: 22-25


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2257

_What behavior does this PR change, and why?_

Page: https://docs.confluent.io/current/tutorials/examples/ccloud/docs/replicator-to-cloud-configuration-types.html
Issue: Replicator docs include lines misaligned


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->

- [x] Validate docs build for https://docs.confluent.io/current/tutorials/examples/ccloud/docs/replicator-to-cloud-configuration-types.html


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->
