### PR TITLE
[ST-5337] Upgrading sphinx to 4

### DIFF
--- a/kubernetes/replicator-aks-cc/docs/index.rst
+++ b/kubernetes/replicator-aks-cc/docs/index.rst
@@ -1,4 +1,3 @@
-.. _quickstart-demos-operator-replicator-aks-cc:
 
 .. |k8s-service-name-long| replace:: Azure Kubernetes Service
 .. |k8s-service-name| replace:: AKS
@@ -10,6 +9,8 @@
 .. |cluster-settings| image:: images/cluster-settings.png
    :align: middle
    :width: 80%
+
+.. _quickstart-demos-operator-replicator-aks-cc:
 
 |k8s-service-name-long| to |ccloud| with |crep-full|
 =====================================================
@@ -56,7 +57,7 @@ Clone the `confluentinc/examples <https://github.com/confluentinc/examples>`__ G
 AKS Setup
 ~~~~~~~~~
 
-In order to properly simulate a realistic replication scenario to |ccloud|, the example requires a AKS Node Pool sufficiently large to support a 3 node clusters for both |ak| and |zk|.  In testing of this demonstration, a sufficient cluster consisted of 7 nodes of machine type ``Standard_D4s_v4``.  
+In order to properly simulate a realistic replication scenario to |ccloud|, the example requires a AKS Node Pool sufficiently large to support a 3 node clusters for both |ak| and |zk|.  In testing of this demonstration, a sufficient cluster consisted of 7 nodes of machine type ``Standard_D4s_v4``.
 
 .. tip:: The :ref:`examples-operator-aks-base-variable-reference` section can be used to control the size of the deployed resources in this example.
 
@@ -83,7 +84,7 @@ Verify that ``az`` has created the cluster properly::
       tier: Free
     tags: null
     type: Microsoft.ContainerService/ManagedClusters
-    
+
     ...
 
     az aks get-credentials --only-show-errors --resource-group confluent-operator-demo --name cp-examples-operator-user --context aks_confluent-operator-demo_centralus_cp-examples-operator-user


### PR DESCRIPTION
### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

https://confluentinc.atlassian.net/browse/ST-5337

It looks like the anchor can't be separated by the rst substitutions in sphinx 4.

This needs to be pint merged down to master


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
