### PR TITLE
Removed deprecation warning on consumer.poll(100)

### DIFF
--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerAvroExample.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -61,7 +62,7 @@ public class ConsumerAvroExample {
 
     try {
       while (true) {
-        ConsumerRecords<String, DataRecordAvro> records = consumer.poll(100);
+        ConsumerRecords<String, DataRecordAvro> records = consumer.poll(Duration.ofMillis(100));
         for (ConsumerRecord<String, DataRecordAvro> record : records) {
           String key = record.key();
           DataRecordAvro value = record.value();

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -62,7 +63,7 @@ public class ConsumerExample {
 
     try {
       while (true) {
-        ConsumerRecords<String, DataRecord> records = consumer.poll(100);
+        ConsumerRecords<String, DataRecord> records = consumer.poll(Duration.ofMillis(100));
         for (ConsumerRecord<String, DataRecord> record : records) {
           String key = record.key();
           DataRecord value = record.value();

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Properties;
+import java.time.Duration;
 
 public class ConsumerExample {
 
@@ -62,7 +63,7 @@ public class ConsumerExample {
 
     try {
       while (true) {
-        ConsumerRecords<String, DataRecord> records = consumer.poll(100);
+        ConsumerRecords<String, DataRecord> records = consumer.poll(Duration.ofMillis(100));
         for (ConsumerRecord<String, DataRecord> record : records) {
           String key = record.key();
           DataRecord value = record.value();

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
@@ -31,7 +31,6 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Properties;
-import java.time.Duration;
 
 public class ConsumerExample {
 

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExamplePageviews.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExamplePageviews.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -60,7 +61,7 @@ public class ConsumerExamplePageviews {
 
     try {
       while (true) {
-        ConsumerRecords<String, PageviewRecord> records = consumer.poll(100);
+        ConsumerRecords<String, PageviewRecord> records = consumer.poll(Duration.ofMillis(100));
         for (ConsumerRecord<String, PageviewRecord> record : records) {
           String key = record.key();
           PageviewRecord value = record.value();


### PR DESCRIPTION
Changed poll(interval) to a time.Duration  type parameter to remove deprecation warning.

### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

_What behavior does this PR change, and why?_
No behaviour change, only removes a code warning.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
- [ ] clients/cloud 
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
