### PR TITLE
DEVX-2670: Promote Confluent Cloud usage in client language tutorials

### DIFF
--- a/clients/docs/includes/client-example-prerequisites.rst
+++ b/clients/docs/includes/client-example-prerequisites.rst
@@ -1,6 +1,6 @@
 The easiest way to follow this tutorial is with `Confluent Cloud <https://www.confluent.io/confluent-cloud/tryfree/>`__ because you don't have to run a local |ak| cluster.
 When you sign up for `Confluent Cloud <https://www.confluent.io/confluent-cloud/tryfree/>`__, apply promo code ``C50INTEG`` to receive an additional $50 free usage (`details <https://www.confluent.io/confluent-cloud-promo-disclaimer/>`__).
-From the Console, click on `LEARN <https://confluent.cloud/learn>`__ to provision a cluster and click on `Clients` to create credentials and get the cluster-specific configurations and credentials to set for your client application.
+From the Console, click on `LEARN <https://confluent.cloud/learn>`__ to provision a cluster and click on ``Clients`` to create credentials and get the cluster-specific configurations and credentials to set for your client application.
 You can alternatively use the supported `CLI <https://docs.confluent.io/ccloud-cli/current/>`__ or `REST API <https://docs.confluent.io/cloud/current/get-started/krest-qs.html>`__, or the community-supported :ref:`ccloud-stack`.
 
 If you don't want to use |ccloud|, you can also use this tutorial with a |ak| cluster running on your :ref:`local host <quickstart>` or any other remote server.

--- a/clients/docs/includes/client-example-prerequisites.rst
+++ b/clients/docs/includes/client-example-prerequisites.rst
@@ -1,6 +1,6 @@
 The easiest way to follow this tutorial is with `Confluent Cloud <https://www.confluent.io/confluent-cloud/tryfree/>`__ because you don't have to run a local |ak| cluster.
 When you sign up for `Confluent Cloud <https://www.confluent.io/confluent-cloud/tryfree/>`__, apply promo code ``C50INTEG`` to receive an additional $50 free usage (`details <https://www.confluent.io/confluent-cloud-promo-disclaimer/>`__).
-To provision a cluster and credentials in |ccloud|, from the Console click on `LEARN <https://confluent.cloud/learn>`__ and follow the instructions to launch an |ak| cluster, then click on `Clients` to get the cluster-specific configurations and credentials to set for your client application.
-You can also provision |ccloud| resources using the supported `CLI <https://docs.confluent.io/ccloud-cli/current/>`__ or `REST API <https://docs.confluent.io/cloud/current/get-started/krest-qs.html>`__, or the community-supported :ref:`ccloud-stack`.
+From the Console, click on `LEARN <https://confluent.cloud/learn>`__ to provision a cluster and click on `Clients` to create credentials and get the cluster-specific configurations and credentials to set for your client application.
+You can alternatively use the supported `CLI <https://docs.confluent.io/ccloud-cli/current/>`__ or `REST API <https://docs.confluent.io/cloud/current/get-started/krest-qs.html>`__, or the community-supported :ref:`ccloud-stack`.
 
 If you don't want to use |ccloud|, you can also use this tutorial with a |ak| cluster running on your :ref:`local host <quickstart>` or any other remote server.

--- a/clients/docs/includes/client-example-prerequisites.rst
+++ b/clients/docs/includes/client-example-prerequisites.rst
@@ -1,13 +1,6 @@
-- You can use this tutorial with a |ak| cluster in any environment:
+The easiest way to follow this tutorial is with `Confluent Cloud <https://www.confluent.io/confluent-cloud/tryfree/>`__ because you don't have to run a local |ak| cluster.
+When you sign up for `Confluent Cloud <https://www.confluent.io/confluent-cloud/tryfree/>`__, apply promo code ``C50INTEG`` to receive an additional $50 free usage (`details <https://www.confluent.io/confluent-cloud-promo-disclaimer/>`__).
+To provision a cluster and credentials in |ccloud|, from the Console click on `LEARN <https://confluent.cloud/learn>`__ and follow the instructions to launch an |ak| cluster, then click on `Clients` to get the cluster-specific configurations and credentials to set for your client application.
+You can also provision |ccloud| resources using the supported `CLI <https://docs.confluent.io/ccloud-cli/current/>`__ or `REST API <https://docs.confluent.io/cloud/current/get-started/krest-qs.html>`__, or the community-supported :ref:`ccloud-stack`.
 
-  - In `Confluent Cloud <https://www.confluent.io/confluent-cloud/>`__
-  - On your :ref:`local host <quickstart>`
-  - Any remote |ak| cluster
-
-- If you are running on |ccloud|, you must have access to a
-  `Confluent Cloud <https://www.confluent.io/confluent-cloud/>`__ cluster
-  with an API key and secret.
-
-  - The first 20 users to sign up for `Confluent Cloud <https://www.confluent.io/confluent-cloud/>`__ and use promo code ``C50INTEG`` will receive an additional $50 free usage (`details <https://www.confluent.io/confluent-cloud-promo-disclaimer/>`__)
-  
-  - For an automated way to create a |ak| cluster, credentials, and ACLs in |ccloud|, see :ref:`ccloud-stack`.
+If you don't want to use |ccloud|, you can also use this tutorial with a |ak| cluster running on your :ref:`local host <quickstart>` or any other remote server.

--- a/clients/docs/includes/client-example-prerequisites.rst
+++ b/clients/docs/includes/client-example-prerequisites.rst
@@ -1,6 +1,6 @@
 The easiest way to follow this tutorial is with `Confluent Cloud <https://www.confluent.io/confluent-cloud/tryfree/>`__ because you don't have to run a local |ak| cluster.
 When you sign up for `Confluent Cloud <https://www.confluent.io/confluent-cloud/tryfree/>`__, apply promo code ``C50INTEG`` to receive an additional $50 free usage (`details <https://www.confluent.io/confluent-cloud-promo-disclaimer/>`__).
-From the Console, click on `LEARN <https://confluent.cloud/learn>`__ to provision a cluster and click on ``Clients`` to create credentials and get the cluster-specific configurations and credentials to set for your client application.
+From the Console, click on `LEARN <https://confluent.cloud/learn>`__ to provision a cluster and click on ``Clients`` to get the cluster-specific configurations and credentials to set for your client application.
 You can alternatively use the supported `CLI <https://docs.confluent.io/ccloud-cli/current/>`__ or `REST API <https://docs.confluent.io/cloud/current/get-started/krest-qs.html>`__, or the community-supported :ref:`ccloud-stack`.
 
 If you don't want to use |ccloud|, you can also use this tutorial with a |ak| cluster running on your :ref:`local host <quickstart>` or any other remote server.


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2670

_What behavior does this PR change, and why?_

Provide more nudging to fully-managed

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
