### PR TITLE
DEVX-2235: update connect version to use vars

### DIFF
--- a/clickstream/start.sh
+++ b/clickstream/start.sh
@@ -7,7 +7,7 @@ source ../utils/helper.sh
 
 # Get jars for source and sink connectors
 docker run -v $PWD/confluent-hub-components:/share/confluent-hub-components confluentinc/ksqldb-server:0.8.0 confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:$KAFKA_CONNECT_DATAGEN_VERSION
-docker run -v $PWD/confluent-hub-components:/share/confluent-hub-components confluentinc/ksqldb-server:0.8.0 confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:10.0.2
+docker run -v $PWD/confluent-hub-components:/share/confluent-hub-components confluentinc/ksqldb-server:0.8.0 confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:$KAFKA_CONNECT_ES_VERSION
 
 docker-compose up -d
 

--- a/connect-streams-pipeline/start.sh
+++ b/connect-streams-pipeline/start.sh
@@ -14,7 +14,7 @@ check_sqlite3 || exit 1
 mvn clean compile
 
 echo "auto.offset.reset=earliest" >> $CONFLUENT_HOME/etc/ksqldb/ksql-server.properties
-confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:latest
+confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:$KAFKA_CONNECT_JDBC_VERSION
 confluent local services start
 
 # Create the SQL table

--- a/microservices-orders/docker-compose.yml
+++ b/microservices-orders/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       - |
         echo "Installing connector plugins"
         confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:$KAFKA_CONNECT_JDBC_VERSION
-        confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:10.0.2
+        confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:$KAFKA_CONNECT_ES_VERSION
         echo "Launching Kafka Connect worker"
         /etc/confluent/docker/run
 

--- a/microservices-orders/docker-compose.yml
+++ b/microservices-orders/docker-compose.yml
@@ -108,7 +108,7 @@ services:
       - -c
       - |
         echo "Installing connector plugins"
-        confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:latest
+        confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:$KAFKA_CONNECT_JDBC_VERSION
         confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:10.0.2
         echo "Launching Kafka Connect worker"
         /etc/confluent/docker/run

--- a/utils/config.env
+++ b/utils/config.env
@@ -56,3 +56,12 @@ OPERATOR_CP_IMAGE_TAG=6.0.1.0
 OPERATOR_KAFKA_CONNECT_DATAGEN_IMAGE_TAG=0.4.0-6.0.0.0
 #####################################################
 
+############### kafka-connect-jdbc ##################
+# We can't use the CP docker tag above for the aggregate JDBC connect version because
+#   kafka-connect-jdbc is not, currently, part of the CP build process.  
+#   kafka-connect-jdbc releases are manual so we have to manage this manually 
+#   and there will be a delay between CP releases and kafka-connect-jdbc releases.
+#   Published kafka-connect-jdbc images can be found here:
+#     https://www.confluent.io/hub/confluentinc/kafka-connect-jdbc
+KAFKA_CONNECT_JDBC_VERSION=10.0.1
+##################################################### 

--- a/utils/config.env
+++ b/utils/config.env
@@ -64,4 +64,15 @@ OPERATOR_KAFKA_CONNECT_DATAGEN_IMAGE_TAG=0.4.0-6.0.0.0
 #   Published kafka-connect-jdbc images can be found here:
 #     https://www.confluent.io/hub/confluentinc/kafka-connect-jdbc
 KAFKA_CONNECT_JDBC_VERSION=10.1.1
-##################################################### 
+#####################################################
+
+########### kafka-connect-elasticsearch #############
+# We can't use the CP docker tag above for the aggregate elasticsearch connect
+#   version because kafka-connect-elasticsearch is not, currently, part of the
+#   CP build process. kafka-connect-elasticsearch releases are manual so we 
+#   have to manage this manually and there will be a delay between CP releases 
+#   and kafka-connect-elasticsearch releases. Published kafka-connect-elasticsearch 
+#   images can be found here:
+#   https://www.confluent.io/hub/confluentinc/kafka-connect-elasticsearch
+KAFKA_CONNECT_ES_VERSION=10.0.2
+#####################################################

--- a/utils/config.env
+++ b/utils/config.env
@@ -63,5 +63,5 @@ OPERATOR_KAFKA_CONNECT_DATAGEN_IMAGE_TAG=0.4.0-6.0.0.0
 #   and there will be a delay between CP releases and kafka-connect-jdbc releases.
 #   Published kafka-connect-jdbc images can be found here:
 #     https://www.confluent.io/hub/confluentinc/kafka-connect-jdbc
-KAFKA_CONNECT_JDBC_VERSION=10.0.1
+KAFKA_CONNECT_JDBC_VERSION=10.1.1
 ##################################################### 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2235

_What behavior does this PR change, and why?_
This pins the kafka-connect-jdbc to a specific version (10.1.1 aka latest). The version is defined in utils/config.env. This also creates a variable for kafka-connect-elasticsearch and substitutes that env var where possible. 

### Author Validation
_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
- [x] clickstream
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
- [x] connect-streams-pipeline
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
- [x] microservices-orders
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._
I think validating one of the examples is sufficient. 
<!-- Uncomment any of the following that are required -->
- [ ] connect-streams-pipeline
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
- [ ] microservices-orders
- [ ] clickstream
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
