### PR TITLE
DEVX-2509: fix microservices-order ccloud version of demo for ksqlDB 0.15.0

### DIFF
--- a/microservices-orders/start-ccloud.sh
+++ b/microservices-orders/start-ccloud.sh
@@ -65,7 +65,7 @@ printf "\n====== Validating and setting up ksqlDB App\n"
 
 MAX_WAIT_KSQLDB=720
 printf "\n====== Waiting up to $MAX_WAIT_KSQLDB for ksqlDB to be ready\n"
-retry $MAX_WAIT ccloud::validate_ccloud_ksqldb_endpoint_ready $KSQLDB_ENDPOINT || exit 1
+retry $MAX_WAIT_KSQLDB ccloud::validate_ccloud_ksqldb_endpoint_ready $KSQLDB_ENDPOINT || exit 1
 
 printf "====== Creating ksqlDB ACLs\n"
 ccloud kafka acl create --allow --service-account $KSQLDB_SERVICE_ACCOUNT_ID --operation READ --topic 'orders'

--- a/microservices-orders/statements-ccloud.sql
+++ b/microservices-orders/statements-ccloud.sql
@@ -1,4 +1,4 @@
 CREATE STREAM orders WITH (kafka_topic='orders', value_format='AVRO');
 CREATE TABLE customers_table (customerid bigint PRIMARY KEY, firstname varchar, lastname varchar, email varchar, address varchar, level varchar) WITH (KAFKA_TOPIC='customers', VALUE_FORMAT='AVRO');
 CREATE STREAM orders_enriched AS SELECT customers_table.customerid AS customerid, customers_table.firstname, customers_table.lastname, customers_table.level, orders.product, orders.quantity, orders.price FROM orders LEFT JOIN customers_table ON orders.customerid = customers_table.customerid;
-CREATE TABLE FRAUD_ORDER AS SELECT CUSTOMERID, LASTNAME, FIRSTNAME, COUNT(*) AS COUNTS FROM orders_enriched WINDOW TUMBLING (SIZE 30 SECONDS) GROUP BY CUSTOMERID, LASTNAME, FIRSTNAME HAVING COUNT(*)>2;
+CREATE TABLE FRAUD_ORDER WITH (key_format='json') AS SELECT CUSTOMERID, LASTNAME, FIRSTNAME, COUNT(*) AS COUNTS FROM orders_enriched WINDOW TUMBLING (SIZE 30 SECONDS) GROUP BY CUSTOMERID, LASTNAME, FIRSTNAME HAVING COUNT(*)>2;


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2509

_What behavior does this PR change, and why?_

1. Bug in script using wrong time to wait for ksqlDB app to be running
2. Fix queries to work with ksqlDB v0.15.0


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
- [x] microservices-orders
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->

Reviewer: I validated the demo, you can just do code review (no need to run)
