### PR TITLE
MIROR: Use return value from ccloud call instead of env variable

### DIFF
--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -1054,10 +1054,10 @@ function ccloud::destroy_ccloud_stack() {
   # Delete associated ACLs
   ccloud::delete_acls_ccloud_stack $SERVICE_ACCOUNT_ID
 
-  if [[ "$KSQLDB_ENDPOINT" != "" ]]; then # This is just a quick check, if set there is a KSQLDB in this stack
-    local ksqldb_id=$(ccloud ksql app list -o json | jq -r 'map(select(.name == "'"$KSQLDB_NAME"'")) | .[].id')
-    echo "Deleting KSQLDB: $KSQLDB_NAME : $ksqldb_id"
-    ccloud ksql app delete $ksqldb_id &> "$REDIRECT_TO"
+  ksqldb_id_found=$(ccloud ksql app list -o json | jq -r 'map(select(.name == "'"$KSQLDB_NAME"'")) | .[].id')
+  if [[ $ksqldb_id_found != "" ]]; then
+    echo "Deleting KSQLDB: $KSQLDB_NAME : $ksqldb_id_found"
+    ccloud ksql app delete $ksqldb_id_found &> "$REDIRECT_TO"
   fi
 
   # Delete connectors associated to this Kafka cluster, otherwise cluster deletion fails


### PR DESCRIPTION
### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

In the `ccloud::destroy_ccloud_stack()` function, the check to determine if a `ksqlDB` needs to be deleted is based on environment variable `KSQLDB_ENDPOINT`.  But there could be cases where the variable is not set or gets un-set.  This situation causes an error and the cluster can't be deleted as the `ksqkDB` application is still running.

Since the function asks the user to pass in the `SERVICE_ACCOUNT_ID` and with that parameter we set the `KSQLDB_NAME` variable.  We can then deterministically figure out if there is a `ksqlDB` application by running the `ccloud` command to list ksql applications and grep for the name.  

This way the delete function isn't relying on any environment parameters and a user can open up a new terminal window and still successfully remove all CCloud resources.


### Author Validation

Validated by running the commands in the process of working on https://github.com/confluentinc/CCloud-Serverless-Integration.  Let me know if a separate validation on this repo is desired.

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
