### PR TITLE
DEVX-2738: update multiregion demo

### DIFF
--- a/multiregion/Dockerfile
+++ b/multiregion/Dockerfile
@@ -7,7 +7,10 @@ FROM $REPOSITORY/$IMAGE:$CP_VERSION
 USER root
 RUN yum install -y \
      libmnl \
+     findutils \
      which
 RUN wget http://vault.centos.org/8.1.1911/BaseOS/x86_64/os/Packages/iproute-tc-4.18.0-15.el8.x86_64.rpm
 RUN rpm -i --nodeps --nosignature http://vault.centos.org/8.1.1911/BaseOS/x86_64/os/Packages/iproute-tc-4.18.0-15.el8.x86_64.rpm
+RUN wget http://vault.centos.org/8.1.1911/BaseOS/x86_64/os/Packages/iptables-libs-1.8.2-16.el8.x86_64.rpm
+RUN rpm -i --nodeps --nosignature http://vault.centos.org/8.1.1911/BaseOS/x86_64/os/Packages/iptables-libs-1.8.2-16.el8.x86_64.rpm
 USER appuser

--- a/multiregion/scripts/build_docker_images.sh
+++ b/multiregion/scripts/build_docker_images.sh
@@ -8,7 +8,7 @@ echo
 echo "Build custom cp-zookeeper and cp-server images with 'tc' installed"
 for image in cp-zookeeper cp-server; do
   IMAGENAME=localbuild/${image}-tc:${CONFLUENT_DOCKER_TAG}
-  docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg REPOSITORY=${REPOSITORY} --build-arg IMAGE=$image -t $IMAGENAME -f ${DIR}/../Dockerfile ${DIR}/../.
+  docker build --no-cache --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg REPOSITORY=${REPOSITORY} --build-arg IMAGE=$image -t $IMAGENAME -f ${DIR}/../Dockerfile ${DIR}/../.
   docker image inspect $IMAGENAME >/dev/null 2>&1 || \
      { echo "Docker image $IMAGENAME not found. Please troubleshoot and rerun"; exit 1; }
 done

--- a/multiregion/scripts/validate_connectivity.sh
+++ b/multiregion/scripts/validate_connectivity.sh
@@ -3,7 +3,7 @@
 echo -e "\n\n==> Validate containers can ping each other\n"
 
 for host in broker-west-1 broker-west-2 zookeeper-west zookeeper-central zookeeper-east broker-east-3 broker-east-4; do
-  OUTPUT=$(docker-compose exec broker-west-1 ping $host -c 1)
+  OUTPUT=$(docker-compose exec -T broker-west-1 ping $host -c 1)
   if [[ "$OUTPUT" =~ "1 received" ]]; then
     echo "broker-west-1 can ping $host"
   else


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2738

* CP 7.1.0
* Updated docker compose

_What behavior does this PR change, and why?_

Makes the demo actually work :) 

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
- [ ] multiregion
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
