### PR TITLE
multi-datacenter: update the max wait time for connect cluster to start

### DIFF
--- a/multi-datacenter/start.sh
+++ b/multi-datacenter/start.sh
@@ -8,7 +8,7 @@ check_jq || exit 1
 docker-compose up -d
 
 # Verify Kafka Connect workers have started
-MAX_WAIT=120
+MAX_WAIT=180
 echo "Waiting up to $MAX_WAIT seconds for Connect to start"
 retry $MAX_WAIT check_connect_up connect-dc2 || exit 1
 retry $MAX_WAIT check_connect_up connect-dc1 || exit 1


### PR DESCRIPTION
### Description 

This change is for example demo for multi-datacenter. At times the the check for cluster status fails because it takes more than 120 seconds ( default time out ). 

```
Waiting up to 120 seconds for Connect to start
........................ERROR: Failed after 120 seconds. Please troubleshoot and run again.
```

_What behavior does this PR change, and why?_
Increasing the timeout to make it more robust across different docker environments. 

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

[ ] multi-datacenter