### PR TITLE
GH-969: ccloud-observability fails to load java dependencies

### DIFF
--- a/ccloud-observability/pom.xml
+++ b/ccloud-observability/pom.xml
@@ -55,12 +55,12 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
-            <version>${confluent.version}</version>
+            <version>${confluent.version.range}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-streams-avro-serde</artifactId>
-            <version>${confluent.version}</version>
+            <version>${confluent.version.range}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-json-serializer</artifactId>
-            <version>${confluent.version}</version>
+            <version>${confluent.version.range}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -154,7 +154,7 @@
             <plugin>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-schema-registry-maven-plugin</artifactId>
-                <version>${confluent.version}</version>
+                <version>${confluent.version.range}</version>
                 <configuration>
                     <schemaRegistryUrls>
                         <param>${schemaRegistryUrl}</param>


### PR DESCRIPTION
### Description 
https://github.com/confluentinc/examples/issues/969

_What behavior does this PR change, and why?_
This PR fixes the confluent.version variable used by the pom.xml in the ccloud-observability project. As it stands rn, the variable will not resolve to a version number. Looking through the parent pom files, it doesn't appear that this variable is defined, rather a similarly named variable is being used "confluent.version.range".  See https://github.com/confluentinc/common/blob/580cfe0ddb94ad306c43218b6ee07a1c8a9bb324/pom.xml#L133. 

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
 - [x] ccloud-observability
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
