### PR TITLE
DEVX-2425: Update k8s demos to resolve CP version mismatch

### DIFF
--- a/kubernetes/common/Makefile
+++ b/kubernetes/common/Makefile
@@ -20,7 +20,8 @@ COMMON_MKFILE_DIR := $(dir $(COMMON_MKFILE_PATH))
 # lastword above changes after this include
 include ../../utils/config.env
 
-OPERATOR_DOWNLOAD_PATH := $(COMMON_MKFILE_DIR)cp/operator/confluent-operator-$(OPERATOR_BUNDLE_VERSION)-for-confluent-platform-$(CONFLUENT).tar.gz
+OPERATOR_FILE_NAME := confluent-operator-$(OPERATOR_BUNDLE_VERSION)-for-confluent-platform-$(OPERATOR_BUNDLE_CP_VERSION).tar.gz
+OPERATOR_DOWNLOAD_PATH := $(COMMON_MKFILE_DIR)cp/operator/$(OPERATOR_FILE_NAME)
 OPERATOR_PATH := $(dir $(OPERATOR_DOWNLOAD_PATH))$(OPERATOR_BUNDLE_VERSION)/
 
 check-dependency = $(if $(shell command -v $(1)),$(call echo_pass,found $(1)),$(call echo_fail,$(1) not installed);exit 1)
@@ -45,7 +46,7 @@ get-helm-bundle: #_ Download the Confluent Operator Helm bundle locally in prepa
 ifeq (,$(wildcard $(OPERATOR_DOWNLOAD_PATH)))
 	@mkdir -p $(dir $(OPERATOR_DOWNLOAD_PATH))
 	@echo "downloading Confluent Operator to $(OPERATOR_DOWNLOAD_PATH)"
-	@curl -s https://platform-ops-bin.s3-us-west-1.amazonaws.com/operator/confluent-operator-$(OPERATOR_BUNDLE_VERSION)-for-confluent-platform-$(CONFLUENT).tar.gz --output $(OPERATOR_DOWNLOAD_PATH)
+	@curl -s https://platform-ops-bin.s3-us-west-1.amazonaws.com/operator/$(OPERATOR_FILE_NAME) --output $(OPERATOR_DOWNLOAD_PATH)
 endif
 ifeq (,$(wildcard $(OPERATOR_PATH)))
 	@mkdir -p $(dir $(OPERATOR_DOWNLOAD_PATH))$(OPERATOR_BUNDLE_VERSION)/

--- a/utils/config.env
+++ b/utils/config.env
@@ -50,8 +50,9 @@ KAFKA_CONNECT_DATAGEN_DOCKER_TAG=0.4.0-6.0.1
 # tooling automation can be put in place to deal
 # with the different release cadence or the releases
 # are syncronized.
-OPERATOR_BUNDLE_VERSION=1.6.0
-OPERATOR_CP_IMAGE_TAG=6.0.0.0
+OPERATOR_BUNDLE_VERSION=1.6.1
+OPERATOR_BUNDLE_CP_VERSION=6.0.0
+OPERATOR_CP_IMAGE_TAG=6.0.1.0
 OPERATOR_KAFKA_CONNECT_DATAGEN_IMAGE_TAG=0.4.0-6.0.0.0
 #####################################################
 


### PR DESCRIPTION
Associated Jira documents issue.  Need a second variable to tie helm bundle versions
to CP versions which are not released on a 1:1

### Description 

Adds a new variable for the kubernetes demos to tie the helm bundle version to a separate CP version, which may or may not differ from the CONFLUENT version tracked by the repo branch and tools automation.  This introduces the new variable and updates the get-helm-chart makefile target to use the new variable.

### Author Validation
- [x] kubernetes/gke-base

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._
Reviewer can run demo or validate with visual code pass.

Output from a validate run on 6.0.1-post showing DL of 1.6.1 helm bundle
```
 make demo
✔ found gcloud
✔ gke-base dependencies verified

✔ gke-base demo validation complete
✔ found curl
✔ found tar
✔ found kubectl
✔ found helm
✔ found jq
✔ Confluent Platform Operator helm bundle ready at: /Users/rspurgeon/dev/confluentinc/examples/kubernetes/common/cp/operator/1.6.1/
✔ common initialization complete
....
✔ GKE Base Demo running

```
And a file list:
```
 ll kubernetes/common/cp/operator
Permissions Size User      Date Modified Git Name
drwxr-xr-x     - rspurgeon 14 Jan  8:43   -- 1.6.1/
.rw-r--r--   76k rspurgeon 14 Jan  8:43   -- confluent-operator-1.6.1-for-confluent-platform-6.0.0.tar.gz
```