### PR TITLE
DEVX-1791: Create librdkafka-friendly file auto-generated by dynamic …

### DIFF
--- a/ccloud/template_delta_configs/librdkafka.delta
+++ b/ccloud/template_delta_configs/librdkafka.delta
@@ -1,0 +1,7 @@
+bootstrap.servers="<CCLOUD_BOOTSTRAP_SERVER>"
+security.protocol=SASL_SSL
+sasl.mechanisms=PLAIN
+sasl.username="<CCLOUD_API_KEY>"
+sasl.password="<CCLOUD_API_SECRET>"
+schema.registry.url="https://<SCHEMA_REGISTRY_ENDPOINT>"
+basic.auth.user.info="<SCHEMA_REGISTRY_API_KEY>:<SCHEMA_REGISTRY_API_SECRET>"

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -1100,6 +1100,7 @@ function ccloud::destroy_ccloud_stack() {
 # Kafka Clients:
 # - Java (Producer/Consumer)
 # - Java (Streams)
+# - librdkafka config
 # - Python
 # - .NET
 # - Go
@@ -1568,6 +1569,24 @@ EOF
   chmod $PERM $JAVA_STREAMS_CONFIG
   
   ################################################################################
+  # librdkafka
+  ################################################################################
+  LIBRDKAFKA_CONFIG=$DEST/librdkafka.delta
+  echo "$LIBRDKAFKA_CONFIG"
+  rm -f $LIBRDKAFKA_CONFIG
+  
+  cat <<EOF >> $LIBRDKAFKA_CONFIG
+bootstrap.servers="$BOOTSTRAP_SERVERS"
+security.protocol=SASL_SSL
+sasl.mechanisms=PLAIN
+sasl.username="$CLOUD_KEY"
+sasl.password="$CLOUD_SECRET"
+schema.registry.url="$SCHEMA_REGISTRY_URL"
+basic.auth.user.info="$SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO"
+EOF
+  chmod $PERM $LIBRDKAFKA_CONFIG
+  
+  ################################################################################
   # Python
   ################################################################################
   PYTHON_CONFIG=$DEST/python.delta
@@ -1790,7 +1809,6 @@ EOF
 
   return 0
 }
-
 
 ##############################################
 # These are some duplicate functions from 


### PR DESCRIPTION
…ccloud-stack variables

### Description 

https://confluentinc.atlassian.net/browse/DEVX-1791

_What behavior does this PR change, and why?_

librdkafka coverage in the script that creates delta config files (from the java-friendly one created by ccloud-stack)

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
