### PR TITLE
DEVX-2403: ccloud-stack error if environment does not exist

### DIFF
--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -895,7 +895,8 @@ function ccloud::create_ccloud_stack() {
     ENVIRONMENT=$(ccloud::create_and_use_environment $ENVIRONMENT_NAME)
     (($? != 0)) && { echo "$ENVIRONMENT"; exit 1; }
   else
-    ccloud environment use $ENVIRONMENT &>/dev/null
+    OUTPUT=$(ccloud environment use $ENVIRONMENT)
+    (($? != 0)) && { echo "$OUTPUT"; exit 1; }
   fi
   
   CLUSTER_NAME=${CLUSTER_NAME:-"demo-kafka-cluster-$SERVICE_ACCOUNT_ID"}

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -895,8 +895,7 @@ function ccloud::create_ccloud_stack() {
     ENVIRONMENT=$(ccloud::create_and_use_environment $ENVIRONMENT_NAME)
     (($? != 0)) && { echo "$ENVIRONMENT"; exit 1; }
   else
-    OUTPUT=$(ccloud environment use $ENVIRONMENT)
-    (($? != 0)) && { echo "$OUTPUT"; exit 1; }
+    ccloud environment use $ENVIRONMENT || exit 1
   fi
   
   CLUSTER_NAME=${CLUSTER_NAME:-"demo-kafka-cluster-$SERVICE_ACCOUNT_ID"}


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2403

_What behavior does this PR change, and why?_


Fail fast if environment does not exit

```
$ ENVIRONMENT=dummy ./ccloud_stack_create.sh
....

Creating Confluent Cloud stack for service account demo-app-8408, ID: 163253.
Error: environment "dummy" not found

Suggestions:
    List available environments with `ccloud environment list`.

```

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
- [x] ccloud/ccloud-stack
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
- [ ] ccloud/ccloud-stack
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->
