### PR TITLE
Fixed Exception caused by Empty Lines in config file.

### DIFF
--- a/clients/cloud/csharp/Program.cs
+++ b/clients/cloud/csharp/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Confluent Inc.
+// Copyright 2020 Confluent Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,8 +32,12 @@ namespace CCloud
         {
             try
             {
+                var jbConfigs = (
+                    await File.ReadAllLinesAsync(configPath));
+                var jbFilterConfig = jbConfigs.Where(line => !line.StartsWith("#"));
+                
                 var cloudConfig = (await File.ReadAllLinesAsync(configPath))
-                    .Where(line => !line.StartsWith("#"))
+                    .Where(line => !line.StartsWith("#") && !line.Length.Equals(0))
                     .ToDictionary(
                         line => line.Substring(0, line.IndexOf('=')),
                         line => line.Substring(line.IndexOf('=') + 1));

--- a/clients/cloud/csharp/Program.cs
+++ b/clients/cloud/csharp/Program.cs
@@ -32,10 +32,6 @@ namespace CCloud
         {
             try
             {
-                var jbConfigs = (
-                    await File.ReadAllLinesAsync(configPath));
-                var jbFilterConfig = jbConfigs.Where(line => !line.StartsWith("#"));
-                
                 var cloudConfig = (await File.ReadAllLinesAsync(configPath))
                     .Where(line => !line.StartsWith("#") && !line.Length.Equals(0))
                     .ToDictionary(


### PR DESCRIPTION
### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

_What behavior does this PR change, and why?_

The config file provided in the C# setup contains empty lines with a Length of 0. This was causing Exceptions when trying to read the config file in the LoadConfig method because the empty lines were not being filtered out by the Where clause. By filtering out empty lines with a length of 0, the LoadConfig method completes without exceptions and the application completes as expected.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._
Verified using .NET 6.0. Needs to be tested against earlier versions of .NET to prove backwards compatibility.

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
[ ] clients/cloud
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._
Needs to be tested against earlier versions of .NET to prove backwards compatibility.

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
[ ] clients/cloud
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
