### PR TITLE
Adding recommended values for `session.timeout.ms`

### DIFF
--- a/clients/docs/includes/configs/cloud/hocon-sr.config
+++ b/clients/docs/includes/configs/cloud/hocon-sr.config
@@ -21,14 +21,14 @@ kafka {
     key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
     value.deserializer = io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer
     json.value.type = io.confluent.developer.Question
-    # Recommended consumer configuration to avoid unwanted or accidental rebalances
+    # Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
     session.timeout.ms=45000
   }
   producer {
     client.id = "ktor-producer"
     key.serializer = org.apache.kafka.common.serialization.StringSerializer
     value.serializer = io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer
-    # Recommended producer configuration to avoid duplication
+    # Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
     request.timeout.ms=30000
   }
 }

--- a/clients/docs/includes/configs/cloud/hocon-sr.config
+++ b/clients/docs/includes/configs/cloud/hocon-sr.config
@@ -21,7 +21,7 @@ kafka {
     key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
     value.deserializer = io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer
     json.value.type = io.confluent.developer.Question
-    # Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
+    # Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
     session.timeout.ms=45000
   }
   producer {

--- a/clients/docs/includes/configs/cloud/hocon-sr.config
+++ b/clients/docs/includes/configs/cloud/hocon-sr.config
@@ -21,7 +21,7 @@ kafka {
     key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
     value.deserializer = io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer
     json.value.type = io.confluent.developer.Question
-    # Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
+    # Best practice for higher availability in Apache Kafka clients prior to 3.0
     session.timeout.ms=45000
   }
   producer {

--- a/clients/docs/includes/configs/cloud/hocon-sr.config
+++ b/clients/docs/includes/configs/cloud/hocon-sr.config
@@ -28,7 +28,5 @@ kafka {
     client.id = "ktor-producer"
     key.serializer = org.apache.kafka.common.serialization.StringSerializer
     value.serializer = io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer
-    # Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
-    request.timeout.ms=30000
   }
 }

--- a/clients/docs/includes/configs/cloud/hocon-sr.config
+++ b/clients/docs/includes/configs/cloud/hocon-sr.config
@@ -21,10 +21,14 @@ kafka {
     key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
     value.deserializer = io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer
     json.value.type = io.confluent.developer.Question
+    # Recommended consumer configuration to avoid unwanted or accidental rebalances
+    session.timeout.ms=45000
   }
   producer {
     client.id = "ktor-producer"
     key.serializer = org.apache.kafka.common.serialization.StringSerializer
     value.serializer = io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer
+    # Recommended producer configuration to avoid duplication
+    request.timeout.ms=30000
   }
 }

--- a/clients/docs/includes/configs/cloud/hocon.config
+++ b/clients/docs/includes/configs/cloud/hocon.config
@@ -15,10 +15,14 @@ kafka {
     group.id = "consumer"
     key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
     value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+    # Recommended consumer configuration to avoid unwanted or accidental rebalances
+    session.timeout.ms=45000
   }
   producer {
     client.id = "producer"
     key.serializer = org.apache.kafka.common.serialization.StringSerializer
     value.serializer = org.apache.kafka.common.serialization.StringSerializer
+    # Recommended producer configuration to avoid duplication
+    request.timeout.ms=30000
   }
 }

--- a/clients/docs/includes/configs/cloud/hocon.config
+++ b/clients/docs/includes/configs/cloud/hocon.config
@@ -15,7 +15,7 @@ kafka {
     group.id = "consumer"
     key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
     value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
-    # Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
+    # Best practice for higher availability in Apache Kafka clients prior to 3.0
     session.timeout.ms=45000
   }
   producer {

--- a/clients/docs/includes/configs/cloud/hocon.config
+++ b/clients/docs/includes/configs/cloud/hocon.config
@@ -15,7 +15,7 @@ kafka {
     group.id = "consumer"
     key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
     value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
-    # Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
+    # Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
     session.timeout.ms=45000
   }
   producer {

--- a/clients/docs/includes/configs/cloud/hocon.config
+++ b/clients/docs/includes/configs/cloud/hocon.config
@@ -22,7 +22,5 @@ kafka {
     client.id = "producer"
     key.serializer = org.apache.kafka.common.serialization.StringSerializer
     value.serializer = org.apache.kafka.common.serialization.StringSerializer
-    # Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
-    request.timeout.ms=30000
   }
 }

--- a/clients/docs/includes/configs/cloud/hocon.config
+++ b/clients/docs/includes/configs/cloud/hocon.config
@@ -15,14 +15,14 @@ kafka {
     group.id = "consumer"
     key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
     value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
-    # Recommended consumer configuration to avoid unwanted or accidental rebalances
+    # Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
     session.timeout.ms=45000
   }
   producer {
     client.id = "producer"
     key.serializer = org.apache.kafka.common.serialization.StringSerializer
     value.serializer = org.apache.kafka.common.serialization.StringSerializer
-    # Recommended producer configuration to avoid duplication
+    # Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
     request.timeout.ms=30000
   }
 }

--- a/clients/docs/includes/configs/cloud/java-sr.config
+++ b/clients/docs/includes/configs/cloud/java-sr.config
@@ -6,7 +6,7 @@ sasl.mechanism=PLAIN
 # Required for correctness in Apache Kafka clients prior to 2.6
 client.dns.lookup=use_all_dns_ips
 
-# Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
+# Best practice for higher availability in Apache Kafka clients prior to 3.0
 session.timeout.ms=45000
 
 # Best practice for Kafka producer to prevent data loss 

--- a/clients/docs/includes/configs/cloud/java-sr.config
+++ b/clients/docs/includes/configs/cloud/java-sr.config
@@ -8,8 +8,6 @@ client.dns.lookup=use_all_dns_ips
 
 # Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
 session.timeout.ms=45000
-# Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
-request.timeout.ms=30000
 
 # Best practice for Kafka producer to prevent data loss 
 acks=all

--- a/clients/docs/includes/configs/cloud/java-sr.config
+++ b/clients/docs/includes/configs/cloud/java-sr.config
@@ -6,9 +6,9 @@ sasl.mechanism=PLAIN
 # Required for correctness in Apache Kafka clients prior to 2.6
 client.dns.lookup=use_all_dns_ips
 
-# Recommended consumer configuration to avoid unwanted or accidental rebalances
+# Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
 session.timeout.ms=45000
-# Recommended producer configuration to avoid duplication
+# Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
 request.timeout.ms=30000
 
 # Best practice for Kafka producer to prevent data loss 

--- a/clients/docs/includes/configs/cloud/java-sr.config
+++ b/clients/docs/includes/configs/cloud/java-sr.config
@@ -6,7 +6,7 @@ sasl.mechanism=PLAIN
 # Required for correctness in Apache Kafka clients prior to 2.6
 client.dns.lookup=use_all_dns_ips
 
-# Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
+# Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
 session.timeout.ms=45000
 
 # Best practice for Kafka producer to prevent data loss 

--- a/clients/docs/includes/configs/cloud/java-sr.config
+++ b/clients/docs/includes/configs/cloud/java-sr.config
@@ -6,6 +6,11 @@ sasl.mechanism=PLAIN
 # Required for correctness in Apache Kafka clients prior to 2.6
 client.dns.lookup=use_all_dns_ips
 
+# Recommended consumer configuration to avoid unwanted or accidental rebalances
+session.timeout.ms=45000
+# Recommended producer configuration to avoid duplication
+request.timeout.ms=30000
+
 # Best practice for Kafka producer to prevent data loss 
 acks=all
 

--- a/clients/docs/includes/configs/cloud/java.config
+++ b/clients/docs/includes/configs/cloud/java.config
@@ -6,7 +6,7 @@ sasl.mechanism=PLAIN
 # Required for correctness in Apache Kafka clients prior to 2.6
 client.dns.lookup=use_all_dns_ips
 
-# Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
+# Best practice for higher availability in Apache Kafka clients prior to 3.0
 session.timeout.ms=45000
 
 # Best practice for Kafka producer to prevent data loss 

--- a/clients/docs/includes/configs/cloud/java.config
+++ b/clients/docs/includes/configs/cloud/java.config
@@ -8,8 +8,6 @@ client.dns.lookup=use_all_dns_ips
 
 # Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
 session.timeout.ms=45000
-# Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
-request.timeout.ms=30000
 
 # Best practice for Kafka producer to prevent data loss 
 acks=all

--- a/clients/docs/includes/configs/cloud/java.config
+++ b/clients/docs/includes/configs/cloud/java.config
@@ -6,9 +6,9 @@ sasl.mechanism=PLAIN
 # Required for correctness in Apache Kafka clients prior to 2.6
 client.dns.lookup=use_all_dns_ips
 
-# Recommended consumer configuration to avoid unwanted or accidental rebalances
+# Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
 session.timeout.ms=45000
-# Recommended producer configuration to avoid duplication
+# Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
 request.timeout.ms=30000
 
 # Best practice for Kafka producer to prevent data loss 

--- a/clients/docs/includes/configs/cloud/java.config
+++ b/clients/docs/includes/configs/cloud/java.config
@@ -6,7 +6,7 @@ sasl.mechanism=PLAIN
 # Required for correctness in Apache Kafka clients prior to 2.6
 client.dns.lookup=use_all_dns_ips
 
-# Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
+# Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
 session.timeout.ms=45000
 
 # Best practice for Kafka producer to prevent data loss 

--- a/clients/docs/includes/configs/cloud/java.config
+++ b/clients/docs/includes/configs/cloud/java.config
@@ -6,5 +6,10 @@ sasl.mechanism=PLAIN
 # Required for correctness in Apache Kafka clients prior to 2.6
 client.dns.lookup=use_all_dns_ips
 
+# Recommended consumer configuration to avoid unwanted or accidental rebalances
+session.timeout.ms=45000
+# Recommended producer configuration to avoid duplication
+request.timeout.ms=30000
+
 # Best practice for Kafka producer to prevent data loss 
 acks=all

--- a/clients/docs/includes/configs/cloud/librdkafka-sr.config
+++ b/clients/docs/includes/configs/cloud/librdkafka-sr.config
@@ -5,7 +5,7 @@ sasl.mechanisms=PLAIN
 sasl.username={{ CLUSTER_API_KEY }}
 sasl.password={{ CLUSTER_API_SECRET }}
 
-# Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
+# Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
 session.timeout.ms=45000
 
 # Confluent Cloud Schema Registry

--- a/clients/docs/includes/configs/cloud/librdkafka-sr.config
+++ b/clients/docs/includes/configs/cloud/librdkafka-sr.config
@@ -5,9 +5,9 @@ sasl.mechanisms=PLAIN
 sasl.username={{ CLUSTER_API_KEY }}
 sasl.password={{ CLUSTER_API_SECRET }}
 
-# Recommended consumer configuration to avoid unwanted or accidental rebalances
+# Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
 session.timeout.ms=45000
-# Recommended producer configuration to avoid duplication
+# Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
 request.timeout.ms=30000
 
 # Confluent Cloud Schema Registry

--- a/clients/docs/includes/configs/cloud/librdkafka-sr.config
+++ b/clients/docs/includes/configs/cloud/librdkafka-sr.config
@@ -5,7 +5,7 @@ sasl.mechanisms=PLAIN
 sasl.username={{ CLUSTER_API_KEY }}
 sasl.password={{ CLUSTER_API_SECRET }}
 
-# Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
+# Increase session timeout for higher availability (45s is the default for Librdkafka 1.7 and above)
 session.timeout.ms=45000
 
 # Confluent Cloud Schema Registry

--- a/clients/docs/includes/configs/cloud/librdkafka-sr.config
+++ b/clients/docs/includes/configs/cloud/librdkafka-sr.config
@@ -7,8 +7,6 @@ sasl.password={{ CLUSTER_API_SECRET }}
 
 # Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
 session.timeout.ms=45000
-# Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
-request.timeout.ms=30000
 
 # Confluent Cloud Schema Registry
 schema.registry.url=https://{{ SR_ENDPOINT }}

--- a/clients/docs/includes/configs/cloud/librdkafka-sr.config
+++ b/clients/docs/includes/configs/cloud/librdkafka-sr.config
@@ -5,6 +5,11 @@ sasl.mechanisms=PLAIN
 sasl.username={{ CLUSTER_API_KEY }}
 sasl.password={{ CLUSTER_API_SECRET }}
 
+# Recommended consumer configuration to avoid unwanted or accidental rebalances
+session.timeout.ms=45000
+# Recommended producer configuration to avoid duplication
+request.timeout.ms=30000
+
 # Confluent Cloud Schema Registry
 schema.registry.url=https://{{ SR_ENDPOINT }}
 basic.auth.credentials.source=USER_INFO

--- a/clients/docs/includes/configs/cloud/librdkafka-sr.config
+++ b/clients/docs/includes/configs/cloud/librdkafka-sr.config
@@ -5,7 +5,7 @@ sasl.mechanisms=PLAIN
 sasl.username={{ CLUSTER_API_KEY }}
 sasl.password={{ CLUSTER_API_SECRET }}
 
-# Increase session timeout for higher availability (45s is the default for Librdkafka 1.7 and above)
+# Increase session timeout for higher availability (45s is the default for librdkafka 1.7 and above)
 session.timeout.ms=45000
 
 # Confluent Cloud Schema Registry

--- a/clients/docs/includes/configs/cloud/librdkafka-sr.config
+++ b/clients/docs/includes/configs/cloud/librdkafka-sr.config
@@ -5,7 +5,7 @@ sasl.mechanisms=PLAIN
 sasl.username={{ CLUSTER_API_KEY }}
 sasl.password={{ CLUSTER_API_SECRET }}
 
-# Increase session timeout for higher availability (45s is the default for librdkafka 1.7 and above)
+# Best practice for higher availability in librdkafka clients prior to 1.7
 session.timeout.ms=45000
 
 # Confluent Cloud Schema Registry

--- a/clients/docs/includes/configs/cloud/librdkafka.config
+++ b/clients/docs/includes/configs/cloud/librdkafka.config
@@ -5,5 +5,5 @@ sasl.mechanisms=PLAIN
 sasl.username={{ CLUSTER_API_KEY }}
 sasl.password={{ CLUSTER_API_SECRET }}
 
-# Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
+# Increase session timeout for higher availability (45s is the default for Librdkafka 1.7 and above)
 session.timeout.ms=45000

--- a/clients/docs/includes/configs/cloud/librdkafka.config
+++ b/clients/docs/includes/configs/cloud/librdkafka.config
@@ -5,7 +5,7 @@ sasl.mechanisms=PLAIN
 sasl.username={{ CLUSTER_API_KEY }}
 sasl.password={{ CLUSTER_API_SECRET }}
 
-# Recommended consumer configuration to avoid unwanted or accidental rebalances
+# Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
 session.timeout.ms=45000
-# Recommended producer configuration to avoid duplication
+# Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
 request.timeout.ms=30000

--- a/clients/docs/includes/configs/cloud/librdkafka.config
+++ b/clients/docs/includes/configs/cloud/librdkafka.config
@@ -5,5 +5,5 @@ sasl.mechanisms=PLAIN
 sasl.username={{ CLUSTER_API_KEY }}
 sasl.password={{ CLUSTER_API_SECRET }}
 
-# Increase session timeout for higher availability (45s is the default for librdkafka 1.7 and above)
+# Best practice for higher availability in librdkafka clients prior to 1.7
 session.timeout.ms=45000

--- a/clients/docs/includes/configs/cloud/librdkafka.config
+++ b/clients/docs/includes/configs/cloud/librdkafka.config
@@ -7,5 +7,3 @@ sasl.password={{ CLUSTER_API_SECRET }}
 
 # Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
 session.timeout.ms=45000
-# Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
-request.timeout.ms=30000

--- a/clients/docs/includes/configs/cloud/librdkafka.config
+++ b/clients/docs/includes/configs/cloud/librdkafka.config
@@ -4,3 +4,8 @@ security.protocol=SASL_SSL
 sasl.mechanisms=PLAIN
 sasl.username={{ CLUSTER_API_KEY }}
 sasl.password={{ CLUSTER_API_SECRET }}
+
+# Recommended consumer configuration to avoid unwanted or accidental rebalances
+session.timeout.ms=45000
+# Recommended producer configuration to avoid duplication
+request.timeout.ms=30000

--- a/clients/docs/includes/configs/cloud/librdkafka.config
+++ b/clients/docs/includes/configs/cloud/librdkafka.config
@@ -5,5 +5,5 @@ sasl.mechanisms=PLAIN
 sasl.username={{ CLUSTER_API_KEY }}
 sasl.password={{ CLUSTER_API_SECRET }}
 
-# Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
+# Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
 session.timeout.ms=45000

--- a/clients/docs/includes/configs/cloud/librdkafka.config
+++ b/clients/docs/includes/configs/cloud/librdkafka.config
@@ -5,5 +5,5 @@ sasl.mechanisms=PLAIN
 sasl.username={{ CLUSTER_API_KEY }}
 sasl.password={{ CLUSTER_API_SECRET }}
 
-# Increase session timeout for higher availability (45s is the default for Librdkafka 1.7 and above)
+# Increase session timeout for higher availability (45s is the default for librdkafka 1.7 and above)
 session.timeout.ms=45000

--- a/clients/docs/includes/configs/cloud/springboot-sr.config
+++ b/clients/docs/includes/configs/cloud/springboot-sr.config
@@ -4,9 +4,9 @@ spring.kafka.properties.bootstrap.servers={{ BROKER_ENDPOINT }}
 spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
 spring.kafka.properties.security.protocol=SASL_SSL
 
-# Recommended consumer configuration to avoid unwanted or accidental rebalances
+# Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
 spring.kafka.properties.session.timeout.ms=45000
-# Recommended producer configuration to avoid duplication
+# Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
 spring.kafka.properties.request.timeout.ms=30000
 
 # Confluent Cloud Schema Registry

--- a/clients/docs/includes/configs/cloud/springboot-sr.config
+++ b/clients/docs/includes/configs/cloud/springboot-sr.config
@@ -4,7 +4,7 @@ spring.kafka.properties.bootstrap.servers={{ BROKER_ENDPOINT }}
 spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
 spring.kafka.properties.security.protocol=SASL_SSL
 
-# Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
+# Best practice for higher availability in Apache Kafka clients prior to 3.0
 spring.kafka.properties.session.timeout.ms=45000
 
 # Confluent Cloud Schema Registry

--- a/clients/docs/includes/configs/cloud/springboot-sr.config
+++ b/clients/docs/includes/configs/cloud/springboot-sr.config
@@ -4,7 +4,7 @@ spring.kafka.properties.bootstrap.servers={{ BROKER_ENDPOINT }}
 spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
 spring.kafka.properties.security.protocol=SASL_SSL
 
-# Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
+# Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
 spring.kafka.properties.session.timeout.ms=45000
 
 # Confluent Cloud Schema Registry

--- a/clients/docs/includes/configs/cloud/springboot-sr.config
+++ b/clients/docs/includes/configs/cloud/springboot-sr.config
@@ -4,6 +4,11 @@ spring.kafka.properties.bootstrap.servers={{ BROKER_ENDPOINT }}
 spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
 spring.kafka.properties.security.protocol=SASL_SSL
 
+# Recommended consumer configuration to avoid unwanted or accidental rebalances
+spring.kafka.properties.session.timeout.ms=45000
+# Recommended producer configuration to avoid duplication
+spring.kafka.properties.request.timeout.ms=30000
+
 # Confluent Cloud Schema Registry
 spring.kafka.properties.basic.auth.credentials.source=USER_INFO
 spring.kafka.properties.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}

--- a/clients/docs/includes/configs/cloud/springboot-sr.config
+++ b/clients/docs/includes/configs/cloud/springboot-sr.config
@@ -6,8 +6,6 @@ spring.kafka.properties.security.protocol=SASL_SSL
 
 # Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
 spring.kafka.properties.session.timeout.ms=45000
-# Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
-spring.kafka.properties.request.timeout.ms=30000
 
 # Confluent Cloud Schema Registry
 spring.kafka.properties.basic.auth.credentials.source=USER_INFO

--- a/clients/docs/includes/configs/cloud/springboot.config
+++ b/clients/docs/includes/configs/cloud/springboot.config
@@ -4,5 +4,5 @@ spring.kafka.properties.bootstrap.servers={{ BROKER_ENDPOINT }}
 spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
 spring.kafka.properties.security.protocol=SASL_SSL
 
-# Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
+# Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
 spring.kafka.properties.session.timeout.ms=45000

--- a/clients/docs/includes/configs/cloud/springboot.config
+++ b/clients/docs/includes/configs/cloud/springboot.config
@@ -4,7 +4,7 @@ spring.kafka.properties.bootstrap.servers={{ BROKER_ENDPOINT }}
 spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
 spring.kafka.properties.security.protocol=SASL_SSL
 
-# Recommended consumer configuration to avoid unwanted or accidental rebalances
+# Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
 spring.kafka.properties.session.timeout.ms=45000
-# Recommended producer configuration to avoid duplication
+# Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
 spring.kafka.properties.request.timeout.ms=30000

--- a/clients/docs/includes/configs/cloud/springboot.config
+++ b/clients/docs/includes/configs/cloud/springboot.config
@@ -4,5 +4,5 @@ spring.kafka.properties.bootstrap.servers={{ BROKER_ENDPOINT }}
 spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
 spring.kafka.properties.security.protocol=SASL_SSL
 
-# Increase session timeout for higher availability (45s is the default for Apache Kafka 3.0 and above)
+# Best practice for higher availability in Apache Kafka clients prior to 3.0
 spring.kafka.properties.session.timeout.ms=45000

--- a/clients/docs/includes/configs/cloud/springboot.config
+++ b/clients/docs/includes/configs/cloud/springboot.config
@@ -3,3 +3,8 @@ spring.kafka.properties.sasl.mechanism=PLAIN
 spring.kafka.properties.bootstrap.servers={{ BROKER_ENDPOINT }}
 spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
 spring.kafka.properties.security.protocol=SASL_SSL
+
+# Recommended consumer configuration to avoid unwanted or accidental rebalances
+spring.kafka.properties.session.timeout.ms=45000
+# Recommended producer configuration to avoid duplication
+spring.kafka.properties.request.timeout.ms=30000

--- a/clients/docs/includes/configs/cloud/springboot.config
+++ b/clients/docs/includes/configs/cloud/springboot.config
@@ -6,5 +6,3 @@ spring.kafka.properties.security.protocol=SASL_SSL
 
 # Recommended consumer configuration for higher availability in Apache Kafka clients prior to 3.0
 spring.kafka.properties.session.timeout.ms=45000
-# Recommended producer configuration to avoid duplication in Apache Kafka clients prior to 2.0
-spring.kafka.properties.request.timeout.ms=30000


### PR DESCRIPTION
### Description 

Explicitly adding any recommended configuration as a preventative measure to avoid any issues due to misconfiguration.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

KIP-735 -- https://kafka.apache.org/documentation/#:~:text=The%20default%20value%20for%20the%20consumer%20configuration%20session.timeout.ms%20was%20increased%20from%2010s%20to%2045s.%20See%20KIP%2D735%20for%20more%20details.



<!-- Uncomment any of the following that are required -->
[x] Documentation
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._
Please help validate if this is the right way to add this configuration to the files (i.e. as raw values and not placeholders referencing environment variables).

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
