### PR TITLE
Increase CLI login verbosity

### DIFF
--- a/security/rbac/scripts/rbac_lib.sh
+++ b/security/rbac/scripts/rbac_lib.sh
@@ -44,7 +44,7 @@ function login_mds() {
   OUTPUT=$(
 expect <<END
   log_user 1
-  spawn confluent login --url $MDS_URL
+  spawn confluent login --url $MDS_URL -vvv
   expect "Username: "
   send "${USER_ADMIN_MDS}\r";
   expect "Password: "

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -710,7 +710,7 @@ function ccloud::login_ccloud_cli(){
   OUTPUT=$(
   expect <<END
     log_user 1
-    spawn ccloud login --url $URL --prompt
+    spawn ccloud login --url $URL --prompt -vvv
     expect "Email: "
     send "$EMAIL\r";
     expect "Password: "


### PR DESCRIPTION
### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

We `expect "Logged in as "`, but that text is no longer visible without the `-vvv` flag.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
- [X] security/rbac


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
