### PR TITLE
Update consumer_ccsr.py

### DIFF
--- a/clients/cloud/python/consumer_ccsr.py
+++ b/clients/cloud/python/consumer_ccsr.py
@@ -45,11 +45,11 @@ if __name__ == '__main__':
         'basic.auth.user.info': conf['basic.auth.user.info']}
     schema_registry_client = SchemaRegistryClient(schema_registry_conf)
 
-    name_avro_deserializer = AvroDeserializer(ccloud_lib.name_schema,
-                                              schema_registry_client,
+    name_avro_deserializer = AvroDeserializer(schema_registry_client,
+                                              ccloud_lib.name_schema,
                                               ccloud_lib.Name.dict_to_name)
-    count_avro_deserializer = AvroDeserializer(ccloud_lib.count_schema,
-                                               schema_registry_client,
+    count_avro_deserializer = AvroDeserializer(schema_registry_client,
+                                               ccloud_lib.count_schema,
                                                ccloud_lib.Count.dict_to_count)
 
     # for full list of configurations, see:

--- a/clients/cloud/python/consumer_ccsr.py
+++ b/clients/cloud/python/consumer_ccsr.py
@@ -45,12 +45,12 @@ if __name__ == '__main__':
         'basic.auth.user.info': conf['basic.auth.user.info']}
     schema_registry_client = SchemaRegistryClient(schema_registry_conf)
 
-    name_avro_deserializer = AvroDeserializer(schema_registry_client,
-                                              ccloud_lib.name_schema,
-                                              ccloud_lib.Name.dict_to_name)
-    count_avro_deserializer = AvroDeserializer(schema_registry_client,
-                                               ccloud_lib.count_schema,
-                                               ccloud_lib.Count.dict_to_count)
+    name_avro_deserializer = AvroDeserializer(schema_registry_client = schema_registry_client,
+                                              schema_str = ccloud_lib.name_schema,
+                                              from_dict = ccloud_lib.Name.dict_to_name)
+    count_avro_deserializer = AvroDeserializer(schema_registry_client = schema_registry_client,
+                                               schema_str = ccloud_lib.count_schema,
+                                               from_dict = ccloud_lib.Count.dict_to_count)
 
     # for full list of configurations, see:
     #   https://docs.confluent.io/platform/current/clients/confluent-kafka-python/#deserializingconsumer


### PR DESCRIPTION
The ordering of the variables is fixed to prevent deserialisation error.

### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

_What behavior does this PR change, and why?_


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
