### PR TITLE
DEVX-2716: check Docker image exists

### DIFF
--- a/multiregion/scripts/build_docker_images.sh
+++ b/multiregion/scripts/build_docker_images.sh
@@ -7,5 +7,8 @@ source ${DIR}/../.env
 echo
 echo "Build custom cp-zookeeper and cp-server images with 'tc' installed"
 for image in cp-zookeeper cp-server; do
-  docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg REPOSITORY=${REPOSITORY} --build-arg IMAGE=$image -t localbuild/${image}-tc:${CONFLUENT_DOCKER_TAG} -f ${DIR}/../Dockerfile ${DIR}/../.
+  IMAGENAME=localbuild/${image}-tc:${CONFLUENT_DOCKER_TAG}
+  docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg REPOSITORY=${REPOSITORY} --build-arg IMAGE=$image -t $IMAGENAME -f ${DIR}/../Dockerfile ${DIR}/../.
+  docker image inspect $IMAGENAME >/dev/null 2>&1 || \
+     { echo "Docker image $IMAGENAME not found. Please troubleshoot and rerun"; exit 1; }
 done

--- a/multiregion/scripts/start.sh
+++ b/multiregion/scripts/start.sh
@@ -5,7 +5,7 @@ source ${DIR}/../.env
 
 ${DIR}/stop.sh
 
-${DIR}/build_docker_images.sh
+${DIR}/build_docker_images.sh || exit 1
 
 export RUN_JMX=${RUN_JMX:-true}
 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2716

_What behavior does this PR change, and why?_

Check Docker image exists

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
- [x] multiregion
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->

