### PR TITLE
DEVX-2235: Use explicit connector version numbers in Dockerfile

### DIFF
--- a/ccloud/Dockerfile
+++ b/ccloud/Dockerfile
@@ -20,4 +20,4 @@ FROM confluentinc/cp-enterprise-replicator:$CP_VERSION
 ENV CONNECT_PLUGIN_PATH: "/usr/share/java,/connect-plugins,/usr/share/confluent-hub-components"
 
 # Install kafka-connect-datagen connector
-RUN confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.4.0
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:$KAFKA_CONNECT_DATAGEN_VERSION

--- a/ccloud/Dockerfile
+++ b/ccloud/Dockerfile
@@ -20,4 +20,4 @@ FROM confluentinc/cp-enterprise-replicator:$CP_VERSION
 ENV CONNECT_PLUGIN_PATH: "/usr/share/java,/connect-plugins,/usr/share/confluent-hub-components"
 
 # Install kafka-connect-datagen connector
-RUN confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:latest
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.4.0

--- a/ccloud/Dockerfile
+++ b/ccloud/Dockerfile
@@ -20,4 +20,5 @@ FROM confluentinc/cp-enterprise-replicator:$CP_VERSION
 ENV CONNECT_PLUGIN_PATH: "/usr/share/java,/connect-plugins,/usr/share/confluent-hub-components"
 
 # Install kafka-connect-datagen connector
+ARG KAFKA_CONNECT_DATAGEN_VERSION
 RUN confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:$KAFKA_CONNECT_DATAGEN_VERSION

--- a/ccloud/start-docker.sh
+++ b/ccloud/start-docker.sh
@@ -73,8 +73,8 @@ printf "\n"
 
 echo
 echo ====== Building custom Docker image with Connect version ${CONFLUENT_DOCKER_TAG}
-echo "docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} -t localbuild/connect-cloud:${CONFLUENT_DOCKER_TAG} -f Dockerfile ."
-docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} -t localbuild/connect-cloud:${CONFLUENT_DOCKER_TAG} -f Dockerfile .
+echo "docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg  KAFKA_CONNECT_DATAGEN_VERSION=${KAFKA_CONNECT_DATAGEN_VERSION} -t localbuild/connect-cloud:${CONFLUENT_DOCKER_TAG} -f Dockerfile ."
+docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg  KAFKA_CONNECT_DATAGEN_VERSION=${KAFKA_CONNECT_DATAGEN_VERSION} -t localbuild/connect-cloud:${CONFLUENT_DOCKER_TAG} -f Dockerfile .
 
 echo
 echo ====== Starting local services in Docker

--- a/connect-streams-pipeline/start.sh
+++ b/connect-streams-pipeline/start.sh
@@ -14,7 +14,7 @@ check_sqlite3 || exit 1
 mvn clean compile
 
 echo "auto.offset.reset=earliest" >> $CONFLUENT_HOME/etc/ksqldb/ksql-server.properties
-confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:latest
+confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.0.1
 confluent local services start
 
 # Create the SQL table

--- a/connect-streams-pipeline/start.sh
+++ b/connect-streams-pipeline/start.sh
@@ -14,7 +14,7 @@ check_sqlite3 || exit 1
 mvn clean compile
 
 echo "auto.offset.reset=earliest" >> $CONFLUENT_HOME/etc/ksqldb/ksql-server.properties
-confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.0.1
+confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:$KAFKA_CONNECT_JDBC_VERSION
 confluent local services start
 
 # Create the SQL table

--- a/microservices-orders/docker-compose-ccloud.yml
+++ b/microservices-orders/docker-compose-ccloud.yml
@@ -98,6 +98,7 @@ services:
       CONNECT_CONSUMER_CONFLUENT_MONITORING_INTERCEPTOR_SECURITY_PROTOCOL: SASL_SSL
       CONNECT_CONSUMER_CONFLUENT_MONITORING_INTERCEPTOR_SASL_JAAS_CONFIG: $SASL_JAAS_CONFIG
       CONNECT_CONSUMER_CONFLUENT_MONITORING_INTERCEPTOR_SASL_MECHANISM: PLAIN
+      KAFKA_CONNECT_JDBC_VERSION: ${KAFKA_CONNECT_JDBC_VERSION}
     volumes:
       - database:/opt/docker/db/data
       - $PWD/stack-configs:/opt/docker/stack-configs
@@ -106,7 +107,7 @@ services:
       - -c
       - |
         echo "Installing connector plugins"
-        confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.0.1
+        confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:$KAFKA_CONNECT_JDBC_VERSION
         confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:10.0.2
         echo "Launching Kafka Connect worker"
         /etc/confluent/docker/run

--- a/microservices-orders/docker-compose-ccloud.yml
+++ b/microservices-orders/docker-compose-ccloud.yml
@@ -106,7 +106,7 @@ services:
       - -c
       - |
         echo "Installing connector plugins"
-        confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:latest
+        confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.0.1
         confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:10.0.2
         echo "Launching Kafka Connect worker"
         /etc/confluent/docker/run

--- a/microservices-orders/docker-compose.yml
+++ b/microservices-orders/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       - -c
       - |
         echo "Installing connector plugins"
-        confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:latest
+        confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.0.1
         confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:10.0.2
         echo "Launching Kafka Connect worker"
         /etc/confluent/docker/run

--- a/microservices-orders/docker-compose.yml
+++ b/microservices-orders/docker-compose.yml
@@ -91,6 +91,7 @@ services:
       CONNECT_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
       CONNECT_PLUGIN_PATH: '/usr/share/java,/usr/share/confluent-hub-components/,/connectors/'
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
+      KAFKA_CONNECT_JDBC_VERSION: ${KAFKA_CONNECT_JDBC_VERSION}
     volumes:
       - database:/opt/docker/db/data
     command:
@@ -98,7 +99,7 @@ services:
       - -c
       - |
         echo "Installing connector plugins"
-        confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.0.1
+        confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:$KAFKA_CONNECT_JDBC_VERSION
         confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:10.0.2
         echo "Launching Kafka Connect worker"
         /etc/confluent/docker/run

--- a/microservices-orders/start.sh
+++ b/microservices-orders/start.sh
@@ -29,7 +29,7 @@ else
 fi;
 JAR="$(pwd)/kafka-streams-examples/target/kafka-streams-examples-*-standalone.jar"
 
-confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.0.1
+confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:$KAFKA_CONNECT_JDBC_VERSION
 confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:10.0.2
 grep -qxF 'auto.offset.reset=earliest' $CONFLUENT_HOME/etc/ksqldb/ksql-server.properties || echo 'auto.offset.reset=earliest' >> $CONFLUENT_HOME/etc/ksqldb/ksql-server.properties 
 confluent local services start

--- a/microservices-orders/start.sh
+++ b/microservices-orders/start.sh
@@ -29,7 +29,7 @@ else
 fi;
 JAR="$(pwd)/kafka-streams-examples/target/kafka-streams-examples-*-standalone.jar"
 
-confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:latest
+confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.0.1
 confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:10.0.2
 grep -qxF 'auto.offset.reset=earliest' $CONFLUENT_HOME/etc/ksqldb/ksql-server.properties || echo 'auto.offset.reset=earliest' >> $CONFLUENT_HOME/etc/ksqldb/ksql-server.properties 
 confluent local services start

--- a/utils/config.env
+++ b/utils/config.env
@@ -56,3 +56,4 @@ OPERATOR_CP_IMAGE_TAG=6.0.1.0
 OPERATOR_KAFKA_CONNECT_DATAGEN_IMAGE_TAG=0.4.0-6.0.0.0
 #####################################################
 
+KAFKA_CONNECT_JDBC_VERSION=10.0.1

--- a/utils/config.env
+++ b/utils/config.env
@@ -56,4 +56,12 @@ OPERATOR_CP_IMAGE_TAG=6.0.1.0
 OPERATOR_KAFKA_CONNECT_DATAGEN_IMAGE_TAG=0.4.0-6.0.0.0
 #####################################################
 
+############### kafka-connect-jdbc ##################
+# We can't use the CP docker tag above for the aggregate datagen version because
+#   kafka-connect-jdbc is not, currently, part of the CP build process.  
+#   kafka-connect-jdbc releases are manual so we have to manage this manually 
+#   and there will be a delay between CP releases and kafka-connect-jdbc releases.
+#   Published kafka-connect-datagen images can be found here:
+#     https://www.confluent.io/hub/confluentinc/kafka-connect-jdbc
 KAFKA_CONNECT_JDBC_VERSION=10.0.1
+#####################################################


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2235

_What behavior does this PR change, and why?_
This pins the kafka-connect-jdbc to a specific version (10.0.1). The version is defined in utils/config.env. 


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._
Validated ccloud and microservices ccloud version.

- [x] ccloud
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
- [ ] connect-streams-pipeline
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
- [x] microservices-orders


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._
Validating any of the other examples would be welcomed. 

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [ ] ccloud
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
- [ ] connect-streams-pipeline
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
- [ ] microservices-orders
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->
