### PR TITLE
DEVX-2513: update catch for validate_logged_in_ccloud_cli

### DIFF
--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -84,8 +84,10 @@ function ccloud::validate_ccloud_cli_v2() {
 function ccloud::validate_logged_in_ccloud_cli() {
   ccloud::validate_ccloud_cli_v2 || exit 1
 
-  if [[ "$(ccloud kafka cluster list 2>&1)" == "Error: You must log in to run that command." ]]; then
-    echo "ERROR: Log into Confluent Cloud with the command 'ccloud login --save' before running the example. The '--save' argument saves your Confluent Cloud user login credentials or refresh token (in the case of SSO) to the local netrc file."
+  if [[ "$(ccloud kafka cluster list 2>&1)" =~ "ccloud login" ]]; then
+    echo
+    echo "ERROR: Not logged into Confluent Cloud."
+    echo "Log in with the command 'ccloud login --save' before running the example. The '--save' argument saves your Confluent Cloud user login credentials or refresh token (in the case of SSO) to the local netrc file."
     exit 1
   fi
 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2513

_What behavior does this PR change, and why?_

Note: I didn't catch on return code because I was thinking that the test command could fail for other reasons and error out, not just because not logged in.  

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
- [x] cp-quickstart
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
- [ ] cp-quickstart
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->
