### PR TITLE
DEVX-2605: Increase wait time for CCloud connectors

### DIFF
--- a/cloud-etl/setup_storage_az.sh
+++ b/cloud-etl/setup_storage_az.sh
@@ -16,11 +16,11 @@ if [[ $? != 0 ]]; then
 fi
 
 ccloud::create_connector connectors/az_no_avro.json || exit 1
-ccloud::wait_for_connector_up connectors/az_no_avro.json 240 || exit 1
+ccloud::wait_for_connector_up connectors/az_no_avro.json 300 || exit 1
 
 # While Azure Blob Sink is in Preview, limit is only one connector of this type
 # So these lines are to remain commented out until then
 #ccloud::create_connector connectors/az_avro.json || exit 1
-#ccloud::wait_for_connector_up connectors/az_avro.json 240 || exit 1
+#ccloud::wait_for_connector_up connectors/az_avro.json 300 || exit 1
 
 exit 0

--- a/cloud-etl/setup_storage_gcs.sh
+++ b/cloud-etl/setup_storage_gcs.sh
@@ -16,9 +16,9 @@ if [[ ! "$bucket_list" =~ "$GCS_BUCKET" ]]; then
 fi
 
 ccloud::create_connector connectors/gcs_no_avro.json || exit 1
-ccloud::wait_for_connector_up connectors/gcs_no_avro.json 240 || exit 1
+ccloud::wait_for_connector_up connectors/gcs_no_avro.json 300 || exit 1
 
 ccloud::create_connector connectors/gcs_avro.json || exit 1
-ccloud::wait_for_connector_up connectors/gcs_avro.json 240 || exit 1
+ccloud::wait_for_connector_up connectors/gcs_avro.json 300 || exit 1
 
 exit 0

--- a/cloud-etl/setup_storage_s3.sh
+++ b/cloud-etl/setup_storage_s3.sh
@@ -26,8 +26,8 @@ fi
 export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile $S3_PROFILE)
 export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile $S3_PROFILE)
 ccloud::create_connector connectors/s3_no_avro.json || exit 1
-ccloud::wait_for_connector_up connectors/s3_no_avro.json 240 || exit 1
+ccloud::wait_for_connector_up connectors/s3_no_avro.json 300 || exit 1
 ccloud::create_connector connectors/s3_avro.json || exit 1
-ccloud::wait_for_connector_up connectors/s3_avro.json 240 || exit 1
+ccloud::wait_for_connector_up connectors/s3_avro.json 300 || exit 1
 
 exit 0

--- a/cloud-etl/start.sh
+++ b/cloud-etl/start.sh
@@ -80,7 +80,7 @@ if [[ "${DATA_SOURCE}" == "rds" ]]; then
   export CONNECTION_PORT=$(aws rds describe-db-instances --db-instance-identifier $DB_INSTANCE_IDENTIFIER --profile $AWS_PROFILE | jq -r ".DBInstances[0].Endpoint.Port")
 fi
 ccloud::create_connector connectors/${DATA_SOURCE}.json || exit 1
-ccloud::wait_for_connector_up connectors/${DATA_SOURCE}.json 240 || exit 1
+ccloud::wait_for_connector_up connectors/${DATA_SOURCE}.json 300 || exit 1
 
 #################################################################
 # Confluent Cloud ksqlDB application

--- a/cp-quickstart/start-cloud.sh
+++ b/cp-quickstart/start-cloud.sh
@@ -84,8 +84,8 @@ print_pass "Topics created"
 printf "\n";print_process_start "====== Create fully-managed Datagen Source Connectors to produce sample data."
 ccloud::create_connector connectors/ccloud-datagen-pageviews.json || exit 1
 ccloud::create_connector connectors/ccloud-datagen-users.json || exit 1
-ccloud::wait_for_connector_up connectors/ccloud-datagen-pageviews.json 240 || exit 1
-ccloud::wait_for_connector_up connectors/ccloud-datagen-users.json 240 || exit 1
+ccloud::wait_for_connector_up connectors/ccloud-datagen-pageviews.json 300 || exit 1
+ccloud::wait_for_connector_up connectors/ccloud-datagen-users.json 300 || exit 1
 printf "\nSleeping 30 seconds to give the Datagen Source Connectors a chance to start producing messages\n"
 sleep 30
 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2605

_What behavior does this PR change, and why?_


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
