### PR TITLE
DOCS-9495 Remove incomplete list of example Replicator ACLs, instead link to Replicator and Connect docs

### DIFF
--- a/ccloud/docs/includes/set-acls-destination.rst
+++ b/ccloud/docs/includes/set-acls-destination.rst
@@ -1,14 +1,5 @@
 |crep| must have authorization to read |ak| data from the origin cluster and write |ak| data in the destination |ccloud| cluster.
 |crep| should be run with a |ccloud| service account, not super user credentials, so use |ccloud| CLI to configure appropriate ACLs for the service account id corresponding to |crep| in |ccloud|.
-For more details on |crep| ACLs, see :ref:`replicator_security_overview`.
 
-.. sourcecode:: bash
-
-   ccloud kafka acl create --allow --service-account <service-account-id> --operation CREATE --topic <replicated-topic>
-   ccloud kafka acl create --allow --service-account <service-account-id> --operation WRITE --topic <replicated-topic>
-   ccloud kafka acl create --allow --service-account <service-account-id> --operation READ --topic <replicated-topic>
-   ccloud kafka acl create --allow --service-account <service-account-id> --operation DESCRIBE --topic <replicated-topic>
-   ccloud kafka acl create --allow --service-account <service-account-id> --operation DESCRIBE-CONFIGS --topic <replicated-topic>
-   ccloud kafka acl create --allow --service-account <service-account-id> --operation ALTER-CONFIGS --topic <replicated-topic>
-   ccloud kafka acl create --allow --service-account <service-account-id> --operation DESCRIBE --cluster-scope
-
+For details on how to configure |crep| ACLs, see :ref:`replicator_security_overview`, and in particular :ref:`replicator_acls`. Also, the details on ACLs
+under :ref:`separate-principals` in the |kconnect| documentation may be useful for other connectors.

--- a/ccloud/docs/includes/set-acls-destination.rst
+++ b/ccloud/docs/includes/set-acls-destination.rst
@@ -1,5 +1,7 @@
 |crep| must have authorization to read |ak| data from the origin cluster and write |ak| data in the destination |ccloud| cluster.
 |crep| should be run with a |ccloud| service account, not super user credentials, so use |ccloud| CLI to configure appropriate ACLs for the service account id corresponding to |crep| in |ccloud|.
 
-For details on how to configure |crep| ACLs, see :ref:`replicator_security_overview`, and in particular :ref:`replicator_acls`. Also, the details on ACLs
-under :ref:`separate-principals` in the |kconnect| documentation may be useful for other connectors.
+For details on how to configure these ACLs for |crep|, see :ref:`replicator_security_overview`.
+
+Also, the details on ACLs under :ref:`separate-principals` in the |kconnect|
+documentation may be useful for other connectors.

--- a/ccloud/docs/includes/set-acls-destination.rst
+++ b/ccloud/docs/includes/set-acls-destination.rst
@@ -2,6 +2,3 @@
 |crep| should be run with a |ccloud| service account, not super user credentials, so use |ccloud| CLI to configure appropriate ACLs for the service account id corresponding to |crep| in |ccloud|.
 
 For details on how to configure these ACLs for |crep|, see :ref:`replicator_security_overview`.
-
-Also, the details on ACLs under :ref:`separate-principals` in the |kconnect|
-documentation may be useful for other connectors.

--- a/ccloud/docs/includes/set-acls-origin-and-destination.rst
+++ b/ccloud/docs/includes/set-acls-origin-and-destination.rst
@@ -1,31 +1,5 @@
 |crep| must have authorization to read |ak| data from the origin cluster and write |ak| data in the destination |ccloud| cluster.
 |crep| should be run with a |ccloud| service account, not super user credentials, so use |ccloud| CLI to configure appropriate ACLs for the service account id corresponding to |crep|.
 Since the origin cluster and destination cluster in this example are both |ccloud|, configure appropriate ACLs for the service account ids corresponding to |crep| in both |ccloud| clusters.
-For more details on |crep| ACLs, see :ref:`replicator_security_overview`.
 
-In the origin |ccloud|:
-
-.. sourcecode:: bash
-
-   ccloud kafka acl create --allow --service-account <service-account-id-origin> --operation CREATE --topic <topic-origin>
-   ccloud kafka acl create --allow --service-account <service-account-id-origin> --operation WRITE --topic <topic-origin>
-   ccloud kafka acl create --allow --service-account <service-account-id-origin> --operation READ --topic <topic-origin>
-   ccloud kafka acl create --allow --service-account <service-account-id-origin> --operation DESCRIBE --topic <topic-origin>
-   ccloud kafka acl create --allow --service-account <service-account-id-origin> --operation DESCRIBE-CONFIGS --topic <topic-origin>
-   ccloud kafka acl create --allow --service-account <service-account-id-origin> --operation DESCRIBE --cluster-scope
-   ccloud kafka acl create --allow --service-account <service-account-id-origin> --operation CREATE --topic __consumer_timestamps
-   ccloud kafka acl create --allow --service-account <service-account-id-origin> --operation WRITE --topic __consumer_timestamps
-   ccloud kafka acl create --allow --service-account <service-account-id-origin> --operation DESCRIBE --topic __consumer_timestamps
-
-In the destination |ccloud|:
-
-.. sourcecode:: bash
-
-   ccloud kafka acl create --allow --service-account <service-account-id-destination> --operation CREATE --topic <topic-destination>
-   ccloud kafka acl create --allow --service-account <service-account-id-destination> --operation WRITE --topic <topic-destination>
-   ccloud kafka acl create --allow --service-account <service-account-id-destination> --operation READ --topic <topic-destination>
-   ccloud kafka acl create --allow --service-account <service-account-id-destination> --operation DESCRIBE --topic <topic-destination>
-   ccloud kafka acl create --allow --service-account <service-account-id-destination> --operation DESCRIBE-CONFIGS --topic <topic-destination>
-   ccloud kafka acl create --allow --service-account <service-account-id-destination> --operation ALTER-CONFIGS --topic <topic-destination>
-   ccloud kafka acl create --allow --service-account <service-account-id-destination> --operation DESCRIBE --cluster-scope
-
+For details on how to configure these ACLs for |crep|, see :ref:`replicator_security_overview`.


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DOCS-9495

- See [Slack thread on #docs channel](https://confluent.slack.com/archives/C1A2E40DT/p1628810426049800)

- Related PR on `docs-platform` repo: https://github.com/confluentinc/docs-platform/pull/986

- The changes here are made to an include (`includes/set-acls-destination.rst`) that is called by `ccloud/docs/replicator-to-cloud-configuration-types.rst`

- The links will go to [Security and ACL Configurations](http://staging-docs-independent.confluent.io.s3-website-us-west-2.amazonaws.com/docs-platform/PR/986/6.0.0/multi-dc-deployments/replicator/index.html#security) in the Replicator docs when the related PR on `docs-platform` (https://github.com/confluentinc/docs-platform/pull/986)
 is merged.

_What behavior does this PR change, and why?_ 

No behaviour changed, only Docs. Customer reported getting stuck bringing up Replicator. The problem was they didn't have enough or the correct ACLs configured. The example here shows an incomplete list of needed ACLs, so it's better to point to the relevant sections where all needed ACLs are listed.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

Reviewers, please verify that this is the appropriate Docs update.

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


Signed-off-by: Victoria Bialas <vicky@confluent.io>

