### PR TITLE
DEVX-2387: delete fully-managed connectors in ccloud-stack destroy

### DIFF
--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -1016,7 +1016,7 @@ function ccloud::destroy_ccloud_stack() {
     ccloud ksql app delete $ksqldb_id &> "$REDIRECT_TO"
   fi
 
-  # Delete connectors associated to this Kafka cluster, otherwise cluster deletion will error
+  # Delete connectors associated to this Kafka cluster, otherwise cluster deletion fails
   local cluster_id=$(ccloud kafka cluster list -o json | jq -r 'map(select(.name == "'"$CLUSTER_NAME"'")) | .[].id')
   ccloud connector list --cluster $cluster_id -o json | jq -r '.[].id' | xargs -I{} ccloud connector delete {}
 

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -1016,7 +1016,10 @@ function ccloud::destroy_ccloud_stack() {
     ccloud ksql app delete $ksqldb_id &> "$REDIRECT_TO"
   fi
 
+  # Delete connectors associated to this Kafka cluster, otherwise cluster deletion will error
   local cluster_id=$(ccloud kafka cluster list -o json | jq -r 'map(select(.name == "'"$CLUSTER_NAME"'")) | .[].id')
+  ccloud connector list --cluster $cluster_id -o json | jq -r '.[].id' | xargs -I{} ccloud connector delete {}
+
   echo "Deleting CLUSTER: $CLUSTER_NAME : $cluster_id"
   ccloud kafka cluster delete $cluster_id &> "$REDIRECT_TO"
 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2387

_What behavior does this PR change, and why?_

Prevent error on ccloud stack destroy (note that ccloud stack destroy still successfully deletes the environment without this PR)

```
	* error deleting kafka cluster: Cannot delete Kafka cluster with associated connect clusters: [datagen_ccloud_users, datagen_ccloud_pageviews]
```

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
- [x] ccloud/ccloud-stack (I validated this by running https://github.com/confluentinc/examples/blob/6.0.1-post/cp-quickstart/start-cloud.sh)
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
- [ ] ccloud/ccloud-stack
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->
