### PR TITLE
DOCS-8035: Add link from Replicator-CCloud page to properties definit…

### DIFF
--- a/ccloud/docs/includes/connect-worker-to-origin-onprem.rst
+++ b/ccloud/docs/includes/connect-worker-to-origin-onprem.rst
@@ -7,7 +7,7 @@ The |kconnect| worker is backed to the origin on-premises |ak| cluster, so set t
    offset.storage.replication.factor=<replication-factor-origin>
    status.storage.replication.factor=<replication-factor-origin>
 
-The origin on-premises |ak| cluster can have a varied set of security features enabled, but for simplicity in this example we show no security configurations, just PLAINTEXT.
+The origin on-premises |ak| cluster can have a varied set of security features enabled, but for simplicity in this example we show no security configurations, just PLAINTEXT (see `this page <https://docs.confluent.io/kafka-connect-replicator/current/configuration_options.html>`__ for more |crep| security configuration options).
 The |kconnect| worker’s admin client requires connection information to the on-premises cluster.
 
 .. sourcecode:: bash

--- a/ccloud/docs/includes/replicator-from-origin-onprem.rst
+++ b/ccloud/docs/includes/replicator-from-origin-onprem.rst
@@ -1,5 +1,5 @@
 The origin cluster in this case is your on-premises |ak| cluster, and |crep| needs to know how to connect to this origin cluster which can be set by using the prefix ``src.`` for these configuration parameters.
-The origin cluster can have a varied set of security features enabled, but for simplicity this example shows no security configurations, just PLAINTEXT.
+The origin cluster can have a varied set of security features enabled, but for simplicity this example shows no security configurations, just PLAINTEXT (see `this page <https://docs.confluent.io/kafka-connect-replicator/current/configuration_options.html>`__ for more |crep| security configuration options).
 
 .. sourcecode:: bash
 


### PR DESCRIPTION
…ions

### Description 

https://confluentinc.atlassian.net/browse/DOCS-8035

_What behavior does this PR change, and why?_


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
