### PR TITLE
DEVX-2463-cont: replace -f removal of files

### DIFF
--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -1146,8 +1146,8 @@ function ccloud::generate_configs() {
   SASL_JAAS_CONFIG=$( grep "^sasl.jaas.config" $CONFIG_FILE | cut -d'=' -f2- )
   SASL_JAAS_CONFIG_PROPERTY_FORMAT=${SASL_JAAS_CONFIG/username\\=/username=}
   SASL_JAAS_CONFIG_PROPERTY_FORMAT=${SASL_JAAS_CONFIG_PROPERTY_FORMAT/password\\=/password=}
-  CLOUD_KEY=$( echo $SASL_JAAS_CONFIG | awk '{print $3}' | awk -F[\"\'] '$0=$2' )
-  CLOUD_SECRET=$( echo $SASL_JAAS_CONFIG | awk '{print $4}' | awk -F[\"\'] '$0=$2' )
+  CLOUD_KEY=$( echo $SASL_JAAS_CONFIG | awk '{print $3}' | awk -F"'" '$0=$2' )
+  CLOUD_SECRET=$( echo $SASL_JAAS_CONFIG | awk '{print $4}' | awk -F"'" '$0=$2' )
   
   # Schema Registry
   BASIC_AUTH_CREDENTIALS_SOURCE=$( grep "^basic.auth.credentials.source" $CONFIG_FILE | awk -F'=' '{print $2;}' )
@@ -1240,6 +1240,7 @@ function ccloud::generate_configs() {
   ################################################################################
   KSQLDB_SERVER_DELTA=$DEST/ksqldb-server-ccloud.delta
   echo "$KSQLDB_SERVER_DELTA"
+  rm -f $KSQLDB_SERVER_DELTA
   cp $INTERCEPTORS_CONFIG_FILE $KSQLDB_SERVER_DELTA
   echo -e "\n# ksqlDB Server specific configuration" >> $KSQLDB_SERVER_DELTA
   echo "producer.interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor" >> $KSQLDB_SERVER_DELTA

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -1163,7 +1163,7 @@ function ccloud::generate_configs() {
   # Confluent Monitoring Interceptors for Streams Monitoring in Confluent Control Center
   ################################################################################
   INTERCEPTORS_CONFIG_FILE=$DEST/interceptors-ccloud.config
-  rm -f $INTERCEPTORS_CONFIG_FILE
+  rm $INTERCEPTORS_CONFIG_FILE 2>/dev/null
   echo "# Configuration derived from $CONFIG_FILE" > $INTERCEPTORS_CONFIG_FILE
   while read -r line
   do
@@ -1210,7 +1210,7 @@ function ccloud::generate_configs() {
   ################################################################################
   SR_CONFIG_DELTA=$DEST/schema-registry-ccloud.delta
   echo "$SR_CONFIG_DELTA"
-  rm -f $SR_CONFIG_DELTA
+  rm $SR_CONFIG_DELTA 2>/dev/null
   while read -r line
   do
     if [[ ! -z $line && ${line:0:1} != '#' ]]; then
@@ -1226,7 +1226,7 @@ function ccloud::generate_configs() {
   ################################################################################
   REPLICATOR_PRODUCER_DELTA=$DEST/replicator-to-ccloud-producer.delta
   echo "$REPLICATOR_PRODUCER_DELTA"
-  rm -f $REPLICATOR_PRODUCER_DELTA
+  rm $REPLICATOR_PRODUCER_DELTA 2>/dev/null
   cp $INTERCEPTORS_CONFIG_FILE $REPLICATOR_PRODUCER_DELTA
   echo -e "\n# Confluent Replicator (executable) specific configuration" >> $REPLICATOR_PRODUCER_DELTA
   echo "interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor" >> $REPLICATOR_PRODUCER_DELTA
@@ -1240,7 +1240,7 @@ function ccloud::generate_configs() {
   ################################################################################
   KSQLDB_SERVER_DELTA=$DEST/ksqldb-server-ccloud.delta
   echo "$KSQLDB_SERVER_DELTA"
-  rm -f $KSQLDB_SERVER_DELTA
+  rm $KSQLDB_SERVER_DELTA 2>/dev/null
   cp $INTERCEPTORS_CONFIG_FILE $KSQLDB_SERVER_DELTA
   echo -e "\n# ksqlDB Server specific configuration" >> $KSQLDB_SERVER_DELTA
   echo "producer.interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor" >> $KSQLDB_SERVER_DELTA
@@ -1268,7 +1268,7 @@ function ccloud::generate_configs() {
   ################################################################################
   KSQL_DATAGEN_DELTA=$DEST/ksql-datagen.delta
   echo "$KSQL_DATAGEN_DELTA"
-  rm -f $KSQL_DATAGEN_DELTA
+  rm $KSQL_DATAGEN_DELTA 2>/dev/null
   cp $INTERCEPTORS_CONFIG_FILE $KSQL_DATAGEN_DELTA
   echo -e "\n# KSQL DataGen specific configuration" >> $KSQL_DATAGEN_DELTA
   echo "interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor" >> $KSQL_DATAGEN_DELTA
@@ -1288,7 +1288,7 @@ function ccloud::generate_configs() {
   ################################################################################
   C3_DELTA=$DEST/control-center-ccloud.delta
   echo "$C3_DELTA"
-  rm -f $C3_DELTA
+  rm $C3_DELTA 2>/dev/null
   echo -e "\n# Confluent Control Center specific configuration" >> $C3_DELTA
   while read -r line
     do
@@ -1320,7 +1320,7 @@ function ccloud::generate_configs() {
   ################################################################################
   METRICS_REPORTER_DELTA=$DEST/metrics-reporter.delta
   echo "$METRICS_REPORTER_DELTA"
-  rm -f $METRICS_REPORTER_DELTA
+  rm $METRICS_REPORTER_DELTA 2>/dev/null
   echo "metric.reporters=io.confluent.metrics.reporter.ConfluentMetricsReporter" >> $METRICS_REPORTER_DELTA
   echo "confluent.metrics.reporter.topic.replicas=3" >> $METRICS_REPORTER_DELTA
   while read -r line
@@ -1338,7 +1338,7 @@ function ccloud::generate_configs() {
   ################################################################################
   REST_PROXY_DELTA=$DEST/rest-proxy.delta
   echo "$REST_PROXY_DELTA"
-  rm -f $REST_PROXY_DELTA
+  rm $REST_PROXY_DELTA 2>/dev/null
   while read -r line
     do
     if [[ ! -z $line && ${line:0:1} != '#' ]]; then
@@ -1364,7 +1364,7 @@ function ccloud::generate_configs() {
   ################################################################################
   CONNECT_DELTA=$DEST/connect-ccloud.delta
   echo "$CONNECT_DELTA"
-  rm -f $CONNECT_DELTA
+  rm $CONNECT_DELTA 2>/dev/null
   cat <<EOF > $CONNECT_DELTA
 # Configuration for embedded admin client
 replication.factor=3
@@ -1419,7 +1419,7 @@ EOF
   ################################################################################
   CONNECTOR_DELTA=$DEST/connector-ccloud.delta
   echo "$CONNECTOR_DELTA"
-  rm -f $CONNECTOR_DELTA
+  rm $CONNECTOR_DELTA 2>/dev/null
   cat <<EOF >> $CONNECTOR_DELTA
 // Confluent Schema Registry for Kafka connectors
 value.converter=io.confluent.connect.avro.AvroConverter
@@ -1434,7 +1434,7 @@ EOF
   ################################################################################
   AK_TOOLS_DELTA=$DEST/ak-tools-ccloud.delta
   echo "$AK_TOOLS_DELTA"
-  rm -f $AK_TOOLS_DELTA
+  rm $AK_TOOLS_DELTA 2>/dev/null
   cp $CONFIG_FILE $AK_TOOLS_DELTA
   chmod $PERM $AK_TOOLS_DELTA
   
@@ -1446,7 +1446,7 @@ EOF
   ################################################################################
   JAVA_PC_CONFIG=$DEST/java_producer_consumer.delta
   echo "$JAVA_PC_CONFIG"
-  rm -f $JAVA_PC_CONFIG
+  rm $JAVA_PC_CONFIG 2>/dev/null
   
   cat <<EOF >> $JAVA_PC_CONFIG
 import java.util.Properties;
@@ -1495,7 +1495,7 @@ EOF
   ################################################################################
   JAVA_STREAMS_CONFIG=$DEST/java_streams.delta
   echo "$JAVA_STREAMS_CONFIG"
-  rm -f $JAVA_STREAMS_CONFIG
+  rm $JAVA_STREAMS_CONFIG 2>/dev/null
   
   cat <<EOF >> $JAVA_STREAMS_CONFIG
 import java.util.Properties;
@@ -1545,7 +1545,7 @@ EOF
   ################################################################################
   PYTHON_CONFIG=$DEST/python.delta
   echo "$PYTHON_CONFIG"
-  rm -f $PYTHON_CONFIG
+  rm $PYTHON_CONFIG 2>/dev/null
   
   cat <<EOF >> $PYTHON_CONFIG
 from confluent_kafka import Producer, Consumer, KafkaError
@@ -1583,7 +1583,7 @@ EOF
   ################################################################################
   DOTNET_CONFIG=$DEST/dotnet.delta
   echo "$DOTNET_CONFIG"
-  rm -f $DOTNET_CONFIG
+  rm $DOTNET_CONFIG 2>/dev/null
   
   cat <<EOF >> $DOTNET_CONFIG
 using Confluent.Kafka;
@@ -1623,7 +1623,7 @@ EOF
   ################################################################################
   GO_CONFIG=$DEST/go.delta
   echo "$GO_CONFIG"
-  rm -f $GO_CONFIG
+  rm $GO_CONFIG 2>/dev/null
   
   cat <<EOF >> $GO_CONFIG
 import (
@@ -1664,7 +1664,7 @@ EOF
   ################################################################################
   NODE_CONFIG=$DEST/node.delta
   echo "$NODE_CONFIG"
-  rm -f $NODE_CONFIG
+  rm $NODE_CONFIG 2>/dev/null
   
   cat <<EOF >> $NODE_CONFIG
 var Kafka = require('node-rdkafka');
@@ -1702,7 +1702,7 @@ EOF
   ################################################################################
   CPP_CONFIG=$DEST/cpp.delta
   echo "$CPP_CONFIG"
-  rm -f $CPP_CONFIG
+  rm $CPP_CONFIG 2>/dev/null
   
   cat <<EOF >> $CPP_CONFIG
 #include <librdkafka/rdkafkacpp.h>
@@ -1744,7 +1744,7 @@ EOF
   ################################################################################
   ENV_CONFIG=$DEST/env.delta
   echo "$ENV_CONFIG"
-  rm -f $ENV_CONFIG
+  rm $ENV_CONFIG 2>/dev/null
   
   cat <<EOF >> $ENV_CONFIG
 export BOOTSTRAP_SERVERS="$BOOTSTRAP_SERVERS"


### PR DESCRIPTION
### Description 


_What behavior does this PR change, and why?_

In https://github.com/confluentinc/examples/pull/920 @rspurgeon suggested 
>IMO we do not need -f here. I tested this command without, and considering the user previously created the file in a folder that they have proper permissions on, the -f isn't required. So introducing the force option seems like an unecessary risk, in case something important (oddly) happen to get into the KSQLDB_SERVER_DELTA variable.

>If we want to silence error messages if the file doesn't exist, i suggeste we use rm $KSQLDB_SERVER_DELTA 2>/dev/null

To be cautious we should refrain from force removing files in our demos when we don't have to. This PR changes for `rm -f` to `rm $KSQLDB_SERVER_DELTA 2>/dev/null`. I validated this by running ccloud-stack-create (generating configs with both `bash` and `zsh`) and running the microservices demo. 

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [ ] ccloud 
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [ ] ccloud 
- [ ] other cloud demos that use ccloud-stack-create
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->
