### PR TITLE
DEVX-2166: use KIP-464 for default replication factor from brokers: c…

### DIFF
--- a/clients/cloud/c/common.c
+++ b/clients/cloud/c/common.c
@@ -124,12 +124,13 @@ int create_topic (rd_kafka_t *rk, const char *topic,
         rd_kafka_event_t *rkev;
         const rd_kafka_CreateTopics_result_t *res;
         const rd_kafka_topic_result_t **restopics;
+        const int replication_factor_or_use_default = -1;
         size_t restopic_cnt;
         int ret = 0;
 
         fprintf(stderr, "Creating topic %s\n", topic);
 
-        newt = rd_kafka_NewTopic_new(topic, num_partitions, -1,
+        newt = rd_kafka_NewTopic_new(topic, num_partitions, replication_factor_or_use_default,
                                      errstr, sizeof(errstr));
         if (!newt) {
                 fprintf(stderr, "Failed to create NewTopic object: %s\n",

--- a/clients/cloud/c/common.c
+++ b/clients/cloud/c/common.c
@@ -117,7 +117,7 @@ rd_kafka_conf_t *read_config (const char *config_file) {
  * @returns 0 on success or -1 on error.
  */
 int create_topic (rd_kafka_t *rk, const char *topic,
-                  int num_partitions, int replication_factor) {
+                  int num_partitions) {
         rd_kafka_NewTopic_t *newt;
         char errstr[256];
         rd_kafka_queue_t *queue;
@@ -129,7 +129,7 @@ int create_topic (rd_kafka_t *rk, const char *topic,
 
         fprintf(stderr, "Creating topic %s\n", topic);
 
-        newt = rd_kafka_NewTopic_new(topic, num_partitions, replication_factor,
+        newt = rd_kafka_NewTopic_new(topic, num_partitions, -1,
                                      errstr, sizeof(errstr));
         if (!newt) {
                 fprintf(stderr, "Failed to create NewTopic object: %s\n",

--- a/clients/cloud/c/common.h
+++ b/clients/cloud/c/common.h
@@ -25,7 +25,7 @@
 extern int run;
 rd_kafka_conf_t *read_config (const char *config_file);
 int create_topic (rd_kafka_t *rk, const char *topic,
-                  int num_partitions, int replication_factor);
+                  int num_partitions);
 
 void error_cb (rd_kafka_t *rk, int err, const char *reason, void *opaque);
 

--- a/clients/cloud/c/producer.c
+++ b/clients/cloud/c/producer.c
@@ -84,7 +84,7 @@ static int run_producer (const char *topic, int msgcnt,
         }
 
         /* Create the topic. */
-        if (create_topic(rk, topic, 1, 3) == -1) {
+        if (create_topic(rk, topic, 1) == -1) {
                 rd_kafka_destroy(rk);
                 return -1;
         }


### PR DESCRIPTION
… client

### Description 

https://confluentinc.atlassian.net/browse/DEVX-2166

_What behavior does this PR change, and why?_

Use default RF value from broker, to allow the code to be used to clusters where RF=3 or RF=1

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
- [x] clients/cloud: validated c example
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
- [ ] clients/cloud: validated c example
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] music -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->
