### PR TITLE
Remove hardcoded avro version

### DIFF
--- a/ccloud-observability/pom.xml
+++ b/ccloud-observability/pom.xml
@@ -63,11 +63,6 @@
             <version>${confluent.version.range}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-            <version>${avro.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
             <version>${kafka.version}</version>

--- a/clients/avro/pom.xml
+++ b/clients/avro/pom.xml
@@ -64,11 +64,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       <version>${kafka.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro</artifactId>
-      <version>${avro.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>

--- a/clients/avro/pom.xml
+++ b/clients/avro/pom.xml
@@ -26,7 +26,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <properties>
     <!-- Keep versions as properties to allow easy modification -->
     <java.version>8</java.version>
-    <avro.version>1.9.1</avro.version>
     <gson.version>2.2.4</gson.version>
     <!-- Maven properties for compilation -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/clients/cloud/java/pom.xml
+++ b/clients/cloud/java/pom.xml
@@ -75,11 +75,6 @@
           <version>${io.confluent.schema-registry.version}</version>
         </dependency>
         <dependency>
-          <groupId>org.apache.avro</groupId>
-          <artifactId>avro</artifactId>
-          <version>${avro.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
             <version>${kafka.version}</version>

--- a/clients/cloud/java/pom.xml
+++ b/clients/cloud/java/pom.xml
@@ -27,7 +27,6 @@
         <java.version>8</java.version>
         <slf4j-api.version>1.7.6</slf4j-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <avro.version>1.9.1</avro.version>
         <gson.version>2.2.4</gson.version>
         <schemaRegistryUrl>http://localhost:8081</schemaRegistryUrl>
         <schemaRegistryBasicAuthUserInfo></schemaRegistryBasicAuthUserInfo>

--- a/connect-streams-pipeline/pom.xml
+++ b/connect-streams-pipeline/pom.xml
@@ -61,11 +61,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       <version>${io.confluent.schema-registry.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro</artifactId>
-      <version>${avro.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>

--- a/connect-streams-pipeline/pom.xml
+++ b/connect-streams-pipeline/pom.xml
@@ -25,7 +25,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <properties>
     <java.version>8</java.version>
-    <avro.version>1.10.1</avro.version>
     <gson.version>2.2.4</gson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/multi-datacenter/pom.xml
+++ b/multi-datacenter/pom.xml
@@ -25,7 +25,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <properties>
     <!-- Keep versions as properties to allow easy modification -->
-    <avro.version>1.9.1</avro.version>
     <java.version>8</java.version>
     <gson.version>2.2.4</gson.version>
     <!-- Maven properties for compilation -->

--- a/multi-datacenter/pom.xml
+++ b/multi-datacenter/pom.xml
@@ -63,11 +63,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       <version>${kafka.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro</artifactId>
-      <version>${avro.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2617

Just specifying the serializer dependency should transitively bring in the correct Avro version.
No need to hardcode it (which would have obviated other issues encountered)


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
- [x] clients/cloud
<!-- - [ ] cloud-etl -->
- [x] connect-streams-pipeline
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
