### PR TITLE
DEVX-2558: ccloud min ver to 1.25.0

### DIFF
--- a/ccloud-observability/docs/observability-overview.rst
+++ b/ccloud-observability/docs/observability-overview.rst
@@ -25,7 +25,7 @@ Prerequisites
 -  Access to `Confluent Cloud <https://confluent.cloud/login>`__.
 
 -  Local `install of Confluent Cloud CLI
-   <https://docs.confluent.io/ccloud-cli/current/install.html>`__ (v1.24.0 or later)
+   <https://docs.confluent.io/ccloud-cli/current/install.html>`__ (v1.25.0 or later)
 
 -  `jq <https://github.com/stedolan/jq/wiki/Installation>`__ installed on your host
 

--- a/ccloud/docs/beginner-cloud.rst
+++ b/ccloud/docs/beginner-cloud.rst
@@ -31,7 +31,7 @@ Prerequisites
 -  Access to `Confluent Cloud <https://confluent.cloud/login>`__.
 
 -  Local `install of Confluent Cloud CLI
-   <https://docs.confluent.io/ccloud-cli/current/install.html>`__ (v1.24.0 or later)
+   <https://docs.confluent.io/ccloud-cli/current/install.html>`__ (v1.25.0 or later)
 
 -  .. include:: ../../ccloud/docs/includes/prereq_timeout.rst
 

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -70,7 +70,7 @@ Prerequisites
 =============
 
 - Create a user account in `Confluent Cloud <https://www.confluent.io/confluent-cloud/>`__
-- Local install of `Confluent Cloud CLI <https://docs.confluent.io/ccloud-cli/current/install.html>`__ v1.24.0 or later.
+- Local install of `Confluent Cloud CLI <https://docs.confluent.io/ccloud-cli/current/install.html>`__ v1.25.0 or later.
 - ``jq`` tool
 
 Note that ``ccloud-stack`` has been validated on macOS 10.15.3 with bash version 3.2.57.

--- a/clients/docs/ccloud.rst
+++ b/clients/docs/ccloud.rst
@@ -15,7 +15,7 @@ Prerequisites
 Client
 ~~~~~~
 
--  Local install of `Confluent Cloud CLI <https://docs.confluent.io/ccloud-cli/current/install.html>`__ v1.24.0 or later.
+-  Local install of `Confluent Cloud CLI <https://docs.confluent.io/ccloud-cli/current/install.html>`__ v1.25.0 or later.
 -  .. include:: ../../ccloud/docs/includes/prereq_timeout.rst
 
 

--- a/cloud-etl/docs/index.rst
+++ b/cloud-etl/docs/index.rst
@@ -95,7 +95,7 @@ Cloud services
 Local Tools
 ~~~~~~~~~~~
 
--  `Confluent Cloud CLI <https://docs.confluent.io/ccloud-cli/current/install.html>`__ v1.24.0 or later, logged in with the ``--save`` argument which saves your |ccloud| user login credentials or refresh token (in the case of SSO) to the local ``netrc`` file.
+-  `Confluent Cloud CLI <https://docs.confluent.io/ccloud-cli/current/install.html>`__ v1.25.0 or later, logged in with the ``--save`` argument which saves your |ccloud| user login credentials or refresh token (in the case of SSO) to the local ``netrc`` file.
 -  ``gsutil`` CLI, properly initialized with your credentials: (optional) if destination is GCP GCS
 -  ``aws`` CLI, properly initialized with your credentials: used for AWS Kinesis or RDS PostgreSQL, and (optional) if destination is AWS S3
 -  ``az`` CLI, properly initialized with your credentials: (optional) if destination is Azure Blob storage

--- a/kubernetes/replicator-aks-cc/docs/index.rst
+++ b/kubernetes/replicator-aks-cc/docs/index.rst
@@ -36,7 +36,7 @@ The following applications or libraries are required to be installed and availab
 +------------------+----------------+-------------------------------------------------------------------------------------+
 | ``az``           | ``2.10.1``     | https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest  |
 +------------------+----------------+-------------------------------------------------------------------------------------+
-| ``ccloud``       | ``v1.24.0``    | https://docs.confluent.io/ccloud-cli/current/install.html                           |
+| ``ccloud``       | ``v1.25.0``    | https://docs.confluent.io/ccloud-cli/current/install.html                           |
 +------------------+----------------+-------------------------------------------------------------------------------------+
 
 .. include:: ../../docs/includes/helm3-requirement-note.rst

--- a/kubernetes/replicator-gke-cc/docs/index.rst
+++ b/kubernetes/replicator-gke-cc/docs/index.rst
@@ -38,7 +38,7 @@ The following applications or libraries are required to be installed and availab
 | ``GCP sdk core`` | ``2020.03.24``    |                                                           |
 | ``GKE cluster``  | ``1.15.11-gke.1`` |                                                           |
 +------------------+-------------------+-----------------------------------------------------------+
-| ``ccloud``       | ``v1.24.0``       | https://docs.confluent.io/ccloud-cli/current/install.html |
+| ``ccloud``       | ``v1.25.0``       | https://docs.confluent.io/ccloud-cli/current/install.html |
 +------------------+-------------------+-----------------------------------------------------------+
 
 .. include:: ../../docs/includes/helm3-requirement-note.rst

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -28,7 +28,7 @@
 # --------------------------------------------------------------
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-CCLOUD_MIN_VERSION=${CCLOUD_MIN_VERSION:-1.24.0}
+CCLOUD_MIN_VERSION=${CCLOUD_MIN_VERSION:-1.25.0}
 
 # --------------------------------------------------------------
 # Library


### PR DESCRIPTION
### Description 

Sets minimum ccloud CLI version to 1.25.0 across demos

### Author Validation

- [x] ccloud/ccloud-stack

### Reviewer Tasks
- [ ] Documentation
any ccloud demo


Local test prior to upgrade:
```
➜ ./ccloud_stack_create.sh
Updates are available for ccloud from (current: v1.24.0, latest: v1.25.0).
To view release notes and install them, please run:
$ ccloud update

ccloud version 1.25.0 or greater is required.  Current reported version: 1.24.0
To update run: ccloud update

➜ ccloud update
...

➜ ./ccloud_stack_create.sh
...
To destroy this Confluent Cloud stack run ->
     ./ccloud_stack_destroy.sh stack-configs/java-service-account-197504.config


Tip: 'ccloud' CLI has been set to the new environment env-k6wnv
```