### PR TITLE
DEVX-2386: simplify SR subject check example to single command

### DIFF
--- a/clients/docs/includes/client-example-schema-registry-2-java.rst
+++ b/clients/docs/includes/client-example-schema-registry-2-java.rst
@@ -1,4 +1,4 @@
-Verify your |ccloud| |sr| credentials by trying to list the |sr| subjects.
+Verify your |ccloud| |sr| credentials by listing the |sr| subjects.
 In the following example, substitute your values for ``{{ SR_API_KEY }}``,
 ``{{ SR_API_SECRET }}``, and ``{{ SR_ENDPOINT }}``.
 

--- a/clients/docs/includes/client-example-schema-registry-2-java.rst
+++ b/clients/docs/includes/client-example-schema-registry-2-java.rst
@@ -1,11 +1,7 @@
-Verify your |ccloud| |sr| credentials work from your host.
+Verify your |ccloud| |sr| credentials by trying to list the |sr| subjects.
 In the following example, substitute your values for ``{{ SR_API_KEY}}``,
 ``{{SR_API_SECRET }}``, and ``{{ SR_ENDPOINT }}``.
 
 .. code-block:: text
 
-   # View the list of registered subjects
-   $ curl -u {{ SR_API_KEY }}:{{ SR_API_SECRET }} https://{{ SR_ENDPOINT }}/subjects
-
-   # Same as above, as a single bash command to parse the values out of  $HOME/.confluent/java.config
-   $ curl -u $(grep "^schema.registry.basic.auth.user.info"  $HOME/.confluent/java.config | cut -d'=' -f2) $(grep "^schema.registry.url"  $HOME/.confluent/java.config | cut -d'=' -f2)/subjects
+   curl -u {{ SR_API_KEY }}:{{ SR_API_SECRET }} https://{{ SR_ENDPOINT }}/subjects

--- a/clients/docs/includes/client-example-schema-registry-2-java.rst
+++ b/clients/docs/includes/client-example-schema-registry-2-java.rst
@@ -1,6 +1,6 @@
 Verify your |ccloud| |sr| credentials by trying to list the |sr| subjects.
-In the following example, substitute your values for ``{{ SR_API_KEY}}``,
-``{{SR_API_SECRET }}``, and ``{{ SR_ENDPOINT }}``.
+In the following example, substitute your values for ``{{ SR_API_KEY }}``,
+``{{ SR_API_SECRET }}``, and ``{{ SR_ENDPOINT }}``.
 
 .. code-block:: text
 

--- a/clients/docs/includes/client-example-schema-registry-2-librdkafka.rst
+++ b/clients/docs/includes/client-example-schema-registry-2-librdkafka.rst
@@ -1,4 +1,4 @@
-Verify your |ccloud| |sr| credentials by trying to list the |sr| subjects.
+Verify your |ccloud| |sr| credentials by listing the |sr| subjects.
 In the following example, substitute your values for ``{{ SR_API_KEY }}``,
 ``{{ SR_API_SECRET }}``, and ``{{ SR_ENDPOINT }}``.
 

--- a/clients/docs/includes/client-example-schema-registry-2-librdkafka.rst
+++ b/clients/docs/includes/client-example-schema-registry-2-librdkafka.rst
@@ -1,6 +1,6 @@
 Verify your |ccloud| |sr| credentials by trying to list the |sr| subjects.
-In the following example, substitute your values for ``{{ SR_API_KEY}}``,
-``{{SR_API_SECRET }}``, and ``{{ SR_ENDPOINT }}``.
+In the following example, substitute your values for ``{{ SR_API_KEY }}``,
+``{{ SR_API_SECRET }}``, and ``{{ SR_ENDPOINT }}``.
 
 .. code-block:: text
 

--- a/clients/docs/includes/client-example-schema-registry-2-librdkafka.rst
+++ b/clients/docs/includes/client-example-schema-registry-2-librdkafka.rst
@@ -1,11 +1,7 @@
-Verify your |ccloud| |sr| credentials work from your host.
+Verify your |ccloud| |sr| credentials by trying to list the |sr| subjects.
 In the following example, substitute your values for ``{{ SR_API_KEY}}``,
 ``{{SR_API_SECRET }}``, and ``{{ SR_ENDPOINT }}``.
 
 .. code-block:: text
 
-   # View the list of registered subjects
-   $ curl -u {{ SR_API_KEY }}:{{ SR_API_SECRET }} https://{{ SR_ENDPOINT }}/subjects
-
-   # Same as above, as a single bash command to parse the values out of  $HOME/.confluent/librdkafka.config
-   $ curl -u $(grep "^schema.registry.basic.auth.user.info"  $HOME/.confluent/librdkafka.config | cut -d'=' -f2) $(grep "^schema.registry.url"  $HOME/.confluent/librdkafka.config | cut -d'=' -f2)/subjects
+   curl -u {{ SR_API_KEY }}:{{ SR_API_SECRET }} https://{{ SR_ENDPOINT }}/subjects

--- a/clients/docs/includes/client-example-schema-registry-2-springboot.rst
+++ b/clients/docs/includes/client-example-schema-registry-2-springboot.rst
@@ -1,4 +1,4 @@
-Verify your |ccloud| |sr| credentials by trying to list the |sr| subjects.
+Verify your |ccloud| |sr| credentials by listing the |sr| subjects.
 In the following example, substitute your values for ``{{ SR_API_KEY }}``,
 ``{{ SR_API_SECRET }}``, and ``{{ SR_ENDPOINT }}``.
 

--- a/clients/docs/includes/client-example-schema-registry-2-springboot.rst
+++ b/clients/docs/includes/client-example-schema-registry-2-springboot.rst
@@ -1,11 +1,7 @@
-Verify your |ccloud| |sr| credentials work from your host.
+Verify your |ccloud| |sr| credentials by trying to list the |sr| subjects.
 In the following example, substitute your values for ``{{ SR_API_KEY}}``,
 ``{{SR_API_SECRET }}``, and ``{{ SR_ENDPOINT }}``.
 
 .. code-block:: text
 
-   # View the list of registered subjects
-   $ curl -u {{ SR_API_KEY }}:{{ SR_API_SECRET }} https://{{ SR_ENDPOINT }}/subjects
-
-   # Same as above, as a single bash command to parse the values out of  $HOME/.confluent/springboot.config
-   $ curl -u $(grep "^schema.registry.basic.auth.user.info"  $HOME/.confluent/springboot.config | cut -d'=' -f2) $(grep "^schema.registry.url"  $HOME/.confluent/springboot.config | cut -d'=' -f2)/subjects
+   curl -u {{ SR_API_KEY }}:{{ SR_API_SECRET }} https://{{ SR_ENDPOINT }}/subjects

--- a/clients/docs/includes/client-example-schema-registry-2-springboot.rst
+++ b/clients/docs/includes/client-example-schema-registry-2-springboot.rst
@@ -1,6 +1,6 @@
 Verify your |ccloud| |sr| credentials by trying to list the |sr| subjects.
-In the following example, substitute your values for ``{{ SR_API_KEY}}``,
-``{{SR_API_SECRET }}``, and ``{{ SR_ENDPOINT }}``.
+In the following example, substitute your values for ``{{ SR_API_KEY }}``,
+``{{ SR_API_SECRET }}``, and ``{{ SR_ENDPOINT }}``.
 
 .. code-block:: text
 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2386

_What behavior does this PR change, and why?_

Simplify command for the user

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [x] Documentation
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation: no need to build (I validated build passes), just eyeball the change please
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->
