### PR TITLE
DEVX-2461: ccloud-stack: ksqlDB app creation reuses SA

### DIFF
--- a/ccloud/beginner-cloud/cleanup.sh
+++ b/ccloud/beginner-cloud/cleanup.sh
@@ -13,7 +13,7 @@
 source ../../utils/helper.sh
 source ../../utils/ccloud_library.sh
 
-ccloud::validate_version_ccloud_cli 1.7.0 || exit 1
+ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION || exit 1
 ccloud::validate_logged_in_ccloud_cli || exit 1
 check_timeout || exit 1
 check_mvn || exit 1

--- a/ccloud/beginner-cloud/start.sh
+++ b/ccloud/beginner-cloud/start.sh
@@ -13,7 +13,7 @@
 source ../../utils/helper.sh
 source ../../utils/ccloud_library.sh
 
-ccloud::validate_version_ccloud_cli 1.7.0 || exit 1
+ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION || exit 1
 ccloud::validate_logged_in_ccloud_cli || exit 1
 ccloud::prompt_continue_ccloud_demo || exit 1
 check_timeout || exit 1

--- a/ccloud/ccloud-stack/ccloud_stack_create.sh
+++ b/ccloud/ccloud-stack/ccloud_stack_create.sh
@@ -10,7 +10,7 @@
 source ../../utils/helper.sh
 source ../../utils/ccloud_library.sh
 
-ccloud::validate_version_ccloud_cli 1.7.0 || exit 1
+ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION || exit 1
 check_jq || exit 1
 ccloud::validate_logged_in_ccloud_cli || exit 1
 

--- a/ccloud/ccloud-stack/ccloud_stack_destroy.sh
+++ b/ccloud/ccloud-stack/ccloud_stack_destroy.sh
@@ -6,7 +6,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source $DIR/../../utils/helper.sh
 source $DIR/../../utils/ccloud_library.sh
 
-ccloud::validate_version_ccloud_cli 1.7.0 || exit 1
+ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION || exit 1
 ccloud::validate_logged_in_ccloud_cli || exit 1
 check_jq || exit 1
 

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -142,7 +142,6 @@ Create a ccloud-stack
 
    .. code-block:: text
 
-ACLs in this cluster:
         ServiceAccountId | Permission |    Operation     |     Resource     |             Name             |   Type
       +------------------+------------+------------------+------------------+------------------------------+----------+
         User:186588      | ALLOW      | DESCRIBE_CONFIGS | GROUP            | *                            | LITERAL

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -54,7 +54,7 @@ By default, the |ccloud| ksqlDB app is not created with ``ccloud-stack``, you ha
    ccloud api-key create --service-account $SERVICE_ACCOUNT_ID --resource $RESOURCE -o json    // for schema-registry
 
    # By default, ccloud-stack does not enable Confluent Cloud ksqlDB, but if you explicitly enable it:
-   ccloud ksql app create --cluster $CLUSTER --api-key "$kafka_api_key" --api-secret "$kafka_api_secret" -o json "$KSQLDB_NAME"
+   ccloud ksql app create --cluster $CLUSTER --api-key "$KAFKA_API_KEY" --api-secret "$KAFKA_API_SECRET" -o json "$KSQLDB_NAME"
    ccloud api-key create --service-account $SERVICE_ACCOUNT_ID --resource $RESOURCE -o json    // for ksqlDB
 
    ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation <....>    // permissive ACLs for all services
@@ -119,7 +119,7 @@ Create a ccloud-stack
 
 #. ``ccloud-stack`` configures permissive ACLs with wildcards, which is useful for development and learning environments. In production, configure much stricter ACLs.
 
-   If you ran without ksqlDB (in the output below, service account ID is ``119612``):
+   If you ran without ksqlDB:
 
    .. code-block:: text
 
@@ -138,7 +138,7 @@ Create a ccloud-stack
         User:186607      | ALLOW      | WRITE            | TOPIC            | *             | LITERAL
         User:186607      | ALLOW      | READ             | TOPIC            | *             | LITERAL
 
-   If you ran with ksqlDB (in the output below, ksqlDB service account ID is ``119613``):
+   If you ran with ksqlDB:
 
    .. code-block:: text
 

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -54,8 +54,8 @@ By default, the |ccloud| ksqlDB app is not created with ``ccloud-stack``, you ha
    ccloud api-key create --service-account $SERVICE_ACCOUNT_ID --resource $RESOURCE -o json    // for schema-registry
 
    # By default, ccloud-stack does not enable Confluent Cloud ksqlDB, but if you explicitly enable it:
-   ccloud ksql app create --cluster $CLUSTER -o json "$KSQLDB_NAME"
-   ccloud api-key create --service-account $KSQLDB_SERVICE_ACCOUNT_ID --resource $RESOURCE -o json    // for ksqlDB
+   ccloud ksql app create --cluster $CLUSTER --api-key "$kafka_api_key" --api-secret "$kafka_api_secret" -o json "$KSQLDB_NAME"
+   ccloud api-key create --service-account $SERVICE_ACCOUNT_ID --resource $RESOURCE -o json    // for ksqlDB
 
    ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation <....>    // permissive ACLs for all services
 
@@ -70,7 +70,7 @@ Prerequisites
 =============
 
 - Create a user account in `Confluent Cloud <https://www.confluent.io/confluent-cloud/>`__
-- Local install of `Confluent Cloud CLI <https://docs.confluent.io/ccloud-cli/current/install.html>`__ v1.13.0 or later.
+- Local install of `Confluent Cloud CLI <https://docs.confluent.io/ccloud-cli/current/install.html>`__ v1.22.1 or later.
 - ``jq`` tool
 
 Note that ``ccloud-stack`` has been validated on macOS 10.15.3 with bash version 3.2.57.
@@ -122,73 +122,62 @@ Create a ccloud-stack
    If you ran without ksqlDB (in the output below, service account ID is ``119612``):
 
    .. code-block:: text
-   
-        ServiceAccountId | Permission |    Operation     |     Resource     |     Name      |  Type    
-      +------------------+------------+------------------+------------------+---------------+---------+
-        User:119612      | ALLOW      | IDEMPOTENT_WRITE | CLUSTER          | kafka-cluster | LITERAL
-        User:119612      | ALLOW      | WRITE            | TRANSACTIONAL_ID | *             | LITERAL
-        User:119612      | ALLOW      | DESCRIBE         | TRANSACTIONAL_ID | *             | LITERAL
-        User:119612      | ALLOW      | WRITE            | GROUP            | *             | LITERAL
-        User:119612      | ALLOW      | CREATE           | GROUP            | *             | LITERAL
-        User:119612      | ALLOW      | READ             | GROUP            | *             | LITERAL
-        User:119612      | ALLOW      | DELETE           | TOPIC            | *             | LITERAL
-        User:119612      | ALLOW      | READ             | TOPIC            | *             | LITERAL
-        User:119612      | ALLOW      | WRITE            | TOPIC            | *             | LITERAL
-        User:119612      | ALLOW      | CREATE           | TOPIC            | *             | LITERAL
-        User:119612      | ALLOW      | DESCRIBE_CONFIGS | TOPIC            | *             | LITERAL
-        User:119612      | ALLOW      | DESCRIBE         | TOPIC            | *             | LITERAL
 
+        ServiceAccountId | Permission |    Operation     |     Resource     |     Name      |  Type
+      +------------------+------------+------------------+------------------+---------------+---------+
+        User:186607      | ALLOW      | DESCRIBE         | TRANSACTIONAL_ID | *             | LITERAL
+        User:186607      | ALLOW      | WRITE            | TRANSACTIONAL_ID | *             | LITERAL
+        User:186607      | ALLOW      | IDEMPOTENT_WRITE | CLUSTER          | kafka-cluster | LITERAL
+        User:186607      | ALLOW      | READ             | GROUP            | *             | LITERAL
+        User:186607      | ALLOW      | WRITE            | GROUP            | *             | LITERAL
+        User:186607      | ALLOW      | CREATE           | GROUP            | *             | LITERAL
+        User:186607      | ALLOW      | DESCRIBE         | TOPIC            | *             | LITERAL
+        User:186607      | ALLOW      | DELETE           | TOPIC            | *             | LITERAL
+        User:186607      | ALLOW      | CREATE           | TOPIC            | *             | LITERAL
+        User:186607      | ALLOW      | DESCRIBE_CONFIGS | TOPIC            | *             | LITERAL
+        User:186607      | ALLOW      | WRITE            | TOPIC            | *             | LITERAL
+        User:186607      | ALLOW      | READ             | TOPIC            | *             | LITERAL
 
    If you ran with ksqlDB (in the output below, ksqlDB service account ID is ``119613``):
 
    .. code-block:: text
-   
-        ServiceAccountId | Permission |    Operation     |     Resource     |             Name             |   Type    
+
+ACLs in this cluster:
+        ServiceAccountId | Permission |    Operation     |     Resource     |             Name             |   Type
       +------------------+------------+------------------+------------------+------------------------------+----------+
-        User:119612      | ALLOW      | IDEMPOTENT_WRITE | CLUSTER          | kafka-cluster                | LITERAL  
-        User:119612      | ALLOW      | WRITE            | TRANSACTIONAL_ID | *                            | LITERAL  
-        User:119612      | ALLOW      | DESCRIBE         | TRANSACTIONAL_ID | *                            | LITERAL  
-        User:119612      | ALLOW      | WRITE            | GROUP            | *                            | LITERAL  
-        User:119612      | ALLOW      | CREATE           | GROUP            | *                            | LITERAL  
-        User:119612      | ALLOW      | READ             | GROUP            | *                            | LITERAL  
-        User:119612      | ALLOW      | DELETE           | TOPIC            | *                            | LITERAL  
-        User:119612      | ALLOW      | READ             | TOPIC            | *                            | LITERAL  
-        User:119612      | ALLOW      | WRITE            | TOPIC            | *                            | LITERAL  
-        User:119612      | ALLOW      | CREATE           | TOPIC            | *                            | LITERAL  
-        User:119612      | ALLOW      | DESCRIBE_CONFIGS | TOPIC            | *                            | LITERAL  
-        User:119612      | ALLOW      | DESCRIBE         | TOPIC            | *                            | LITERAL 
-        User:119613      | ALLOW      | CREATE           | TOPIC            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | DELETE           | TOPIC            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | WRITE            | TOPIC            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | DESCRIBE         | TOPIC            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | DESCRIBE_CONFIGS | TOPIC            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | ALTER_CONFIGS    | TOPIC            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | READ             | TOPIC            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | ALTER            | TOPIC            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | DESCRIBE         | CLUSTER          | kafka-cluster                | LITERAL   
-        User:119613      | ALLOW      | DESCRIBE_CONFIGS | CLUSTER          | kafka-cluster                | LITERAL   
-        User:119613      | ALLOW      | DESCRIBE_CONFIGS | GROUP            | *                            | LITERAL   
-        User:119613      | ALLOW      | DESCRIBE         | GROUP            | *                            | LITERAL   
-        User:119613      | ALLOW      | DESCRIBE         | GROUP            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | DESCRIBE_CONFIGS | GROUP            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | ALTER_CONFIGS    | GROUP            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | READ             | GROUP            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | ALTER            | GROUP            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | CREATE           | GROUP            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | DELETE           | GROUP            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | WRITE            | GROUP            | _confluent-ksql-pksqlc-81qj0 | PREFIXED  
-        User:119613      | ALLOW      | DESCRIBE_CONFIGS | TOPIC            | *                            | LITERAL   
-        User:119613      | ALLOW      | DESCRIBE         | TOPIC            | *                            | LITERAL   
-        User:119613      | ALLOW      | CREATE           | TOPIC            | pksqlc-81qj0                 | PREFIXED  
-        User:119613      | ALLOW      | DELETE           | TOPIC            | pksqlc-81qj0                 | PREFIXED  
-        User:119613      | ALLOW      | WRITE            | TOPIC            | pksqlc-81qj0                 | PREFIXED  
-        User:119613      | ALLOW      | DESCRIBE         | TOPIC            | pksqlc-81qj0                 | PREFIXED  
-        User:119613      | ALLOW      | DESCRIBE_CONFIGS | TOPIC            | pksqlc-81qj0                 | PREFIXED  
-        User:119613      | ALLOW      | ALTER_CONFIGS    | TOPIC            | pksqlc-81qj0                 | PREFIXED  
-        User:119613      | ALLOW      | READ             | TOPIC            | pksqlc-81qj0                 | PREFIXED  
-        User:119613      | ALLOW      | ALTER            | TOPIC            | pksqlc-81qj0                 | PREFIXED  
-        User:119613      | ALLOW      | WRITE            | TRANSACTIONAL_ID | pksqlc-81qj0                 | LITERAL   
-        User:119613      | ALLOW      | DESCRIBE         | TRANSACTIONAL_ID | pksqlc-81qj0                 | LITERAL   
+        User:186588      | ALLOW      | DESCRIBE_CONFIGS | GROUP            | *                            | LITERAL
+        User:186588      | ALLOW      | DESCRIBE         | GROUP            | *                            | LITERAL
+        User:186588      | ALLOW      | DELETE           | TOPIC            | pksqlc-o3g5o                 | PREFIXED
+        User:186588      | ALLOW      | READ             | TOPIC            | pksqlc-o3g5o                 | PREFIXED
+        User:186588      | ALLOW      | ALTER            | TOPIC            | pksqlc-o3g5o                 | PREFIXED
+        User:186588      | ALLOW      | DESCRIBE         | TOPIC            | pksqlc-o3g5o                 | PREFIXED
+        User:186588      | ALLOW      | ALTER_CONFIGS    | TOPIC            | pksqlc-o3g5o                 | PREFIXED
+        User:186588      | ALLOW      | DESCRIBE_CONFIGS | TOPIC            | pksqlc-o3g5o                 | PREFIXED
+        User:186588      | ALLOW      | CREATE           | TOPIC            | pksqlc-o3g5o                 | PREFIXED
+        User:186588      | ALLOW      | WRITE            | TOPIC            | pksqlc-o3g5o                 | PREFIXED
+        User:186588      | ALLOW      | DESCRIBE         | TOPIC            | *                            | LITERAL
+        User:186588      | ALLOW      | DESCRIBE_CONFIGS | TOPIC            | *                            | LITERAL
+        User:186588      | ALLOW      | DESCRIBE         | TRANSACTIONAL_ID | pksqlc-o3g5o                 | LITERAL
+        User:186588      | ALLOW      | WRITE            | TRANSACTIONAL_ID | pksqlc-o3g5o                 | LITERAL
+        User:186588      | ALLOW      | ALTER            | TOPIC            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | WRITE            | TOPIC            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | READ             | TOPIC            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | DELETE           | TOPIC            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | DESCRIBE         | TOPIC            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | ALTER_CONFIGS    | TOPIC            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | CREATE           | TOPIC            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | DESCRIBE_CONFIGS | TOPIC            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | IDEMPOTENT_WRITE | CLUSTER          | kafka-cluster                | LITERAL
+        User:186588      | ALLOW      | DESCRIBE         | CLUSTER          | kafka-cluster                | LITERAL
+        User:186588      | ALLOW      | DESCRIBE_CONFIGS | CLUSTER          | kafka-cluster                | LITERAL
+        User:186588      | ALLOW      | WRITE            | GROUP            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | DESCRIBE         | GROUP            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | DELETE           | GROUP            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | READ             | GROUP            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | CREATE           | GROUP            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | ALTER            | GROUP            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | ALTER_CONFIGS    | GROUP            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
+        User:186588      | ALLOW      | DESCRIBE_CONFIGS | GROUP            | _confluent-ksql-pksqlc-o3g5o | PREFIXED
 
 #. In addition to creating all the resources in |ccloud| with associated service account and ACLs, running ``ccloud-stack`` also generates a local configuration file with all the |ccloud| connection information, which is useful for other demos/automation. View this file at ``stack-configs/java-service-account-<SERVICE_ACCOUNT_ID>.config``. It resembles:
 
@@ -317,7 +306,7 @@ If you don't want to create and destroy a ``ccloud-stack`` using the provided ba
 
    .. code:: bash
 
-      ccloud::destroy_ccloud_stack
+      ccloud::destroy_ccloud_stack $SERVICE_ACCOUNT_ID
 
 
 ====================

--- a/clients/cloud/ccloud/ccloud-ccsr-example.sh
+++ b/clients/cloud/ccloud/ccloud-ccsr-example.sh
@@ -6,7 +6,7 @@ source ../../../utils/ccloud_library.sh
 check_timeout \
   && print_pass "timeout installed" \
   || exit 1
-ccloud::validate_version_ccloud_cli 1.13.0 \
+ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION \
   && print_pass "ccloud version ok" \
   || exit 1
 ccloud::validate_logged_in_ccloud_cli \

--- a/clients/cloud/ccloud/ccloud-example.sh
+++ b/clients/cloud/ccloud/ccloud-example.sh
@@ -6,7 +6,7 @@ source ../../../utils/ccloud_library.sh
 check_timeout \
   && print_pass "timeout installed" \
   || exit 1
-ccloud::validate_version_ccloud_cli 1.13.0 \
+ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION \
   && print_pass "ccloud version ok" \
   || exit 1
 ccloud::validate_logged_in_ccloud_cli \

--- a/clients/docs/ccloud.rst
+++ b/clients/docs/ccloud.rst
@@ -15,7 +15,7 @@ Prerequisites
 Client
 ~~~~~~
 
--  Local install of `Confluent Cloud CLI <https://docs.confluent.io/ccloud-cli/current/install.html>`__ v1.13.0 or later.
+-  Local install of `Confluent Cloud CLI <https://docs.confluent.io/ccloud-cli/current/install.html>`__ v1.22.1 or later.
 -  .. include:: ../../ccloud/docs/includes/prereq_timeout.rst
 
 

--- a/cloud-etl/start.sh
+++ b/cloud-etl/start.sh
@@ -9,7 +9,7 @@ NAME=`basename "$0"`
 source ../utils/helper.sh
 source ../utils/ccloud_library.sh
 
-ccloud::validate_version_ccloud_cli 1.7.0 \
+ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION \
   && print_pass "ccloud version ok" \
   || exit 1
 ccloud::validate_logged_in_ccloud_cli \

--- a/cp-quickstart/start-cloud.sh
+++ b/cp-quickstart/start-cloud.sh
@@ -18,7 +18,7 @@ source ../utils/ccloud_library.sh
 check_jq \
   && print_pass "jq found"
 
-ccloud::validate_version_ccloud_cli 1.7.0 \
+ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION \
   && print_pass "ccloud version ok"
 
 ccloud::validate_logged_in_ccloud_cli \

--- a/microservices-orders/start-ccloud.sh
+++ b/microservices-orders/start-ccloud.sh
@@ -6,7 +6,7 @@ source ../utils/helper.sh
 
 MAX_WAIT=${MAX_WAIT:-60}
 
-ccloud::validate_version_ccloud_cli 1.20.1 \
+ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION \
   && print_pass "ccloud version ok"
 
 ccloud::validate_logged_in_ccloud_cli \

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -105,11 +105,10 @@ function ccloud::validate_version_ccloud_cli() {
 
   ccloud::validate_ccloud_cli_installed || exit 1
 
-  REQUIRED_CCLOUD_VER=${1:-$CCLOUD_MIN_VERSION}
   CCLOUD_VER=$(ccloud::get_version_ccloud_cli)
 
-  if ccloud::version_gt $REQUIRED_CCLOUD_VER $CCLOUD_VER; then
-    echo "ccloud version ${REQUIRED_CCLOUD_VER} or greater is required.  Current reported version: ${CCLOUD_VER}"
+  if ccloud::version_gt $CCLOUD_MIN_VERSION $CCLOUD_VER; then
+    echo "ccloud version ${CCLOUD_MIN_VERSION} or greater is required.  Current reported version: ${CCLOUD_VER}"
     echo 'To update run: ccloud update'
     exit 1
   fi

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -28,6 +28,8 @@
 # --------------------------------------------------------------
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+CCLOUD_MIN_VERSION=${CCLOUD_MIN_VERSION:-1.22.1}
+
 # --------------------------------------------------------------
 # Library
 # --------------------------------------------------------------
@@ -103,7 +105,7 @@ function ccloud::validate_version_ccloud_cli() {
 
   ccloud::validate_ccloud_cli_installed || exit 1
 
-  REQUIRED_CCLOUD_VER=${1:-"1.7.0"}
+  REQUIRED_CCLOUD_VER=${1:-$CCLOUD_MIN_VERSION}
   CCLOUD_VER=$(ccloud::get_version_ccloud_cli)
 
   if ccloud::version_gt $REQUIRED_CCLOUD_VER $CCLOUD_VER; then
@@ -418,7 +420,7 @@ function ccloud::create_credentials_resource() {
 #####################################################################
 # The return from this function will be a colon ':' delimited
 #   list, if the api-key is created the second element of the
-#   list will the secret.  If the api-key is being reused
+#   list will be the secret.  If the api-key is being reused
 #   the second element of the list will be empty
 #####################################################################
 function ccloud::maybe_create_credentials_resource() {
@@ -451,8 +453,12 @@ function ccloud::find_ksqldb_app() {
 function ccloud::create_ksqldb_app() {
   KSQLDB_NAME=$1
   CLUSTER=$2
+  # colon deliminated credentials (APIKEY:APISECRET)
+  local ksqlDB_kafka_creds=$3
+  local kafka_api_key=$(echo $ksqlDB_kafka_creds | cut -d':' -f1)
+  local kafka_api_secret=$(echo $ksqlDB_kafka_creds | cut -d':' -f2)
 
-  KSQLDB=$(ccloud ksql app create --cluster $CLUSTER -o json "$KSQLDB_NAME" | jq -r ".id")
+  KSQLDB=$(ccloud ksql app create --cluster $CLUSTER --api-key "$kafka_api_key" --api-secret "$kafka_api_secret" -o json "$KSQLDB_NAME" | jq -r ".id")
   echo $KSQLDB
 
   return 0
@@ -460,13 +466,15 @@ function ccloud::create_ksqldb_app() {
 function ccloud::maybe_create_ksqldb_app() {
   KSQLDB_NAME=$1
   CLUSTER=$2
+  # colon deliminated credentials (APIKEY:APISECRET)
+  local ksqlDB_kafka_creds=$3
   
   APP_ID=$(ccloud::find_ksqldb_app $KSQLDB_NAME $CLUSTER)
   if [ $? -eq 0 ]
   then
     echo $APP_ID
   else
-    ccloud::create_ksqldb_app "$KSQLDB_NAME" "$CLUSTER"
+    ccloud::create_ksqldb_app "$KSQLDB_NAME" "$CLUSTER" "$ksqlDB_kafka_creds"
   fi
 
   return 0
@@ -879,6 +887,9 @@ function ccloud::set_kafka_cluster_use() {
 # https://docs.confluent.io/platform/current/tutorials/examples/ccloud/docs/ccloud-stack.html
 #
 function ccloud::create_ccloud_stack() {
+	
+	ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION || exit 1
+
   QUIET="${QUIET:-true}"
   REPLICATION_FACTOR=${REPLICATION_FACTOR:-3}
   enable_ksqldb=${1:-false}
@@ -897,12 +908,14 @@ function ccloud::create_ccloud_stack() {
     SERVICE_ACCOUNT_ID=$(ccloud::create_service_account $SERVICE_NAME)
   fi
 
+
   if [[ "$SERVICE_NAME" == "" ]]; then
     echo "ERROR: SERVICE_NAME is not defined. If you are providing the SERVICE_ACCOUNT_ID to this function please also provide the SERVICE_NAME"
     exit 1
   fi
 
   echo "Creating Confluent Cloud stack for service account $SERVICE_NAME, ID: $SERVICE_ACCOUNT_ID."
+
 
   if [[ -z "$ENVIRONMENT" ]]; 
   then
@@ -924,6 +937,7 @@ function ccloud::create_ccloud_stack() {
     echo "ERROR: Could not create cluster. Please troubleshoot"
     exit 1
   fi
+
   BOOTSTRAP_SERVERS=$(ccloud kafka cluster describe $CLUSTER -o json | jq -r ".endpoint" | cut -c 12-)
   CLUSTER_CREDS=$(ccloud::maybe_create_credentials_resource $SERVICE_ACCOUNT_ID $CLUSTER)
 
@@ -937,6 +951,8 @@ function ccloud::create_ccloud_stack() {
   echo "Sleeping an additional ${WARMUP_TIME} seconds to ensure propagation of all metadata"
   sleep $WARMUP_TIME 
 
+  ccloud::create_acls_all_resources_full_access $SERVICE_ACCOUNT_ID
+
   SCHEMA_REGISTRY_GEO="${SCHEMA_REGISTRY_GEO:-us}"
   SCHEMA_REGISTRY=$(ccloud::enable_schema_registry $CLUSTER_CLOUD $SCHEMA_REGISTRY_GEO)
   SCHEMA_REGISTRY_ENDPOINT=$(ccloud schema-registry cluster describe -o json | jq -r ".endpoint_url")
@@ -944,14 +960,11 @@ function ccloud::create_ccloud_stack() {
   
   if $enable_ksqldb ; then
     KSQLDB_NAME=${KSQLDB_NAME:-"demo-ksqldb-$SERVICE_ACCOUNT_ID"}
-    KSQLDB=$(ccloud::maybe_create_ksqldb_app "$KSQLDB_NAME" $CLUSTER)
+    KSQLDB=$(ccloud::maybe_create_ksqldb_app "$KSQLDB_NAME" $CLUSTER "$CLUSTER_CREDS")
     KSQLDB_ENDPOINT=$(ccloud ksql app describe $KSQLDB -o json | jq -r ".endpoint")
-    KSQLDB_SERVICE_ACCOUNT_ID=$(ccloud service-account list -o json 2>/dev/null | jq -r "map(select(.name == \"KSQL.$KSQLDB\")) | .[0].id")
-    KSQLDB_CREDS=$(ccloud::maybe_create_credentials_resource $KSQLDB_SERVICE_ACCOUNT_ID $KSQLDB)
-    ccloud ksql app configure-acls $KSQLDB
+    KSQLDB_CREDS=$(ccloud::maybe_create_credentials_resource $SERVICE_ACCOUNT_ID $KSQLDB)
+		ccloud ksql app configure-acls $KSQLDB
   fi
-
-  ccloud::create_acls_all_resources_full_access $SERVICE_ACCOUNT_ID
 
   CLOUD_API_KEY=`echo $CLUSTER_CREDS | awk -F: '{print $1}'`
   CLOUD_API_SECRET=`echo $CLUSTER_CREDS | awk -F: '{print $2}'`
@@ -1003,6 +1016,11 @@ EOF
 }
 
 function ccloud::destroy_ccloud_stack() {
+	if [ $# -eq 0 ];then
+	  echo "ccloud::destroy_ccloud_stack requires a single parameter, the service account id."
+		exit 1
+	fi
+
   SERVICE_ACCOUNT_ID=$1
 
   PRESERVE_ENVIRONMENT="${PRESERVE_ENVIRONMENT:-false}"
@@ -1020,12 +1038,6 @@ function ccloud::destroy_ccloud_stack() {
 
   echo "Destroying Confluent Cloud stack associated to service account id $SERVICE_ACCOUNT_ID"
 
-  # Delete API keys associated to the service account
-  ccloud api-key list --service-account $SERVICE_ACCOUNT_ID -o json | jq -r '.[].key' | xargs -I{} ccloud api-key delete {}
-
-  ccloud::delete_acls_ccloud_stack $SERVICE_ACCOUNT_ID
-  ccloud service-account delete $SERVICE_ACCOUNT_ID &>"$REDIRECT_TO" 
-
   if [[ "$KSQLDB_ENDPOINT" != "" ]]; then # This is just a quick check, if set there is a KSQLDB in this stack
     local ksqldb_id=$(ccloud ksql app list -o json | jq -r 'map(select(.name == "'"$KSQLDB_NAME"'")) | .[].id')
     echo "Deleting KSQLDB: $KSQLDB_NAME : $ksqldb_id"
@@ -1038,6 +1050,12 @@ function ccloud::destroy_ccloud_stack() {
 
   echo "Deleting CLUSTER: $CLUSTER_NAME : $cluster_id"
   ccloud kafka cluster delete $cluster_id &> "$REDIRECT_TO"
+
+  # Delete API keys associated to the service account
+  ccloud api-key list --service-account $SERVICE_ACCOUNT_ID -o json | jq -r '.[].key' | xargs -I{} ccloud api-key delete {}
+
+  ccloud::delete_acls_ccloud_stack $SERVICE_ACCOUNT_ID
+  ccloud service-account delete $SERVICE_ACCOUNT_ID &>"$REDIRECT_TO" 
 
   if [[ $PRESERVE_ENVIRONMENT == "false" ]]; then
     local environment_id=$(ccloud environment list -o json | jq -r 'map(select(.name | startswith("'"$ENVIRONMENT_NAME_PREFIX"'"))) | .[].id')

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -529,18 +529,18 @@ function ccloud::delete_acls_ccloud_stack() {
 }
 
 function ccloud::validate_ccloud_config() {
-	[ -z "$1" ] && {
-  	echo "ccloud::validate_ccloud_config expects one parameter (configuration file with Confluent Cloud connection information)"
-  	exit 1
+  [ -z "$1" ] && {
+    echo "ccloud::validate_ccloud_config expects one parameter (configuration file with Confluent Cloud connection information)"
+    exit 1
   }
 
-	local cfg_file="$1"
-	local bootstrap=$(grep "bootstrap\.servers" "$cfg_file" | cut -d'=' -f2-)
-	[ -z "$bootstrap" ] && {
-		echo "ERROR: Cannot read the 'bootstrap.servers' key-value pair from $cfg_file."
-		exit 1;
-	}
-	return 0;
+  local cfg_file="$1"
+  local bootstrap=$(grep "bootstrap\.servers" "$cfg_file" | cut -d'=' -f2-)
+  [ -z "$bootstrap" ] && {
+    echo "ERROR: Cannot read the 'bootstrap.servers' key-value pair from $cfg_file."
+    exit 1;
+  }
+  return 0;
 }
 
 function ccloud::validate_ksqldb_up() {
@@ -887,8 +887,8 @@ function ccloud::set_kafka_cluster_use() {
 # https://docs.confluent.io/platform/current/tutorials/examples/ccloud/docs/ccloud-stack.html
 #
 function ccloud::create_ccloud_stack() {
-	
-	ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION || exit 1
+  
+  ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION || exit 1
 
   QUIET="${QUIET:-true}"
   REPLICATION_FACTOR=${REPLICATION_FACTOR:-3}
@@ -963,7 +963,7 @@ function ccloud::create_ccloud_stack() {
     KSQLDB=$(ccloud::maybe_create_ksqldb_app "$KSQLDB_NAME" $CLUSTER "$CLUSTER_CREDS")
     KSQLDB_ENDPOINT=$(ccloud ksql app describe $KSQLDB -o json | jq -r ".endpoint")
     KSQLDB_CREDS=$(ccloud::maybe_create_credentials_resource $SERVICE_ACCOUNT_ID $KSQLDB)
-		ccloud ksql app configure-acls $KSQLDB
+    ccloud ksql app configure-acls $KSQLDB
   fi
 
   CLOUD_API_KEY=`echo $CLUSTER_CREDS | awk -F: '{print $1}'`
@@ -1016,10 +1016,10 @@ EOF
 }
 
 function ccloud::destroy_ccloud_stack() {
-	if [ $# -eq 0 ];then
-	  echo "ccloud::destroy_ccloud_stack requires a single parameter, the service account id."
-		exit 1
-	fi
+  if [ $# -eq 0 ];then
+    echo "ccloud::destroy_ccloud_stack requires a single parameter, the service account id."
+    exit 1
+  fi
 
   SERVICE_ACCOUNT_ID=$1
 
@@ -1648,11 +1648,11 @@ EOF
   
   cat <<EOF >> $GO_CONFIG
 import (
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+  "github.com/confluentinc/confluent-kafka-go/kafka"
   
  
 producer, err := kafka.NewProducer(&kafka.ConfigMap{
-	         "bootstrap.servers": "$BOOTSTRAP_SERVERS",
+           "bootstrap.servers": "$BOOTSTRAP_SERVERS",
           "broker.version.fallback": "0.10.0.0",
           "api.version.fallback.ms": 0,
           "sasl.mechanisms": "PLAIN",
@@ -1665,15 +1665,15 @@ producer, err := kafka.NewProducer(&kafka.ConfigMap{
                  })
  
 consumer, err := kafka.NewConsumer(&kafka.ConfigMap{
-		 "bootstrap.servers": "$BOOTSTRAP_SERVERS",
-  		 "broker.version.fallback": "0.10.0.0",
-  		 "api.version.fallback.ms": 0,
-  		 "sasl.mechanisms": "PLAIN",
-  		 "security.protocol": "SASL_SSL",
-  		 "sasl.username": "$CLOUD_KEY",
-  		 "sasl.password": "$CLOUD_SECRET",
+     "bootstrap.servers": "$BOOTSTRAP_SERVERS",
+       "broker.version.fallback": "0.10.0.0",
+       "api.version.fallback.ms": 0,
+       "sasl.mechanisms": "PLAIN",
+       "security.protocol": "SASL_SSL",
+       "sasl.username": "$CLOUD_KEY",
+       "sasl.password": "$CLOUD_SECRET",
                  // "ssl.ca.location": "/usr/local/etc/openssl/cert.pem", // varies by distro
-  		 "session.timeout.ms": 6000,
+       "session.timeout.ms": 6000,
                  "plugin.library.paths": "monitoring-interceptor",
                  // .... additional configuration settings
                  })


### PR DESCRIPTION
### Description 

ccloud-stack: ksqlDB app creation reuses SA. There are other fixes as well related to docs, some minor functional reordering and validtions on functions.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

- [X] Documentation
- [X] ccloud/ccloud-stack (script and source function)
- [X] cp-quickstart cloud

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

- [ ] Any demo which uses ccloud-stack