### PR TITLE
Add CHECK_CREDIT_CARD env variable in order to bypass payment describe

### DIFF
--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -320,6 +320,20 @@ If you don't want to create and destroy a ``ccloud-stack`` using the provided ba
       ccloud::destroy_ccloud_stack $SERVICE_ACCOUNT_ID
 
 
+Running with Marketplace
+------------------------
+
+By default, ``ccloud-stack`` checks your payment method to verify that there is a credit card on file.
+However, when using |ccloud| on a cloud provider's Marketplace for a self-serve Pay-as-you-go account on Azure, GCP or AWS, your payment method is directly linked to your cloud provider and not necessarily with a credit card. 
+In these cases, therefore, ``ccloud-stack`` will fail, and you need a workaround.
+
+When you create a new stack, set the parameter ``CHECK_CREDIT_CARD=false``, as shown in the example:
+
+.. code-block:: bash
+
+   CHECK_CREDIT_CARD=false ./ccloud_stack_create.sh
+
+
 ====================
 Additional Resources
 ====================

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -340,7 +340,7 @@ function ccloud::create_and_use_cluster() {
   CLUSTER_NAME=$1
   CLUSTER_CLOUD=$2
   CLUSTER_REGION=$3
-  
+
   OUTPUT=$(ccloud kafka cluster create "$CLUSTER_NAME" --cloud $CLUSTER_CLOUD --region $CLUSTER_REGION 2>&1)
   (($? != 0)) && { echo "$OUTPUT"; exit 1; }
   CLUSTER=$(echo "$OUTPUT" | grep '| Id' | awk '{print $4;}')
@@ -905,10 +905,12 @@ function ccloud::create_ccloud_stack() {
   REPLICATION_FACTOR=${REPLICATION_FACTOR:-3}
   enable_ksqldb=${1:-false}
   EXAMPLE=${EXAMPLE:-ccloud-stack-function}
+  CHECK_CREDIT_CARD="${CHECK_CREDIT_CARD:-true}"
 
   # Check if credit card is on file, which is required for cluster creation
-  if [[ $(ccloud admin payment describe) =~ "not found" ]]; then
+  if $CHECK_CREDIT_CARD && [[  $(ccloud admin payment describe) =~ "not found" ]]; then
     echo "ERROR: No credit card on file. Add a payment method and try again."
+    echo "If you are using a cloud provider's Marketplace, see documentation for a workaround: https://docs.confluent.io/platform/current/tutorials/examples/ccloud/docs/ccloud-stack.html#running-with-marketplace"
     exit 1
   fi
 
@@ -937,7 +939,7 @@ function ccloud::create_ccloud_stack() {
   else
     ccloud environment use $ENVIRONMENT || exit 1
   fi
-  
+
   CLUSTER_NAME=${CLUSTER_NAME:-"demo-kafka-cluster-$SERVICE_ACCOUNT_ID"}
   CLUSTER_CLOUD="${CLUSTER_CLOUD:-aws}"
   CLUSTER_REGION="${CLUSTER_REGION:-us-west-2}"


### PR DESCRIPTION
### Description 
 

By default, `ccloud-stack` check your payment method and verify if there is a credit card.
However, when you subscribe to pay as you go on Azure, GCP or AWS, your payment method is directly linked to your cloud provider and not necessarily with a credit card.

Create the `ccloud-stack` and override the parameters `CHECK_CREDIT_CARD`

```
CLUSTER_CLOUD=gcp CLUSTER_REGION=europe-west2 CHECK_CREDIT_CARD=false ./ccloud_stack_create.sh
```

### Author Validation

- [x] Documentation
- [x] ccloud/ccloud-stack


### Reviewer Tasks

- [ ] Documentation -->
- [x] ccloud/ccloud-stack
