### PR TITLE
DEVX-2341: build_docker_images.sh does not run from scripts directory

### DIFF
--- a/multiregion/scripts/build_docker_images.sh
+++ b/multiregion/scripts/build_docker_images.sh
@@ -7,5 +7,5 @@ source ${DIR}/../.env
 echo
 echo "Build custom cp-zookeeper and cp-server images with 'tc' installed"
 for image in cp-zookeeper cp-server; do
-  docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg REPOSITORY=${REPOSITORY} --build-arg IMAGE=$image -t localbuild/${image}-tc:${CONFLUENT_DOCKER_TAG} -f Dockerfile .
+  docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg REPOSITORY=${REPOSITORY} --build-arg IMAGE=$image -t localbuild/${image}-tc:${CONFLUENT_DOCKER_TAG} -f ${DIR}/../Dockerfile ${DIR}/../.
 done


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2341

_What behavior does this PR change, and why?_

Allow `build_docker_images.sh` to be run from within the scripts folder

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
- [x] multiregion
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->
