### PR TITLE
KSE-286: Fix multi-group-by persistence format

### DIFF
--- a/clickstream/docker-compose.yml
+++ b/clickstream/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       KSQL_CONNECT_CONFIG_STORAGE_TOPIC: _ksqldb-kafka-connect-group-01-configs
       KSQL_CONNECT_OFFSET_STORAGE_TOPIC: _ksqldb-kafka-connect-group-01-offsets
       KSQL_CONNECT_STATUS_STORAGE_TOPIC: _ksqldb-kafka-connect-group-01-status
-      KSQL_CONNECT_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      KSQL_CONNECT_KEY_CONVERTER: org.apache.kafka.connect.storage.StringConverter
       KSQL_CONNECT_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
       KSQL_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "false"
       KSQL_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1

--- a/clickstream/docker-compose.yml
+++ b/clickstream/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       KSQL_CONNECT_CONFIG_STORAGE_TOPIC: _ksqldb-kafka-connect-group-01-configs
       KSQL_CONNECT_OFFSET_STORAGE_TOPIC: _ksqldb-kafka-connect-group-01-offsets
       KSQL_CONNECT_STATUS_STORAGE_TOPIC: _ksqldb-kafka-connect-group-01-status
-      KSQL_CONNECT_KEY_CONVERTER: org.apache.kafka.connect.storage.StringConverter
+      KSQL_CONNECT_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
       KSQL_CONNECT_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
       KSQL_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "false"
       KSQL_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1

--- a/clickstream/ksql/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
+++ b/clickstream/ksql/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
@@ -39,7 +39,7 @@ curl -s -X "POST" "http://$CONNECT_HOST:8083/connectors/" \
   "config": {
     "schema.ignore": "true",
     "topics": "'$TABLE_NAME'",
-    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
     "value.converter.schemas.enable": false,
     "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
     "key.ignore": "true",

--- a/clickstream/ksql/ksql-clickstream-demo/demo/statements.sql
+++ b/clickstream/ksql/ksql-clickstream-demo/demo/statements.sql
@@ -13,7 +13,7 @@ CREATE STREAM clickstream (
         agent varchar
     ) with (
         kafka_topic = 'clickstream',
-        value_format = 'json'
+        format = 'json'
     );
 
 -- error code lookup table:

--- a/clickstream/ksql/ksql-clickstream-demo/demo/statements.sql
+++ b/clickstream/ksql/ksql-clickstream-demo/demo/statements.sql
@@ -13,7 +13,7 @@ CREATE STREAM clickstream (
         agent varchar
     ) with (
         kafka_topic = 'clickstream',
-        format = 'json'
+        value_format = 'json'
     );
 
 -- error code lookup table:
@@ -133,7 +133,7 @@ CREATE TABLE ERRORS_PER_MIN AS
 
 -- Enriched error codes table:
 -- Aggregate (count&groupBy) using a TABLE-Window
-CREATE TABLE ENRICHED_ERROR_CODES_COUNT AS
+CREATE TABLE ENRICHED_ERROR_CODES_COUNT WITH (key_format='json') AS
     SELECT
         code as k1,
         definition as K2,
@@ -147,7 +147,7 @@ CREATE TABLE ENRICHED_ERROR_CODES_COUNT AS
 
 -- Enriched user details table:
 -- Aggregate (count&groupBy) using a TABLE-Window
-CREATE TABLE USER_IP_ACTIVITY AS
+CREATE TABLE USER_IP_ACTIVITY WITH (key_format='json') AS
     SELECT
         username as k1,
         ip as k2,

--- a/cp-quickstart/statements-cloud.sql
+++ b/cp-quickstart/statements-cloud.sql
@@ -1,4 +1,4 @@
-CREATE STREAM pageviews WITH (kafka_topic='pageviews', value_format='AVRO');
+CREATE STREAM pageviews WITH (kafka_topic='pageviews', format='AVRO');
 CREATE TABLE users (id STRING PRIMARY KEY) WITH (kafka_topic='users', value_format='PROTOBUF');
 CREATE STREAM pageviews_female AS SELECT users.id AS userid, pageid, regionid, gender FROM pageviews LEFT JOIN users ON pageviews.userid = users.id WHERE gender = 'FEMALE';
 CREATE STREAM pageviews_female_like_89 AS SELECT * FROM pageviews_female WHERE regionid LIKE '%_8' OR regionid LIKE '%_9';

--- a/cp-quickstart/statements-cloud.sql
+++ b/cp-quickstart/statements-cloud.sql
@@ -1,6 +1,6 @@
-CREATE STREAM pageviews WITH (kafka_topic='pageviews', format='AVRO');
+CREATE STREAM pageviews WITH (kafka_topic='pageviews', value_format='AVRO');
 CREATE TABLE users (id STRING PRIMARY KEY) WITH (kafka_topic='users', value_format='PROTOBUF');
 CREATE STREAM pageviews_female AS SELECT users.id AS userid, pageid, regionid, gender FROM pageviews LEFT JOIN users ON pageviews.userid = users.id WHERE gender = 'FEMALE';
 CREATE STREAM pageviews_female_like_89 AS SELECT * FROM pageviews_female WHERE regionid LIKE '%_8' OR regionid LIKE '%_9';
-CREATE TABLE pageviews_regions WITH (key_format='json') AS SELECT gender, regionid , COUNT(*) AS numusers FROM pageviews_female WINDOW TUMBLING (size 30 second) GROUP BY gender, regionid HAVING COUNT(*) > 1;
+CREATE TABLE pageviews_regions WITH (key_format='JSON') AS SELECT gender, regionid , COUNT(*) AS numusers FROM pageviews_female WINDOW TUMBLING (size 30 second) GROUP BY gender, regionid HAVING COUNT(*) > 1;
 CREATE STREAM accomplished_female_readers WITH (value_format='JSON_SR') AS SELECT * FROM PAGEVIEWS_FEMALE WHERE CAST(SPLIT(PAGEID,'_')[2] as INT) >= 50;

--- a/cp-quickstart/statements.sql
+++ b/cp-quickstart/statements.sql
@@ -1,5 +1,5 @@
-CREATE STREAM pageviews WITH (kafka_topic='pageviews', format='AVRO');
+CREATE STREAM pageviews WITH (kafka_topic='pageviews', value_format='AVRO');
 CREATE TABLE users (id STRING PRIMARY KEY) WITH (kafka_topic='users', value_format='AVRO');
 CREATE STREAM pageviews_female AS SELECT users.id AS userid, pageid, regionid, gender FROM pageviews LEFT JOIN users ON pageviews.userid = users.id WHERE gender = 'FEMALE';
 CREATE STREAM pageviews_female_like_89 AS SELECT * FROM pageviews_female WHERE regionid LIKE '%_8' OR regionid LIKE '%_9';
-CREATE TABLE pageviews_regions AS SELECT gender, regionid , COUNT(*) AS numusers FROM pageviews_female WINDOW TUMBLING (size 30 second) GROUP BY gender, regionid HAVING COUNT(*) > 1;
+CREATE TABLE pageviews_regions WITH (key_format='JSON') AS SELECT gender, regionid , COUNT(*) AS numusers FROM pageviews_female WINDOW TUMBLING (size 30 second) GROUP BY gender, regionid HAVING COUNT(*) > 1;

--- a/cp-quickstart/statements.sql
+++ b/cp-quickstart/statements.sql
@@ -1,4 +1,4 @@
-CREATE STREAM pageviews WITH (kafka_topic='pageviews', value_format='AVRO');
+CREATE STREAM pageviews WITH (kafka_topic='pageviews', format='AVRO');
 CREATE TABLE users (id STRING PRIMARY KEY) WITH (kafka_topic='users', value_format='AVRO');
 CREATE STREAM pageviews_female AS SELECT users.id AS userid, pageid, regionid, gender FROM pageviews LEFT JOIN users ON pageviews.userid = users.id WHERE gender = 'FEMALE';
 CREATE STREAM pageviews_female_like_89 AS SELECT * FROM pageviews_female WHERE regionid LIKE '%_8' OR regionid LIKE '%_9';


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/KSE-286

In 6.2.0+, when multiple grouping criteria are used, ksqlDB requires the key format to be one of JSON, AVRO, PROTOBUF, DELIMITED, or JSON_SR. The default KAFKA format does not support multiple grouping criteria as of this version (and ksqlDB standalone 0.15+).

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
