### PR TITLE
DEVX-2704: CCloud observability demo should handle error on API key c…

### DIFF
--- a/ccloud-observability/start.sh
+++ b/ccloud-observability/start.sh
@@ -55,11 +55,16 @@ eval $CMD \
 echo -e "\n====== Create cloud api-key and set environment variables for the ccloud-exporter"
 echo "confluent api-key create --resource cloud --description \"confluent-cloud-metrics-api\" -o json"
 OUTPUT=$(confluent api-key create --resource cloud --description "confluent-cloud-metrics-api" -o json)
-rm .env 2>/dev/null
+status=$?
+if [[ $status != 0 ]]; then
+  echo "ERROR: Failed to create an API key.  Please troubleshoot and run again"
+  exit 1
+fi
 echo "$OUTPUT" | jq .
 export METRICS_API_KEY=$(echo "$OUTPUT" | jq -r ".key")
 export METRICS_API_SECRET=$(echo "$OUTPUT" | jq -r ".secret")
 export CLOUD_CLUSTER=$CLUSTER
+rm .env 2>/dev/null
 
 echo -e "\n====== Starting up Prometheus, Grafana, exporters, and clients"
 echo "docker-compose up -d"

--- a/ccloud-observability/stop.sh
+++ b/ccloud-observability/stop.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+if [ -z "$METRICS_API_KEY" ]; then
+  echo "ERROR: Must export parameter METRICS_API_KEY before running this script to destroy the API key created for metrics."
+  exit 1
+fi
+
 if [ -z "$1" ]; then
   echo "ERROR: Must supply argument that is the client configuration file created from './start.sh'. (Is it in stack-configs/ folder?) "
   exit 1
 else
+  confluent api-key delete $METRICS_API_KEY
   docker-compose down -v
   DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
   CONFIG_FILE=${DIR}/$1


### PR DESCRIPTION
…reation

### Description 

https://confluentinc.atlassian.net/browse/DEVX-2704

_What behavior does this PR change, and why?_

- Catch condition where API key limit has been reached
- Better cleanup in stop.sh

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
- [x] ccloud-observability
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
