### PR TITLE
DEVX-2723: call confluent kafka cluster use before stack tear-down

### DIFF
--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -1057,6 +1057,7 @@ function ccloud::destroy_ccloud_stack() {
   echo "Destroying Confluent Cloud stack associated to service account id $SERVICE_ACCOUNT_ID"
 
   local cluster_id=$(confluent kafka cluster list -o json | jq -r 'map(select(.name == "'"$CLUSTER_NAME"'")) | .[].id')
+  confluent kafka cluster use $cluster_id 2>/dev/null
 
   # Delete associated ACLs
   ccloud::delete_acls_ccloud_stack $cluster_id $SERVICE_ACCOUNT_ID

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -1068,7 +1068,7 @@ function ccloud::destroy_ccloud_stack() {
   fi
 
   # Delete connectors associated to this Kafka cluster, otherwise cluster deletion fails
-  confluent connect list --cluster $cluster_id -o json | jq -r '.[].id' | xargs -I{} confluent connect delete {}
+  confluent connect list --cluster $cluster_id -o json | jq -r '.[].id' | xargs -I{} confluent connect delete --cluster $cluster_id {}
 
   echo "Deleting CLUSTER: $CLUSTER_NAME : $cluster_id"
   confluent kafka cluster delete $cluster_id &> "$REDIRECT_TO"

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -519,8 +519,7 @@ function ccloud::create_acls_all_resources_full_access() {
 }
 
 function ccloud::delete_acls_ccloud_stack() {
-  CLUSTER_ID=$1
-  SERVICE_ACCOUNT_ID=$2
+  SERVICE_ACCOUNT_ID=$1
   # Setting default QUIET=false to surface potential errors
   QUIET="${QUIET:-false}"
   [[ $QUIET == "true" ]] &&
@@ -529,23 +528,23 @@ function ccloud::delete_acls_ccloud_stack() {
 
   echo "Deleting ACLs for service account ID $SERVICE_ACCOUNT_ID"
 
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation CREATE --topic '*' &>"$REDIRECT_TO"
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation DELETE --topic '*' &>"$REDIRECT_TO"
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic '*' &>"$REDIRECT_TO"
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation READ --topic '*' &>"$REDIRECT_TO"
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --topic '*' &>"$REDIRECT_TO"
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE_CONFIGS --topic '*' &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --topic '*' &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation DELETE --topic '*' &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --topic '*' &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation READ --topic '*' &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --topic '*' &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE_CONFIGS --topic '*' &>"$REDIRECT_TO"
 
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation READ --consumer-group '*' &>"$REDIRECT_TO"
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation WRITE --consumer-group '*' &>"$REDIRECT_TO"
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation CREATE --consumer-group '*' &>"$REDIRECT_TO"
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --consumer-group '*' &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation READ --consumer-group '*' &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --consumer-group '*' &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation CREATE --consumer-group '*' &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --consumer-group '*' &>"$REDIRECT_TO"
 
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --transactional-id '*' &>"$REDIRECT_TO"
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation WRITE --transactional-id '*' &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --transactional-id '*' &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation WRITE --transactional-id '*' &>"$REDIRECT_TO"
 
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation IDEMPOTENT-WRITE --cluster-scope &>"$REDIRECT_TO"
-  confluent kafka acl delete --allow --cluster $CLUSTER_ID --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --cluster-scope &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation IDEMPOTENT-WRITE --cluster-scope &>"$REDIRECT_TO"
+  confluent kafka acl delete --allow --service-account $SERVICE_ACCOUNT_ID --operation DESCRIBE --cluster-scope &>"$REDIRECT_TO"
 
   return 0
 }
@@ -1060,7 +1059,7 @@ function ccloud::destroy_ccloud_stack() {
   confluent kafka cluster use $cluster_id 2>/dev/null
 
   # Delete associated ACLs
-  ccloud::delete_acls_ccloud_stack $cluster_id $SERVICE_ACCOUNT_ID
+  ccloud::delete_acls_ccloud_stack $SERVICE_ACCOUNT_ID
 
   ksqldb_id_found=$(confluent ksql cluster list -o json | jq -r 'map(select(.name == "'"$KSQLDB_NAME"'")) | .[].id')
   if [[ $ksqldb_id_found != "" ]]; then
@@ -1069,7 +1068,7 @@ function ccloud::destroy_ccloud_stack() {
   fi
 
   # Delete connectors associated to this Kafka cluster, otherwise cluster deletion fails
-  confluent connect list --cluster $cluster_id -o json | jq -r '.[].id' | xargs -I{} confluent connect delete --cluster $cluster_id {}
+  confluent connect list --cluster $cluster_id -o json | jq -r '.[].id' | xargs -I{} confluent connect delete {}
 
   echo "Deleting CLUSTER: $CLUSTER_NAME : $cluster_id"
   confluent kafka cluster delete $cluster_id &> "$REDIRECT_TO"


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2723

_What behavior does this PR change, and why?_

Specifies `--cluster` ID when running `confluent kafka acl delete` during tear-down, to prevent attempt to delete ACL from the context cluster, should a cluster different from the demo cluster be selected when `stop-cloud.sh` is run.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
 - [X] ccloud/ccloud-stack
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
