### PR TITLE
DEVX-2565: Correct service account used in Confluent Cloud ksqlDB; DEVX-2566: us-east-1 for S3

### DIFF
--- a/cloud-etl/config/demo.cfg
+++ b/cloud-etl/config/demo.cfg
@@ -54,7 +54,7 @@ export DESTINATION_STORAGE='s3'
 # S3_BUCKET: bucket name
 # Demo will modify contents of the bucket
 # Do not specify one that you do not want accidentally deleted
-#export S3_BUCKET='confluent-cloud-etl-demo'
+#export S3_BUCKET='cloud-etl-example'
 
 #---------------------------------------------------------
 # GCP GCS

--- a/cloud-etl/create_ksqldb_app.sh
+++ b/cloud-etl/create_ksqldb_app.sh
@@ -29,8 +29,9 @@ ccloud kafka topic create $KAFKA_TOPIC_NAME_OUT1
 ccloud kafka topic create $KAFKA_TOPIC_NAME_OUT2
 ksqlDBAppId=$(ccloud ksql app list | grep "$KSQLDB_ENDPOINT" | awk '{print $1}')
 ccloud ksql app configure-acls $ksqlDBAppId $KAFKA_TOPIC_NAME_IN $KAFKA_TOPIC_NAME_OUT1 $KAFKA_TOPIC_NAME_OUT2
-ccloud kafka acl create --allow --service-account $(ccloud service-account list | grep $ksqlDBAppId | awk '{print $1;}') --operation WRITE --topic $KAFKA_TOPIC_NAME_OUT1
-ccloud kafka acl create --allow --service-account $(ccloud service-account list | grep $ksqlDBAppId | awk '{print $1;}') --operation WRITE --topic $KAFKA_TOPIC_NAME_OUT2
+SERVICE_ACCOUNT_ID=$(ccloud kafka cluster list -o json | jq -r '.[0].name' | awk -F'-' '{print $4;}')
+ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic $KAFKA_TOPIC_NAME_OUT1
+ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic $KAFKA_TOPIC_NAME_OUT2
 
 # Submit KSQL queries
 echo -e "\nSubmit KSQL queries\n"

--- a/cloud-etl/setup_storage_s3.sh
+++ b/cloud-etl/setup_storage_s3.sh
@@ -9,8 +9,14 @@ source config/demo.cfg
 
 aws s3api head-bucket --bucket "$S3_BUCKET" --region $STORAGE_REGION --profile $S3_PROFILE 2>/dev/null
 if [[ $? != 0 ]]; then
-  echo "aws s3api create-bucket --bucket $S3_BUCKET --region $STORAGE_REGION --create-bucket-configuration LocationConstraint=$STORAGE_REGION --profile $S3_PROFILE"
-  aws s3api create-bucket --bucket $S3_BUCKET --region $STORAGE_REGION --create-bucket-configuration LocationConstraint=$STORAGE_REGION --profile $S3_PROFILE
+  # us-east-1 does not accept the LocationConstraint
+  if [[ "$STORAGE_REGION" == "us-east-1" ]]; then
+    CONSTRAINT=""
+  else
+    CONSTRAINT=" --create-bucket-configuration LocationConstraint=$STORAGE_REGION"
+  fi
+  echo "aws s3api create-bucket --bucket $S3_BUCKET --region $STORAGE_REGION $CONSTRAINT --profile $S3_PROFILE"
+  aws s3api create-bucket --bucket $S3_BUCKET --region $STORAGE_REGION $CONSTRAINT --profile $S3_PROFILE
   if [[ $? != 0 ]]; then
     echo "ERROR: Could not create S3 bucket $S3_BUCKET in region $STORAGE_REGION using the profile $S3_PROFILE. Troubleshoot and try again."
     exit 1

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -483,7 +483,7 @@ function ccloud::create_acls_all_resources_full_access() {
   SERVICE_ACCOUNT_ID=$1
   # Setting default QUIET=false to surface potential errors
   QUIET="${QUIET:-false}"
-  [[ $QUIET == "false" ]] &&
+  [[ $QUIET == "true" ]] &&
     local REDIRECT_TO="/dev/null" ||
     local REDIRECT_TO="/dev/stdout"
 
@@ -512,7 +512,7 @@ function ccloud::delete_acls_ccloud_stack() {
   SERVICE_ACCOUNT_ID=$1
   # Setting default QUIET=false to surface potential errors
   QUIET="${QUIET:-false}"
-  [[ $QUIET == "false" ]] &&
+  [[ $QUIET == "true" ]] &&
     local REDIRECT_TO="/dev/null" ||
     local REDIRECT_TO="/dev/stdout"
 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2565
https://confluentinc.atlassian.net/browse/DEVX-2566

_What behavior does this PR change, and why?_

- service account ID used for ksqlDB is now the same as the cluster
- handle us-east-1 for S3
- correct logging on `QUIET`

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
- [x] cloud-etl
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->

No need to run; just code review is ok
