### PR TITLE
Update request-rate-limits.rst

### DIFF
--- a/ccloud-observability/docs/general-scenarios/request-rate-limits.rst
+++ b/ccloud-observability/docs/general-scenarios/request-rate-limits.rst
@@ -11,7 +11,7 @@ client is throttled, |ccloud| will delay the client's requests for ``produce-thr
 producers or ``fetch-throttle-time-avg`` (in ms) for consumers
 
 |ccloud| offers different cluster types, each with its own `usage limits <https://docs.confluent.io/cloud/current/clusters/cluster-types.html#basic-clusters>`__. This demo assumes
-you are running on a "basic" or "standard" cluster; both have a request limit of 1500 per second.
+you are running on a "basic" or "standard" cluster; both have a request limit of 15000 per second.
 
 #. Open `Grafana <localhost:3000>`__ and use the username ``admin`` and password ``password`` to login.
 

--- a/ccloud-observability/docs/general-scenarios/request-rate-limits.rst
+++ b/ccloud-observability/docs/general-scenarios/request-rate-limits.rst
@@ -10,8 +10,7 @@ are hit, requests may be refused and clients may be throttled to keep the cluste
 client is throttled, |ccloud| will delay the client's requests for ``produce-throttle-time-avg`` (in ms) for
 producers or ``fetch-throttle-time-avg`` (in ms) for consumers
 
-|ccloud| offers different cluster types, each with its own `usage limits <https://docs.confluent.io/cloud/current/clusters/cluster-types.html#basic-clusters>`__. This demo assumes
-you are running on a "basic" or "standard" cluster; both have a request limit of 15000 per second.
+|ccloud| offers different cluster types, each with its own `usage limits <https://docs.confluent.io/cloud/current/clusters/cluster-types.html#basic-clusters>`__. 
 
 #. Open `Grafana <localhost:3000>`__ and use the username ``admin`` and password ``password`` to login.
 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DOCS-9848

_What behavior does this PR change, and why?_
It aligns the documented request limit with the limit in the cloud docs


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
