### PR TITLE
DEVX-2726: Paywall removal

### DIFF
--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -319,21 +319,6 @@ If you don't want to create and destroy a ``ccloud-stack`` using the provided ba
 
       ccloud::destroy_ccloud_stack $SERVICE_ACCOUNT_ID
 
-
-Running with Marketplace
-------------------------
-
-By default, ``ccloud-stack`` checks your payment method to verify that there is a credit card on file.
-However, when using |ccloud| on a cloud provider's Marketplace for a self-serve Pay-as-you-go account on Azure, GCP or AWS, your payment method is directly linked to your cloud provider and not necessarily with a credit card. 
-In these cases, therefore, ``ccloud-stack`` will fail, and you need a workaround.
-
-When you create a new stack, set the parameter ``CHECK_CREDIT_CARD=false``, as shown in the example:
-
-.. code-block:: bash
-
-   CHECK_CREDIT_CARD=false ./ccloud_stack_create.sh
-
-
 ====================
 Additional Resources
 ====================

--- a/utils/ccloud_library.sh
+++ b/utils/ccloud_library.sh
@@ -908,7 +908,7 @@ function ccloud::create_ccloud_stack() {
   REPLICATION_FACTOR=${REPLICATION_FACTOR:-3}
   enable_ksqldb=${1:-false}
   EXAMPLE=${EXAMPLE:-ccloud-stack-function}
-  CHECK_CREDIT_CARD="${CHECK_CREDIT_CARD:-true}"
+  CHECK_CREDIT_CARD="${CHECK_CREDIT_CARD:-false}"
 
   # Check if credit card is on file, which is required for cluster creation
   if $CHECK_CREDIT_CARD && [[ $(confluent admin payment describe) =~ "not found" ]]; then


### PR DESCRIPTION
### Description 

DEVX-2726

Makes the default behavior for ccloud-stack to _not_ require a credit card on file before proceeding.

### Author Validation
Created a new account using Google social login and did not put a credit card on file.  Then I used `ccloud-stack` to create new environments, both with ksqlDB and without sucessfully.

- [X] ccloud/ccloud-stack

### Reviewer Tasks

Review documentation changes around marketplace and verify that ccloud-stack runs properly on accounts without credit cards on file.

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
