### PR TITLE
DEVX-2683: Update language on running ccloud-stack

### DIFF
--- a/ccloud-observability/start.sh
+++ b/ccloud-observability/start.sh
@@ -14,6 +14,11 @@ source ../utils/ccloud_library.sh
 check_jq \
   && print_pass "jq found"
 
+[[ -z "$AUTO" ]] && {
+  printf "\n====== Confirm\n\n"
+  ccloud::prompt_continue_ccloud_demo || exit 1
+} 
+
 ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION \
   && print_pass "ccloud version ok"
 
@@ -21,11 +26,6 @@ ccloud::validate_logged_in_ccloud_cli \
   && print_pass "logged into ccloud CLI" 
 
 print_pass "Prerequisite check pass"
-
-[[ -z "$AUTO" ]] && {
-  printf "\n====== Confirm\n\n"
-  ccloud::prompt_continue_ccloud_demo || exit 1
-} 
 
 printf "\n====== Starting\n\n"
 

--- a/ccloud/beginner-cloud/start.sh
+++ b/ccloud/beginner-cloud/start.sh
@@ -13,9 +13,9 @@
 source ../../utils/helper.sh
 source ../../utils/ccloud_library.sh
 
+ccloud::prompt_continue_ccloud_demo || exit 1
 ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION || exit 1
 ccloud::validate_logged_in_ccloud_cli || exit 1
-ccloud::prompt_continue_ccloud_demo || exit 1
 check_timeout || exit 1
 check_mvn || exit 1
 check_jq || exit 1

--- a/ccloud/ccloud-stack/ccloud_stack_create.sh
+++ b/ccloud/ccloud-stack/ccloud_stack_create.sh
@@ -10,11 +10,11 @@
 source ../../utils/helper.sh
 source ../../utils/ccloud_library.sh
 
+ccloud::prompt_continue_ccloud_demo || exit 1
+
 ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION || exit 1
 check_jq || exit 1
 ccloud::validate_logged_in_ccloud_cli || exit 1
-
-ccloud::prompt_continue_ccloud_demo || exit 1
 
 enable_ksqldb=false
 read -p "Do you also want to create a Confluent Cloud ksqlDB app (hourly charges may apply)? [y/n] " -n 1 -r

--- a/cloud-etl/start.sh
+++ b/cloud-etl/start.sh
@@ -9,6 +9,8 @@ NAME=`basename "$0"`
 source ../utils/helper.sh
 source ../utils/ccloud_library.sh
 
+ccloud::prompt_continue_ccloud_demo || exit 1
+
 ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION \
   && print_pass "ccloud version ok" \
   || exit 1
@@ -33,7 +35,6 @@ export EXAMPLE="cloud-etl"
 
 echo
 echo ====== Create new Confluent Cloud stack
-ccloud::prompt_continue_ccloud_demo || exit 1
 ccloud::create_ccloud_stack true
 SERVICE_ACCOUNT_ID=$(ccloud kafka cluster list -o json | jq -r '.[0].name' | awk -F'-' '{print $4;}')
 if [[ "$SERVICE_ACCOUNT_ID" == "" ]]; then

--- a/cp-quickstart/start-cloud.sh
+++ b/cp-quickstart/start-cloud.sh
@@ -19,14 +19,6 @@ source ../utils/ccloud_library.sh
 check_jq \
   && print_pass "jq found"
 
-ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION \
-  && print_pass "ccloud version ok"
-
-ccloud::validate_logged_in_ccloud_cli \
-  && print_pass "logged into ccloud CLI" 
-
-print_pass "Prerequisite check pass"
-
 [[ -z "$AUTO" ]] && {
   printf "\n====== Confirm\n\n"
   ccloud::prompt_continue_ccloud_demo || exit 1
@@ -34,6 +26,14 @@ print_pass "Prerequisite check pass"
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then exit 1; fi
 	printf "\n"
 } 
+
+ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION \
+  && print_pass "ccloud version ok"
+
+ccloud::validate_logged_in_ccloud_cli \
+  && print_pass "logged into ccloud CLI" 
+
+print_pass "Prerequisite check pass"
 
 printf "\nFor your reference the demo will highlight some commands in "; print_code "code format"
 

--- a/microservices-orders/start-ccloud.sh
+++ b/microservices-orders/start-ccloud.sh
@@ -6,6 +6,8 @@ source ../utils/helper.sh
 
 MAX_WAIT=${MAX_WAIT:-60}
 
+[[ -z "$NO_PROMPT" ]] && ccloud::prompt_continue_ccloud_demo
+
 ccloud::validate_version_ccloud_cli $CCLOUD_MIN_VERSION \
   && print_pass "ccloud version ok"
 
@@ -13,7 +15,6 @@ ccloud::validate_logged_in_ccloud_cli \
   && print_pass "logged into ccloud CLI"
 
 printf "\n====== Create new Confluent Cloud stack\n"
-[[ -z "$NO_PROMPT" ]] && ccloud::prompt_continue_ccloud_demo
 export EXAMPLE="microservices-orders"
 ccloud::create_ccloud_stack true
 

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -36,17 +36,20 @@ CCLOUD_MIN_VERSION=${CCLOUD_MIN_VERSION:-1.25.0}
 
 function ccloud::prompt_continue_ccloud_demo() {
   echo
-  echo "-------------------------------------------------------------------------------------------"
-  echo "Any Confluent Cloud example uses real Confluent Cloud resources that may be billable,"
-  echo "including connectors and ksqlDB applications that may have hourly charges."
+  echo "--------------------------------------------------------------------------------------------"
+  echo "This example runs on Confluent Cloud, sign up here:"
   echo
-  echo "At the end of this script, it will show a command to destroy all Confluent Cloud resources."
-  echo "When you're done with the example, run the command and verify resources have been removed."
+  echo "         https://www.confluent.io/confluent-cloud/tryfree/"
   echo
-  echo "Use Confluent Cloud promo code C50INTEG to receive \$50 free usage, which should"
-  echo "sufficiently cover one day of running this example, beyond which you may be billed"
+  echo "The example uses real Confluent Cloud resources that may be billable, including connectors"
+  echo "and ksqlDB applications that may have hourly charges. The end of this script will show a"
+  echo "command to destroy all Confluent Cloud resources, and you should verify they are destroyed."
+  echo
+  echo "New Confluent Cloud signups receive \$400 to spend within Confluent Cloud during their first"
+  echo "60 days. Use Confluent Cloud promo code C50INTEG to receive an additional \$50 free usage."
+  echo "This will sufficiently cover one day of running this example, beyond which you may be billed"
   echo "for the Confluent Cloud resources until you destroy them."
-  echo "-------------------------------------------------------------------------------------------"
+  echo "--------------------------------------------------------------------------------------------"
   echo
 
   read -p "Do you still want to run this script? [y/n] " -n 1 -r

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -42,8 +42,8 @@ function ccloud::prompt_continue_ccloud_demo() {
   echo "         https://www.confluent.io/confluent-cloud/tryfree/"
   echo
   echo "The example uses real Confluent Cloud resources that may be billable, including connectors"
-  echo "and ksqlDB applications that may have hourly charges. The end of this script will show a"
-  echo "command to destroy all Confluent Cloud resources, and you should verify they are destroyed."
+  echo "and ksqlDB applications that may have hourly charges. The end of this script shows a command"
+  echo "you can run to destroy all the cloud resources, and you should verify they are destroyed."
   echo
   echo "New Confluent Cloud signups receive \$400 to spend within Confluent Cloud during their first"
   echo "60 days. Use Confluent Cloud promo code C50INTEG to receive an additional \$50 free usage."


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2683

_What behavior does this PR change, and why?_

Update language for Confluent Cloud examples

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
- [x] ccloud/ccloud-stack
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
