### PR TITLE
DEVX-2648 Wrong config file variable name at kafkacat-example

### DIFF
--- a/clients/cloud/kafkacat/kafkacat-example.sh
+++ b/clients/cloud/kafkacat/kafkacat-example.sh
@@ -22,11 +22,11 @@ kafka-topics --bootstrap-server `grep "^\s*bootstrap.server" $CONFIG_FILE | tail
 # Produce messages
 num_messages=10
 (for i in `seq 1 $num_messages`; do echo "alice,{\"count\":${i}}" ; done) | \
-   kafkacat -F $HOME/.confluent/config \
+   kafkacat -F $CONFIG_FILE \
             -K , \
             -P -t $topic_name
 
 # Consume messages
-kafkacat -F $HOME/.confluent/config \
+kafkacat -F $CONFIG_FILE \
          -K , \
          -C -t $topic_name -e


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2648

Fix for the `kafkacat-example.sh` file. The config file specification was wrong.


### Author Validation

- [x] clients/cloud Tested on a ccloud cluster

### Reviewer Tasks

<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
