### PR TITLE
DOCS-9993: Update path to includes/docker-prereqs.rst

### DIFF
--- a/clickstream/docs/index.rst
+++ b/clickstream/docs/index.rst
@@ -8,7 +8,7 @@ These steps will guide you through how to setup your environment and run the cli
 .. figure:: images/clickstream_demo_flow.png
    :alt: image
 
-.. include:: ../../../../quickstart/includes/docker-prereqs.rst
+.. include:: ../../../../includes/docker-prereqs.rst
 
 - If you are using Linux as your host, for the Elasticsearch container to start successfully you must first run: 
 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DOCS-9993

During the CP Quick Start rewrite, we moved the prereq includes from the `quickstart` directory to the main `docs-platform/include` directory.