### PR TITLE
DEVX-2559: make ccloud-stack functions more verbose by default

### DIFF
--- a/ccloud-observability/start.sh
+++ b/ccloud-observability/start.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 NAME=`basename "$0"`
-QUIET="${QUIET:-true}"
+# Setting default QUIET=false to surface potential errors
+QUIET="${QUIET:-false}"
 [[ $QUIET == "true" ]] && 
   REDIRECT_TO="/dev/null" ||
   REDIRECT_TO="/dev/stdout"

--- a/cp-quickstart/start-cloud.sh
+++ b/cp-quickstart/start-cloud.sh
@@ -6,7 +6,8 @@
 #########################################
 
 NAME=`basename "$0"`
-QUIET="${QUIET:-true}"
+# Setting default QUIET=false to surface potential errors
+QUIET="${QUIET:-false}"
 [[ $QUIET == "true" ]] && 
   REDIRECT_TO="/dev/null" ||
   REDIRECT_TO="/dev/stdout"

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -510,6 +510,11 @@ function ccloud::create_acls_all_resources_full_access() {
 
 function ccloud::delete_acls_ccloud_stack() {
   SERVICE_ACCOUNT_ID=$1
+  # Setting default QUIET=false to surface potential errors
+  QUIET="${QUIET:-false}"
+  [[ $QUIET == "false" ]] &&
+    local REDIRECT_TO="/dev/null" ||
+    local REDIRECT_TO="/dev/stdout"
 
   echo "Deleting ACLs for service account ID $SERVICE_ACCOUNT_ID"
 

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -481,7 +481,9 @@ function ccloud::maybe_create_ksqldb_app() {
 
 function ccloud::create_acls_all_resources_full_access() {
   SERVICE_ACCOUNT_ID=$1
-  [[ $QUIET == "true" ]] && 
+  # Setting default QUIET=false to surface potential errors
+  QUIET="${QUIET:-false}"
+  [[ $QUIET == "false" ]] &&
     local REDIRECT_TO="/dev/null" ||
     local REDIRECT_TO="/dev/stdout"
 
@@ -510,8 +512,6 @@ function ccloud::delete_acls_ccloud_stack() {
   SERVICE_ACCOUNT_ID=$1
 
   echo "Deleting ACLs for service account ID $SERVICE_ACCOUNT_ID"
-
-  local REDIRECT_TO="/dev/null"
 
   ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --topic '*' &>"$REDIRECT_TO"
   ccloud kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation DELETE --topic '*' &>"$REDIRECT_TO"
@@ -896,7 +896,7 @@ function ccloud::create_ccloud_stack() {
   
   ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION || exit 1
 
-  QUIET="${QUIET:-true}"
+  QUIET="${QUIET:-false}"
   REPLICATION_FACTOR=${REPLICATION_FACTOR:-3}
   enable_ksqldb=${1:-false}
   EXAMPLE=${EXAMPLE:-ccloud-stack-function}
@@ -1036,13 +1036,16 @@ function ccloud::destroy_ccloud_stack() {
   CONFIG_FILE=${CONFIG_FILE:-"stack-configs/java-service-account-$SERVICE_ACCOUNT_ID.config"}
   KSQLDB_NAME=${KSQLDB_NAME:-"demo-ksqldb-$SERVICE_ACCOUNT_ID"}
 
-  # Setting default QUIET=false to surface potential deletion errors
+  # Setting default QUIET=false to surface potential errors
   QUIET="${QUIET:-false}"
   [[ $QUIET == "true" ]] && 
     local REDIRECT_TO="/dev/null" ||
     local REDIRECT_TO="/dev/stdout"
 
   echo "Destroying Confluent Cloud stack associated to service account id $SERVICE_ACCOUNT_ID"
+
+  # Delete associated ACLs
+  ccloud::delete_acls_ccloud_stack $SERVICE_ACCOUNT_ID
 
   if [[ "$KSQLDB_ENDPOINT" != "" ]]; then # This is just a quick check, if set there is a KSQLDB in this stack
     local ksqldb_id=$(ccloud ksql app list -o json | jq -r 'map(select(.name == "'"$KSQLDB_NAME"'")) | .[].id')
@@ -1060,7 +1063,7 @@ function ccloud::destroy_ccloud_stack() {
   # Delete API keys associated to the service account
   ccloud api-key list --service-account $SERVICE_ACCOUNT_ID -o json | jq -r '.[].key' | xargs -I{} ccloud api-key delete {}
 
-  ccloud::delete_acls_ccloud_stack $SERVICE_ACCOUNT_ID
+  # Delete service account
   ccloud service-account delete $SERVICE_ACCOUNT_ID &>"$REDIRECT_TO" 
 
   if [[ $PRESERVE_ENVIRONMENT == "false" ]]; then


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2559


_What behavior does this PR change, and why?_

- Make ccloud-stack functions more verbose by default to help surface errors (if they do occur)
- Fix ordering of ACL deletion (occur before cluster deletion) so it does not fail

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
- [ ] ccloud/ccloud-stack
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
