### PR TITLE
DEVX-2562: Issues with REST Proxy example to Confluent Cloud

### DIFF
--- a/ccloud/ccloud-generate-cp-configs.sh
+++ b/ccloud/ccloud-generate-cp-configs.sh
@@ -3,6 +3,7 @@
 # This file is deprecated in favor of the function in ../utils/ccloud_library.sh
 
 # Source library
-source ../utils/ccloud_library.sh
+DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+source ${DIR_THIS}/../utils/ccloud_library.sh
 
 ccloud::generate_configs "$1"

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -194,7 +194,7 @@ Create a ccloud-stack
       bootstrap.servers=<BROKER ENDPOINT>
       sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='<API KEY>' password='<API SECRET>';
       basic.auth.credentials.source=USER_INFO
-      schema.registry.basic.auth.user.info=<SR API KEY>:<SR API SECRET>
+      basic.auth.user.info=<SR API KEY>:<SR API SECRET>
       schema.registry.url=https://<SR ENDPOINT>
       ksql.endpoint=<KSQLDB ENDPOINT>
       ksql.basic.auth.user.info=<KSQLDB API KEY>:<KSQLDB API SECRET>

--- a/clients/cloud/rest-proxy/produce-ccsr.sh
+++ b/clients/cloud/rest-proxy/produce-ccsr.sh
@@ -14,7 +14,7 @@ KAFKA_CLUSTER_ID=$(docker-compose exec rest-proxy curl -X GET \
 # Create topic (API v3)
 docker-compose exec rest-proxy curl -X POST \
      -H "Content-Type: application/json" \
-     -d "{\"topic_name\":\"test2\",\"partitions_count\":6,\"replication_factor\":3,\"configs\":[]}" \
+     -d "{\"topic_name\":\"test2\",\"partitions_count\":6,\"configs\":[]}" \
      "http://localhost:8082/v3/clusters/${KAFKA_CLUSTER_ID}/topics" | jq .
 
 # Register a new Avro schema for topic test2

--- a/clients/cloud/rest-proxy/produce.sh
+++ b/clients/cloud/rest-proxy/produce.sh
@@ -7,7 +7,7 @@ KAFKA_CLUSTER_ID=$(docker-compose exec rest-proxy curl -X GET \
 # Create topic (API v3)
 docker-compose exec rest-proxy curl -X POST \
      -H "Content-Type: application/json" \
-     -d "{\"topic_name\":\"test1\",\"partitions_count\":6,\"replication_factor\":3,\"configs\":[]}" \
+     -d "{\"topic_name\":\"test1\",\"partitions_count\":6,\"configs\":[]}" \
      "http://localhost:8082/v3/clusters/${KAFKA_CLUSTER_ID}/topics" | jq .
 
 # Produce 3 messages using JSON (API v2)

--- a/clients/docs/rest-proxy.rst
+++ b/clients/docs/rest-proxy.rst
@@ -108,7 +108,7 @@ Produce Records
 
       echo $KAFKA_CLUSTER_ID
 
-#. Create the |ak| topic ``test1`` using the ``AdminClient`` functionality of the |crest| API v3. If |crest| is backed to |ccloud|, configure the replication factor to ``3``.
+#. Create the |ak| topic ``test1`` using the ``AdminClient`` functionality of the |crest| API v3.
 
    .. literalinclude:: ../cloud/rest-proxy/produce.sh
       :lines: 8-11
@@ -126,7 +126,7 @@ Produce Records
         "cluster_id": "lkc-56ngz",
         "topic_name": "test2",
         "is_internal": false,
-        "replication_factor": 3,
+        "replication_factor": 0,
         "partitions": {
           "related": "http://rest-proxy:8082/v3/clusters/lkc-56ngz/topics/test2/partitions"
         },
@@ -311,7 +311,7 @@ Produce Avro Records
    in this tutorial, it is shown as ``lkc-56ngz``, but it will differ in your
    output.
 
-#. Create the |ak| topic ``test2`` using the ``AdminClient`` functionality of the |crest| API v3. If |crest| is backed to |ccloud|, configure the replication factor to ``3``.
+#. Create the |ak| topic ``test2`` using the ``AdminClient`` functionality of the |crest| API v3.
 
    .. literalinclude:: ../cloud/rest-proxy/produce-ccsr.sh
       :lines: 15-18
@@ -329,7 +329,7 @@ Produce Avro Records
         "cluster_id": "lkc-56ngz",
         "topic_name": "test2",
         "is_internal": false,
-        "replication_factor": 3,
+        "replication_factor": 0,
         "partitions": {
           "related": "http://rest-proxy:8082/v3/clusters/lkc-56ngz/topics/test2/partitions"
         },

--- a/clients/docs/rest-proxy.rst
+++ b/clients/docs/rest-proxy.rst
@@ -89,7 +89,7 @@ Produce Records
 
        docker-compose up -d rest-proxy
 
-#. View the |crest| logs in Docker and wait till you see the log message ``Server started, listening for requests`` to confirm |crest| has started.
+#. View the |crest| logs and wait till you see the log message ``Server started, listening for requests`` to confirm it has started.
 
    .. code-block:: text
 
@@ -296,7 +296,7 @@ Produce Avro Records
 
        docker-compose up -d rest-proxy
 
-#. View the |crest| logs in Docker and wait till you see the log message ``Server started, listening for requests`` to confirm |crest| has started.
+#. View the |crest| logs and wait till you see the log message ``Server started, listening for requests`` to confirm it has started.
 
    .. code-block:: text
 

--- a/clients/docs/rest-proxy.rst
+++ b/clients/docs/rest-proxy.rst
@@ -44,7 +44,7 @@ Setup
 
    .. code-block:: text
 
-      ../../../ccloud/ccloud-generate-cp-configs.sh $HOME/.confluent/java.config
+      (cd ../../../ccloud/ && ./ccloud-generate-cp-configs.sh $HOME/.confluent/java.config)
 
 #. Source the generated file of ``ENV`` variables.
 

--- a/clients/docs/rest-proxy.rst
+++ b/clients/docs/rest-proxy.rst
@@ -44,7 +44,7 @@ Setup
 
    .. code-block:: text
 
-      (cd ../../../ccloud/ && ./ccloud-generate-cp-configs.sh $HOME/.confluent/java.config)
+      ../../../ccloud/ccloud-generate-cp-configs.sh $HOME/.confluent/java.config
 
 #. Source the generated file of ``ENV`` variables.
 
@@ -66,6 +66,23 @@ Setup
 
       cat docker-compose.yml
 
+Basic Producer and Consumer
+---------------------------
+
+.. include:: includes/producer-consumer-description.rst
+
+
+Produce Records
+~~~~~~~~~~~~~~~
+
+#. Since you are not going to use |sr| in this section, comment out the following lines in the ``docker-compose.yml`` file:
+
+   .. code-block:: text
+
+      #KAFKA_REST_SCHEMA_REGISTRY_URL: $SCHEMA_REGISTRY_URL
+      #KAFKA_REST_CLIENT_BASIC_AUTH_CREDENTIALS_SOURCE: $BASIC_AUTH_CREDENTIALS_SOURCE
+      #KAFKA_REST_CLIENT_SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO: $SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO
+
 #. Start the |crest| Docker container by running the following command:
 
    .. code-block:: text
@@ -77,16 +94,6 @@ Setup
    .. code-block:: text
 
       docker-compose logs -f rest-proxy
-
-
-Basic Producer and Consumer
----------------------------
-
-.. include:: includes/producer-consumer-description.rst
-
-
-Produce Records
-~~~~~~~~~~~~~~~
 
 #. Get the |ak| cluster ID that the |crest| is connected to.
 
@@ -236,6 +243,15 @@ Consume Records
 
 #. View the :devx-examples:`consumer code|clients/cloud/rest-proxy/consume.sh`.
 
+Stop |crest|
+~~~~~~~~~~~~
+
+#. Stop Docker by running the following command:
+
+   .. code-block:: text
+
+       docker-compose down
+
 
 Avro and Confluent Cloud Schema Registry
 -----------------------------------------
@@ -253,6 +269,26 @@ Avro and Confluent Cloud Schema Registry
 
 Produce Avro Records
 ~~~~~~~~~~~~~~~~~~~~
+
+#. Since you are now going to use |sr| in this section, uncomment the following lines in the ``docker-compose.yml`` file:
+
+   .. code-block:: text
+
+      KAFKA_REST_SCHEMA_REGISTRY_URL: $SCHEMA_REGISTRY_URL
+      KAFKA_REST_CLIENT_BASIC_AUTH_CREDENTIALS_SOURCE: $BASIC_AUTH_CREDENTIALS_SOURCE
+      KAFKA_REST_CLIENT_SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO: $SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO
+
+#. Start the |crest| Docker container by running the following command:
+
+   .. code-block:: text
+
+       docker-compose up -d rest-proxy
+
+#. View the |crest| logs in Docker and wait till you see the log message ``Server started, listening for requests`` to confirm |crest| has started.
+
+   .. code-block:: text
+
+      docker-compose logs -f rest-proxy
 
 #. Get the |ak| cluster ID that the |crest| is connected to.
 
@@ -443,8 +479,8 @@ Consume Avro Records
 
       {"subject":"test2-value","version":1,"id":100001,"schema":"[{\"type\":\"record\",\"name\":\"countInfo\",\"fields\":[{\"name\":\"count\",\"type\":\"long\"}]}]"}
 
-Stop
-----
+Stop |crest|
+~~~~~~~~~~~~
 
 #. Stop Docker by running the following command:
 

--- a/clients/docs/rest-proxy.rst
+++ b/clients/docs/rest-proxy.rst
@@ -58,7 +58,7 @@ Setup
 
    .. codewithvars:: bash
 
-      wget -O docker-compose.yml https://raw.githubusercontent.com/confluentinc/cp-all-in-one/|release|/cp-all-in-one-cloud/docker-compose.yml
+      wget -O docker-compose.yml https://raw.githubusercontent.com/confluentinc/cp-all-in-one/|release_post_branch|/cp-all-in-one-cloud/docker-compose.yml
 
 #. For the full |crest| configuration, view the |crest| section in the ``docker-compose.yml`` file which you just downloaded in the previous step.
 

--- a/clients/docs/rest-proxy.rst
+++ b/clients/docs/rest-proxy.rst
@@ -266,6 +266,18 @@ Avro and Confluent Cloud Schema Registry
 
 #. .. include:: includes/client-example-schema-registry-2-java.rst
 
+#. Regenerate a file of ENV variables used by Docker to set the bootstrap
+   servers and security configuration.
+
+   .. code-block:: text
+
+      ../../../ccloud/ccloud-generate-cp-configs.sh $HOME/.confluent/java.config
+
+#. Source the regenerated file of ``ENV`` variables.
+
+   .. code-block:: text
+
+      source ./delta_configs/env.delta
 
 Produce Avro Records
 ~~~~~~~~~~~~~~~~~~~~

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -1135,7 +1135,7 @@ function ccloud::destroy_ccloud_stack() {
 # If you are using Confluent Cloud Schema Registry, add the following configuration parameters
 #
 #   basic.auth.credentials.source=USER_INFO
-#   schema.registry.basic.auth.user.info=<SR API KEY>:<SR API SECRET>
+#   basic.auth.user.info=<SR API KEY>:<SR API SECRET>
 #   schema.registry.url=https://<SR ENDPOINT>
 #
 # If you are using Confluent Cloud ksqlDB, add the following configuration parameters
@@ -1187,7 +1187,7 @@ function ccloud::generate_configs() {
   
   # Schema Registry
   BASIC_AUTH_CREDENTIALS_SOURCE=$( grep "^basic.auth.credentials.source" $CONFIG_FILE | awk -F'=' '{print $2;}' )
-  SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO=$( grep "basic.auth.user.info" $CONFIG_FILE | awk -F'=' '{print $2;}' )
+  SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO=$( grep "^basic.auth.user.info" $CONFIG_FILE | awk -F'=' '{print $2;}' )
   SCHEMA_REGISTRY_URL=$( grep "^schema.registry.url" $CONFIG_FILE | awk -F'=' '{print $2;}' )
   
   # ksqlDB

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -1009,7 +1009,7 @@ bootstrap.servers=${BOOTSTRAP_SERVERS}
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='${CLOUD_API_KEY}' password='${CLOUD_API_SECRET}';
 basic.auth.credentials.source=USER_INFO
 schema.registry.url=${SCHEMA_REGISTRY_ENDPOINT}
-schema.registry.basic.auth.user.info=`echo $SCHEMA_REGISTRY_CREDS | awk -F: '{print $1}'`:`echo $SCHEMA_REGISTRY_CREDS | awk -F: '{print $2}'`
+basic.auth.user.info=`echo $SCHEMA_REGISTRY_CREDS | awk -F: '{print $1}'`:`echo $SCHEMA_REGISTRY_CREDS | awk -F: '{print $2}'`
 replication.factor=${REPLICATION_FACTOR}
 EOF
     if $enable_ksqldb ; then
@@ -1187,7 +1187,7 @@ function ccloud::generate_configs() {
   
   # Schema Registry
   BASIC_AUTH_CREDENTIALS_SOURCE=$( grep "^basic.auth.credentials.source" $CONFIG_FILE | awk -F'=' '{print $2;}' )
-  SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO=$( grep "^schema.registry.basic.auth.user.info" $CONFIG_FILE | awk -F'=' '{print $2;}' )
+  SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO=$( grep "basic.auth.user.info" $CONFIG_FILE | awk -F'=' '{print $2;}' )
   SCHEMA_REGISTRY_URL=$( grep "^schema.registry.url" $CONFIG_FILE | awk -F'=' '{print $2;}' )
   
   # ksqlDB


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2562

_What behavior does this PR change, and why?_

- Fix REST Proxy example
- Changes to SR parameter names, impacts `ccloud-stack` and all examples

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [x] Documentation: https://github.com/confluentinc/docs-platform/pull/527
<!-- - [ ] ccloud/beginner-cloud -->
- [x] ccloud/ccloud-stack
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
- [ ] clients/cloud: rest-proxy, java
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
- [ ] cp-quickstart: cloud version
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
