### PR TITLE
DEVX-2697: add link

### DIFF
--- a/connect-streams-pipeline/docs/index.rst
+++ b/connect-streams-pipeline/docs/index.rst
@@ -154,6 +154,8 @@ Example 2: JDBC source connector with Single Message Transformations -> Key:Long
 Example 3: JDBC source connector with SpecificAvro -> Key:String(null) and Value:SpecificAvro
 ---------------------------------------------------------------------------------------------
 
+.. note:: See this example in the tutorial `Add key to data ingested through Kafka Connect <https://kafka-tutorials.confluent.io/connect-add-key-to-source/kstreams.html>`__.
+
 - :devx-examples:`Kafka Connect JDBC source connector|connect-streams-pipeline/jdbcspecificavro-connector.properties` produces Avro values, and null ``String`` keys, to a Kafka topic.
 - This example uses a single message transformation (SMT) called ``SetSchemaMetadata`` with code that has a fix for `KAFKA-5164 <https://issues.apache.org/jira/browse/KAFKA-5164>`__, allowing the connector to set the namespace in the schema. If you do not have the fix for `KAFKA-5164 <https://issues.apache.org/jira/browse/KAFKA-5164>`__, see Example 4 that uses ``GenericAvro`` instead of ``SpecificAvro``.
 

--- a/connect-streams-pipeline/docs/index.rst
+++ b/connect-streams-pipeline/docs/index.rst
@@ -154,7 +154,7 @@ Example 2: JDBC source connector with Single Message Transformations -> Key:Long
 Example 3: JDBC source connector with SpecificAvro -> Key:String(null) and Value:SpecificAvro
 ---------------------------------------------------------------------------------------------
 
-.. note:: See this example in the tutorial `Add key to data ingested through Kafka Connect <https://kafka-tutorials.confluent.io/connect-add-key-to-source/kstreams.html>`__.
+.. seealso:: See this example in the tutorial `Add key to data ingested through Kafka Connect <https://kafka-tutorials.confluent.io/connect-add-key-to-source/kstreams.html>`__.
 
 - :devx-examples:`Kafka Connect JDBC source connector|connect-streams-pipeline/jdbcspecificavro-connector.properties` produces Avro values, and null ``String`` keys, to a Kafka topic.
 - This example uses a single message transformation (SMT) called ``SetSchemaMetadata`` with code that has a fix for `KAFKA-5164 <https://issues.apache.org/jira/browse/KAFKA-5164>`__, allowing the connector to set the namespace in the schema. If you do not have the fix for `KAFKA-5164 <https://issues.apache.org/jira/browse/KAFKA-5164>`__, see Example 4 that uses ``GenericAvro`` instead of ``SpecificAvro``.


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2697

_What behavior does this PR change, and why?_


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [x] Documentation: built locally and passed
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
