### PR TITLE
update sr configs to use basic.auth.user.info instead of schema.regis…

### DIFF
--- a/clients/docs/includes/configs/cloud/java-sr.config
+++ b/clients/docs/includes/configs/cloud/java-sr.config
@@ -12,4 +12,4 @@ acks=all
 # Required connection configs for Confluent Cloud Schema Registry
 schema.registry.url=https://{{ SR_ENDPOINT }}
 basic.auth.credentials.source=USER_INFO
-schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
+basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}

--- a/clients/docs/includes/configs/cloud/librdkafka-sr.config
+++ b/clients/docs/includes/configs/cloud/librdkafka-sr.config
@@ -8,4 +8,4 @@ sasl.password={{ CLUSTER_API_SECRET }}
 # Confluent Cloud Schema Registry
 schema.registry.url=https://{{ SR_ENDPOINT }}
 basic.auth.credentials.source=USER_INFO
-schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
+basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}

--- a/clients/docs/includes/configs/cloud/springboot-sr.config
+++ b/clients/docs/includes/configs/cloud/springboot-sr.config
@@ -6,5 +6,5 @@ spring.kafka.properties.security.protocol=SASL_SSL
 
 # Confluent Cloud Schema Registry
 spring.kafka.properties.basic.auth.credentials.source=USER_INFO
-spring.kafka.properties.schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
+spring.kafka.properties.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
 spring.kafka.properties.schema.registry.url=https://{{ SR_ENDPOINT }}


### PR DESCRIPTION
…try.basic.auth.user.info

From this ticket: https://confluentinc.atlassian.net/browse/CPG-606

### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

_What behavior does this PR change, and why?_


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->
