### PR TITLE
DEVX-2114: Adds kafka-devops refs to existing Kubernetes demos

### DIFF
--- a/ccloud/docs/ccloud-demos-overview.rst
+++ b/ccloud/docs/ccloud-demos-overview.rst
@@ -123,6 +123,8 @@ Kafka DevOps
 
 The :ref:`kafka-devops` project is a simulated production environment running a streaming application targeting |ak-tm| on |ccloud|.  Applications and resources are managed by GitOps with a declarative infrastructure, Kubernetes, and the Operator Pattern.
 
+.. figure:: ../../images/github-flux-kubernetes-600x105.png
+
 =========================
 Build Your Own Cloud Demo
 =========================

--- a/ccloud/docs/ccloud-demos-overview.rst
+++ b/ccloud/docs/ccloud-demos-overview.rst
@@ -121,7 +121,7 @@ You can choose between two examples:
 Kafka DevOps
 ------------
 
-The :ref:`kafka_devops` project is a simulated production environment running a streaming application targeting |ak-long| on |ccloud|.  Applications and resources are managed by GitOps with a declarative infrastructure, Kubernetes, and the Operator Pattern.
+The :ref:`kafka-devops` project is a simulated production environment running a streaming application targeting |ak-long| on |ccloud|.  Applications and resources are managed by GitOps with a declarative infrastructure, Kubernetes, and the Operator Pattern.
 
 =========================
 Build Your Own Cloud Demo

--- a/ccloud/docs/ccloud-demos-overview.rst
+++ b/ccloud/docs/ccloud-demos-overview.rst
@@ -118,6 +118,10 @@ You can choose between two examples:
 
 .. figure:: ../../kubernetes/replicator-gke-cc/docs/images/operator-demo-phase-2.png
 
+Kafka DevOps
+------------
+
+The :ref:`kafka_devops` project is a simulated production environment running a streaming application targeting |ak-long| on |ccloud|.  Applications and resources are managed by GitOps with a declarative infrastructure, Kubernetes, and the Operator Pattern.
 
 =========================
 Build Your Own Cloud Demo

--- a/ccloud/docs/ccloud-demos-overview.rst
+++ b/ccloud/docs/ccloud-demos-overview.rst
@@ -121,7 +121,7 @@ You can choose between two examples:
 Kafka DevOps
 ------------
 
-The :ref:`kafka-devops` project is a simulated production environment running a streaming application targeting |ak-tm| on |ccloud|.  Applications and resources are managed by GitOps with a declarative infrastructure, Kubernetes, and the Operator Pattern.
+The :ref:`kafka-devops` project is a simulated production-environment running a streaming application targeting |ak-tm| on |ccloud|.  Applications and resources are managed by GitOps with a declarative infrastructure, Kubernetes, and the Operator Pattern.
 
 .. figure:: ../../images/github-flux-kubernetes-600x105.png
 

--- a/ccloud/docs/ccloud-demos-overview.rst
+++ b/ccloud/docs/ccloud-demos-overview.rst
@@ -121,7 +121,7 @@ You can choose between two examples:
 Kafka DevOps
 ------------
 
-The :ref:`kafka-devops` project is a simulated production environment running a streaming application targeting |ak-long| on |ccloud|.  Applications and resources are managed by GitOps with a declarative infrastructure, Kubernetes, and the Operator Pattern.
+The :ref:`kafka-devops` project is a simulated production environment running a streaming application targeting |ak-tm| on |ccloud|.  Applications and resources are managed by GitOps with a declarative infrastructure, Kubernetes, and the Operator Pattern.
 
 =========================
 Build Your Own Cloud Demo

--- a/kubernetes/docs/includes/base-demo/overview.rst
+++ b/kubernetes/docs/includes/base-demo/overview.rst
@@ -3,7 +3,7 @@ Overview
 
 This demo shows a deployment of |cp| on |k8s-service-name-long| (|k8s-service-name|) leveraging |co-long| with mock data generation provided via the `Kafka Connect Datagen <https://www.confluent.io/hub/confluentinc/kafka-connect-datagen>`__.
 
-.. note:: See the :ref:`kafka_devops` project for an example of using Kubernetes in a production-like environment targeting |ccloud|.
+.. note:: See the :ref:`kafka-devops` project for an example of using Kubernetes in a production-like environment targeting |ccloud|.
 
 The major components of this demo are:
 

--- a/kubernetes/docs/includes/base-demo/overview.rst
+++ b/kubernetes/docs/includes/base-demo/overview.rst
@@ -3,7 +3,7 @@ Overview
 
 This demo shows a deployment of |cp| on |k8s-service-name-long| (|k8s-service-name|) leveraging |co-long| with mock data generation provided via the `Kafka Connect Datagen <https://www.confluent.io/hub/confluentinc/kafka-connect-datagen>`__.
 
-.. note:: See the :ref:`kafka_devops` project for an example of using Kubernetes in a production like environment targeting |ccloud|.
+.. note:: See the :ref:`kafka_devops` project for an example of using Kubernetes in a production-like environment targeting |ccloud|.
 
 The major components of this demo are:
 

--- a/kubernetes/docs/includes/base-demo/overview.rst
+++ b/kubernetes/docs/includes/base-demo/overview.rst
@@ -3,6 +3,8 @@ Overview
 
 This demo shows a deployment of |cp| on |k8s-service-name-long| (|k8s-service-name|) leveraging |co-long| with mock data generation provided via the `Kafka Connect Datagen <https://www.confluent.io/hub/confluentinc/kafka-connect-datagen>`__.
 
+.. note:: See the :ref:`kafka_devops` project for an example of using Kubernetes in a production like environment targeting |ccloud|.
+
 The major components of this demo are:
 
 * A Kubernetes cluster running on |k8s-service-name|.

--- a/kubernetes/docs/includes/replicator-cc-demo/overview.rst
+++ b/kubernetes/docs/includes/replicator-cc-demo/overview.rst
@@ -4,7 +4,7 @@ If you'd like a primer on running |co-long| in |k8s-service-name| with lower res
 
 This example is featured in the `Conquering Hybrid Cloud with Replicated Event-Driven Architectures blog post <https://www.confluent.io/blog/replicated-event-driven-architectures-for-hybrid-cloud-kafka/>`__ which provides more details on use cases for replicated event streaming architectures.
 
-.. note:: See the :ref:`kafka_devops` project for an example of using Kubernetes in a production like environment targeting |ccloud|.
+.. note:: See the :ref:`kafka_devops` project for an example of using Kubernetes in a production-like environment targeting |ccloud|.
 
 The major components of this example are:
 

--- a/kubernetes/docs/includes/replicator-cc-demo/overview.rst
+++ b/kubernetes/docs/includes/replicator-cc-demo/overview.rst
@@ -4,7 +4,7 @@ If you'd like a primer on running |co-long| in |k8s-service-name| with lower res
 
 This example is featured in the `Conquering Hybrid Cloud with Replicated Event-Driven Architectures blog post <https://www.confluent.io/blog/replicated-event-driven-architectures-for-hybrid-cloud-kafka/>`__ which provides more details on use cases for replicated event streaming architectures.
 
-.. note:: See the :ref:`kafka_devops` project for an example of using Kubernetes in a production-like environment targeting |ccloud|.
+.. note:: See the :ref:`kafka-devops` project for an example of using Kubernetes in a production-like environment targeting |ccloud|.
 
 The major components of this example are:
 

--- a/kubernetes/docs/includes/replicator-cc-demo/overview.rst
+++ b/kubernetes/docs/includes/replicator-cc-demo/overview.rst
@@ -4,6 +4,8 @@ If you'd like a primer on running |co-long| in |k8s-service-name| with lower res
 
 This example is featured in the `Conquering Hybrid Cloud with Replicated Event-Driven Architectures blog post <https://www.confluent.io/blog/replicated-event-driven-architectures-for-hybrid-cloud-kafka/>`__ which provides more details on use cases for replicated event streaming architectures.
 
+.. note:: See the :ref:`kafka_devops` project for an example of using Kubernetes in a production like environment targeting |ccloud|.
+
 The major components of this example are:
 
 * A |ccloud| Environment and |ak| Cluster


### PR DESCRIPTION
### Description 
Adds doc refs to existing K8s demos pointing to kafka-devops project

_What behavior does this PR change, and why?_
- [ ] Documentation

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._
- [ ] Documentation
