### PR TITLE
DEVX-2672: Using /dev/tty instead of /dev/stdout

### DIFF
--- a/ccloud-observability/start.sh
+++ b/ccloud-observability/start.sh
@@ -5,7 +5,7 @@ NAME=`basename "$0"`
 QUIET="${QUIET:-false}"
 [[ $QUIET == "true" ]] && 
   REDIRECT_TO="/dev/null" ||
-  REDIRECT_TO="/dev/stdout"
+  REDIRECT_TO="/dev/tty"
 
 # Source library
 source ../utils/helper.sh

--- a/cp-quickstart/start-cloud.sh
+++ b/cp-quickstart/start-cloud.sh
@@ -10,7 +10,7 @@ NAME=`basename "$0"`
 QUIET="${QUIET:-false}"
 [[ $QUIET == "true" ]] && 
   REDIRECT_TO="/dev/null" ||
-  REDIRECT_TO="/dev/stdout"
+  REDIRECT_TO="/dev/tty"
 
 # Source library
 source ../utils/helper.sh

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -485,7 +485,7 @@ function ccloud::create_acls_all_resources_full_access() {
   QUIET="${QUIET:-false}"
   [[ $QUIET == "true" ]] &&
     local REDIRECT_TO="/dev/null" ||
-    local REDIRECT_TO="/dev/stdout"
+    local REDIRECT_TO="/dev/tty"
 
   ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --topic '*' &>"$REDIRECT_TO"
   ccloud kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation DELETE --topic '*' &>"$REDIRECT_TO"
@@ -514,7 +514,7 @@ function ccloud::delete_acls_ccloud_stack() {
   QUIET="${QUIET:-false}"
   [[ $QUIET == "true" ]] &&
     local REDIRECT_TO="/dev/null" ||
-    local REDIRECT_TO="/dev/stdout"
+    local REDIRECT_TO="/dev/tty"
 
   echo "Deleting ACLs for service account ID $SERVICE_ACCOUNT_ID"
 
@@ -1050,7 +1050,7 @@ function ccloud::destroy_ccloud_stack() {
   QUIET="${QUIET:-false}"
   [[ $QUIET == "true" ]] && 
     local REDIRECT_TO="/dev/null" ||
-    local REDIRECT_TO="/dev/stdout"
+    local REDIRECT_TO="/dev/tty"
 
   echo "Destroying Confluent Cloud stack associated to service account id $SERVICE_ACCOUNT_ID"
 


### PR DESCRIPTION
With gitpod.io, I'm getting /dev/stdout: Permission denied otherwise

### Description 

https://confluentinc.atlassian.net/browse/DEVX-2672

_What behavior does this PR change, and why?_

Using Gitpod.io, I had some errors like this:

```
./ccloud_library.sh: line 490: /dev/stdout: Permission denied
./ccloud_library.sh: line 491: /dev/stdout: Permission denied
```

I have:

``` 
gitpod /workspace/cp-demo $ ls -lrt /dev/null 
crw-rw-rw- 1 nobody nogroup 1, 3 Sep 22 14:50 /dev/null
gitpod /workspace/cp-demo $ ls -lrt /dev/stdout
lrwxrwxrwx 1 nobody nogroup 15 Sep 22 14:50 /dev/stdout -> /proc/self/fd/1
gitpod /workspace/cp-demo $ ls -lrt /proc/self/fd/1
lrwx------ 1 gitpod gitpod 64 Sep 22 15:10 /proc/self/fd/1 -> /dev/pts/2
gitpod /workspace/cp-demo $ ls -lrt /dev/tty
crw-rw-rw- 1 nobody nogroup 5, 0 Sep 22 15:08 /dev/tty
```

In this Stack Overflow [answer](https://stackoverflow.com/a/19703931/2381999), it suggests to use `/dev/tty` instead

That does the trick:

``` 
gitpod /workspace/cp-demo $ echo "cdscs" >> /dev/tty
cdscs
```

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
