### PR TITLE
DEVX-2324: Two source datagen connector went in degraded state (task …

### DIFF
--- a/clickstream/ksql/ksql-clickstream-demo/demo/create-connectors.sql
+++ b/clickstream/ksql/ksql-clickstream-demo/demo/create-connectors.sql
@@ -3,7 +3,6 @@ CREATE SOURCE CONNECTOR datagen_clickstream_codes WITH (
   'kafka.topic'              = 'clickstream_codes',
   'quickstart'               = 'clickstream_codes',
   'maxInterval'              = '20',
-  'iterations'               = '100',
   'format'                   = 'json',
   'key.converter'            = 'org.apache.kafka.connect.converters.IntegerConverter');
 
@@ -12,7 +11,6 @@ CREATE SOURCE CONNECTOR datagen_clickstream_users WITH (
   'kafka.topic'              = 'clickstream_users',
   'quickstart'               = 'clickstream_users',
   'maxInterval'              = '10',
-  'iterations'               = '1000',
   'format'                   = 'json',
   'key.converter'            = 'org.apache.kafka.connect.converters.IntegerConverter');
 


### PR DESCRIPTION
…failed) state just after deployment

### Description 

https://confluentinc.atlassian.net/browse/DEVX-2324

_What behavior does this PR change, and why?_

History: the datagen connectors used to run indefinitely because the iterations parameter was misspelled. The spelling error was fixed in https://github.com/confluentinc/examples/pull/871/files#diff-1f0220c18c3cb85a6616f5532f4f4ef55314d53f5a680faaf990dc48965661c1R133 , and consequently the datagen connector stops after iterations number is reached and generates those log messages – this is expected and working as designed. However, the docs were not updated to reflect this.

Resolution: remove `iterations` parameter completely to avoid connector log messages, connectors won't show degraded state (which might be confusing for users), docs won't need to change

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
- [x] clickstream
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
- [x] clickstream
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->
