### PR TITLE
DEVX-2714: update Confluent CLI syntax and checking ids

### DIFF
--- a/ccloud/beginner-cloud/start.sh
+++ b/ccloud/beginner-cloud/start.sh
@@ -346,9 +346,6 @@ confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --opera
 # - Delete the API key, service account, Kafka topics, Kafka cluster, environment, and the log files
 ##################################################
 
-echo "Premature exit"
-exit
-
 echo -e "\n# Cleanup: delete connector, service-account, topics, api-keys, kafka cluster, environment"
 CONNECTOR_ID=$(confluent connect list -o json | jq -r 'map(select(.name == "'"$CONNECTOR"'")) | .[].id')
 echo "confluent connect delete $CONNECTOR_ID"

--- a/ccloud/beginner-cloud/start.sh
+++ b/ccloud/beginner-cloud/start.sh
@@ -48,15 +48,15 @@ CLUSTER_NAME="${CLUSTER_NAME:-demo-kafka-cluster}"
 CLUSTER_CLOUD="${CLUSTER_CLOUD:-aws}"
 CLUSTER_REGION="${CLUSTER_REGION:-us-west-2}"
 echo -e "\n# Create a new Confluent Cloud cluster $CLUSTER_NAME"
-echo "confluent kafka cluster create $CLUSTER_NAME --cloud $CLUSTER_CLOUD --region $CLUSTER_REGION"
-OUTPUT=$(confluent kafka cluster create $CLUSTER_NAME --cloud $CLUSTER_CLOUD --region $CLUSTER_REGION)
+echo "confluent kafka cluster create $CLUSTER_NAME --cloud $CLUSTER_CLOUD --region $CLUSTER_REGION --output json"
+OUTPUT=$(confluent kafka cluster create $CLUSTER_NAME --cloud $CLUSTER_CLOUD --region $CLUSTER_REGION --output json)
 status=$?
 echo "$OUTPUT"
 if [[ $status != 0 ]]; then
   echo "ERROR: Failed to create Kafka cluster $CLUSTER_NAME. Please troubleshoot and run again"
   exit 1
 fi
-CLUSTER=$(echo "$OUTPUT" | grep '| Id' | awk '{print $4;}')
+CLUSTER=$(echo "$OUTPUT" | jq -r .id)
 
 echo -e "\n# Specify $CLUSTER as the active Kafka cluster"
 echo "confluent kafka cluster use $CLUSTER"
@@ -346,8 +346,11 @@ confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --opera
 # - Delete the API key, service account, Kafka topics, Kafka cluster, environment, and the log files
 ##################################################
 
+echo "Premature exit"
+exit
+
 echo -e "\n# Cleanup: delete connector, service-account, topics, api-keys, kafka cluster, environment"
-CONNECTOR_ID=$(confluent connect list | grep $CONNECTOR | tr -d '\*' | awk '{print $1;}')
+CONNECTOR_ID=$(confluent connect list -o json | jq -r 'map(select(.name == "'"$CONNECTOR"'")) | .[].id')
 echo "confluent connect delete $CONNECTOR_ID"
 confluent connect delete $CONNECTOR_ID 1>/dev/null
 echo "confluent iam service-account delete $SERVICE_ACCOUNT_ID"

--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -54,7 +54,7 @@ By default, the |ccloud| ksqlDB app is not created with ``ccloud-stack``, you ha
    confluent api-key create --service-account $SERVICE_ACCOUNT_ID --resource $RESOURCE -o json    // for schema-registry
 
    # By default, ccloud-stack does not enable Confluent Cloud ksqlDB, but if you explicitly enable it:
-   confluent ksql app create --cluster $CLUSTER --api-key "$KAFKA_API_KEY" --api-secret "$KAFKA_API_SECRET" -o json "$KSQLDB_NAME"
+   confluent ksql cluster create --cluster $CLUSTER --api-key "$KAFKA_API_KEY" --api-secret "$KAFKA_API_SECRET" -o json "$KSQLDB_NAME"
    confluent api-key create --service-account $SERVICE_ACCOUNT_ID --resource $RESOURCE -o json    // for ksqlDB REST API
 
    confluent kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation <....>    // permissive ACLs for all services

--- a/cloud-etl/README.md
+++ b/cloud-etl/README.md
@@ -1,7 +1,7 @@
 # Overview
 
 This demo showcases a cloud ETL solution leveraging all fully-managed services on [Confluent Cloud](https://confluent.cloud?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.cloud-etl)
-A source connector reads data from an AWS Kinesis stream or PostgreSQL database and written into Confluent Cloud, a Confluent KSQL application processes that data, and then a sink connector writes the output data into cloud storage in the provider of your choice.
+A source connector reads data from an AWS Kinesis stream or PostgreSQL database and written into Confluent Cloud, a Confluent ksqlDB application processes that data, and then a sink connector writes the output data into cloud storage in the provider of your choice.
 
 ![image](docs/images/topology.png)
 

--- a/cloud-etl/create_ksqldb_app.sh
+++ b/cloud-etl/create_ksqldb_app.sh
@@ -27,8 +27,8 @@ ccloud::validate_credentials_ksqldb "$KSQLDB_ENDPOINT" "$CONFIG_FILE" "$KSQLDB_B
 echo -e "Create output topics $KAFKA_TOPIC_NAME_OUT1 and $KAFKA_TOPIC_NAME_OUT2, and ACLs to allow the ksqlDB application to run\n"
 confluent kafka topic create $KAFKA_TOPIC_NAME_OUT1
 confluent kafka topic create $KAFKA_TOPIC_NAME_OUT2
-ksqlDBAppId=$(confluent ksql app list | grep "$KSQLDB_ENDPOINT" | awk '{print $1}')
-confluent ksql app configure-acls $ksqlDBAppId $KAFKA_TOPIC_NAME_IN $KAFKA_TOPIC_NAME_OUT1 $KAFKA_TOPIC_NAME_OUT2
+ksqlDBAppId=$(confluent ksql cluster list | grep "$KSQLDB_ENDPOINT" | awk '{print $1}')
+confluent ksql cluster configure-acls $ksqlDBAppId $KAFKA_TOPIC_NAME_IN $KAFKA_TOPIC_NAME_OUT1 $KAFKA_TOPIC_NAME_OUT2
 SERVICE_ACCOUNT_ID=$(ccloud:get_service_account_from_current_cluster_name)
 confluent kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic $KAFKA_TOPIC_NAME_OUT1
 confluent kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic $KAFKA_TOPIC_NAME_OUT2

--- a/cloud-etl/create_ksqldb_app.sh
+++ b/cloud-etl/create_ksqldb_app.sh
@@ -28,7 +28,6 @@ echo -e "Create output topics $KAFKA_TOPIC_NAME_OUT1 and $KAFKA_TOPIC_NAME_OUT2,
 confluent kafka topic create $KAFKA_TOPIC_NAME_OUT1
 confluent kafka topic create $KAFKA_TOPIC_NAME_OUT2
 ksqlDBAppId=$(confluent ksql cluster list -o json | jq -r 'map(select(.endpoint == "'"$KSQLDB_ENDPOINT"'")) | .[].id')
-
 confluent ksql cluster configure-acls $ksqlDBAppId $KAFKA_TOPIC_NAME_IN $KAFKA_TOPIC_NAME_OUT1 $KAFKA_TOPIC_NAME_OUT2
 SERVICE_ACCOUNT_ID=$(ccloud:get_service_account_from_current_cluster_name)
 confluent kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic $KAFKA_TOPIC_NAME_OUT1

--- a/cloud-etl/create_ksqldb_app.sh
+++ b/cloud-etl/create_ksqldb_app.sh
@@ -27,7 +27,8 @@ ccloud::validate_credentials_ksqldb "$KSQLDB_ENDPOINT" "$CONFIG_FILE" "$KSQLDB_B
 echo -e "Create output topics $KAFKA_TOPIC_NAME_OUT1 and $KAFKA_TOPIC_NAME_OUT2, and ACLs to allow the ksqlDB application to run\n"
 confluent kafka topic create $KAFKA_TOPIC_NAME_OUT1
 confluent kafka topic create $KAFKA_TOPIC_NAME_OUT2
-ksqlDBAppId=$(confluent ksql cluster list | grep "$KSQLDB_ENDPOINT" | awk '{print $1}')
+ksqlDBAppId=$(confluent ksql cluster list -o json | jq -r 'map(select(.endpoint == "'"$KSQLDB_ENDPOINT"'")) | .[].id')
+
 confluent ksql cluster configure-acls $ksqlDBAppId $KAFKA_TOPIC_NAME_IN $KAFKA_TOPIC_NAME_OUT1 $KAFKA_TOPIC_NAME_OUT2
 SERVICE_ACCOUNT_ID=$(ccloud:get_service_account_from_current_cluster_name)
 confluent kafka acl create --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic $KAFKA_TOPIC_NAME_OUT1

--- a/cp-quickstart/start-cloud.sh
+++ b/cp-quickstart/start-cloud.sh
@@ -93,13 +93,13 @@ retry $MAX_WAIT ccloud::validate_ccloud_ksqldb_endpoint_ready $KSQLDB_ENDPOINT |
 print_pass "Confluent Cloud KSQL is UP"
 
 printf "Obtaining the ksqlDB App Id\n"
-CMD="confluent ksql app list -o json | jq -r '.[].id'"
+CMD="confluent ksql cluster list -o json | jq -r '.[].id'"
 ksqlDBAppId=$(eval $CMD) \
   && print_code_pass -c "$CMD" -m "$ksqlDBAppId" \
   || exit_with_error -c $? -n "$NAME" -m "$CMD" -l $(($LINENO -3))
 
 printf "\nConfiguring ksqlDB ACLs\n"
-CMD="confluent ksql app configure-acls $ksqlDBAppId pageviews users"
+CMD="confluent ksql cluster configure-acls $ksqlDBAppId pageviews users"
 $CMD \
   && print_code_pass -c "$CMD" \
   || exit_with_error -c $? -n "$NAME" -m "$CMD" -l $(($LINENO -3))

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -675,7 +675,6 @@ function ccloud::wait_for_connector_up() {
 function ccloud::validate_ccloud_ksqldb_endpoint_ready() {
   KSQLDB_ENDPOINT=$1
 
-
   STATUS=$(confluent ksql cluster list -o json | jq -r 'map(select(.endpoint == "'"$KSQLDB_ENDPOINT"'")) | .[].status' | grep UP)
   if [[ "$STATUS" == "" ]]; then
     return 1


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2714

_What behavior does this PR change, and why?_

- update CLI change for ksql cluster
- Better to use json with jq over grep



### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
