### PR TITLE
DEVX-2510: Reorders email service startup

### DIFF
--- a/microservices-orders/docker-compose-ccloud.yml
+++ b/microservices-orders/docker-compose-ccloud.yml
@@ -21,6 +21,8 @@ services:
     container_name: microservices
     ports:
       - "18894:18894"
+    depends_on:
+      - connect
     volumes:
       - $PWD/scripts:/opt/docker/scripts
       - $PWD/logs:/opt/docker/logs

--- a/microservices-orders/read-topics-ccloud.sh
+++ b/microservices-orders/read-topics-ccloud.sh
@@ -31,7 +31,7 @@ docker-compose -f docker-compose-ccloud.yml exec connect kafka-console-consumer 
   
 # Topic platinum: dynamic routing
 echo -e "\n-----platinum topic-----"
-docker-compose -f docker-compose-ccloud.yml exec connect kafka-avro-console-consumer --bootstrap-server $BOOTSTRAP_SERVERS --consumer.config $CONFIG_FILE --property basic.auth.credentials.source=USER_INFO --property schema.registry.basic.auth.user.info=$SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO --property schema.registry.url=$SCHEMA_REGISTRY_URL --from-beginning --timeout-ms 10000 --max-messages 5 --topic platinum
+docker-compose -f docker-compose-ccloud.yml exec connect kafka-avro-console-consumer --bootstrap-server $BOOTSTRAP_SERVERS --consumer.config $CONFIG_FILE --property basic.auth.credentials.source=USER_INFO --property schema.registry.basic.auth.user.info=$SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO --property schema.registry.url=$SCHEMA_REGISTRY_URL --from-beginning --timeout-ms 30000 --max-messages 5 --topic platinum
  
 # Sample ksqlDB
 echo -e "\n-----Query ksqlDB-----"

--- a/microservices-orders/scripts/run-services.sh
+++ b/microservices-orders/scripts/run-services.sh
@@ -27,7 +27,7 @@ echo "Adding Inventory"
 java -cp $JAR io.confluent.examples.streams.microservices.AddInventory --bootstrap-servers $BOOTSTRAP_SERVERS $CONFIG_FILE_ARG $ADDITIONAL_ARGS >$LOG_DIR/AddInventory.log 2>&1 &
 sleep 5
 
-for SERVICE in "InventoryService" "FraudService" "OrderDetailsService" "ValidationsAggregatorService" "EmailService"; do
+for SERVICE in "InventoryService" "FraudService" "OrderDetailsService" "ValidationsAggregatorService" ; do
   echo "Starting $SERVICE"
   java -cp $JAR io.confluent.examples.streams.microservices.$SERVICE --bootstrap-servers $BOOTSTRAP_SERVERS --schema-registry $SCHEMA_REGISTRY_URL $CONFIG_FILE_ARG $ADDITIONAL_ARGS >$LOG_DIR/$SERVICE.log 2>&1 &
   PIDS+=($!)
@@ -36,10 +36,13 @@ sleep 20
 
 echo "Posting Orders and Payments"
 java -cp $JAR io.confluent.examples.streams.microservices.PostOrdersAndPayments --bootstrap-servers $BOOTSTRAP_SERVERS --schema-registry $SCHEMA_REGISTRY_URL --order-service-url "http://localhost:$RESTPORT" $CONFIG_FILE_ARG >$LOG_DIR/PostOrdersAndPayments.log 2>&1 &
+sleep 30
 
+echo "Starting EmailService"
+java -cp $JAR io.confluent.examples.streams.microservices.EmailService --bootstrap-servers $BOOTSTRAP_SERVERS --schema-registry $SCHEMA_REGISTRY_URL $CONFIG_FILE_ARG $ADDITIONAL_ARGS >$LOG_DIR/$SERVICE.log 2>&1 &
 PIDS+=($!)
-sleep 10
 
+sleep 10
 echo "Microservice processes running under PIDS: ${PIDS[@]}"
 echo "${PIDS[@]}" > $PIDS_FILE 
 wait $PIDS

--- a/microservices-orders/scripts/run-services.sh
+++ b/microservices-orders/scripts/run-services.sh
@@ -36,8 +36,8 @@ sleep 20
 
 echo "Posting Orders and Payments"
 java -cp $JAR io.confluent.examples.streams.microservices.PostOrdersAndPayments --bootstrap-servers $BOOTSTRAP_SERVERS --schema-registry $SCHEMA_REGISTRY_URL --order-service-url "http://localhost:$RESTPORT" $CONFIG_FILE_ARG >$LOG_DIR/PostOrdersAndPayments.log 2>&1 &
-sleep 30
 
+sleep 60
 echo "Starting EmailService"
 java -cp $JAR io.confluent.examples.streams.microservices.EmailService --bootstrap-servers $BOOTSTRAP_SERVERS --schema-registry $SCHEMA_REGISTRY_URL $CONFIG_FILE_ARG $ADDITIONAL_ARGS >$LOG_DIR/$SERVICE.log 2>&1 &
 PIDS+=($!)


### PR DESCRIPTION
### Description 

Email service has upstream dependencies, these minor changes
just help to ensure topics and data are running prior to starting
the service


### Author Validation
<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
- [X] microservices-orders (ccloud and docker both)
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
<!-- - [ ] security/secret-protection -->


### Reviewer Tasks
- [ ] microservices-orders (ccloud and docker both)
