### PR TITLE
Avoid override file being pulled in

### DIFF
--- a/cp-quickstart/start-docker-kraft.sh
+++ b/cp-quickstart/start-docker-kraft.sh
@@ -7,6 +7,7 @@ wget -O docker-compose.yml https://raw.githubusercontent.com/confluentinc/cp-all
 wget -O update_run.sh https://raw.githubusercontent.com/confluentinc/cp-all-in-one/${CONFLUENT_RELEASE_TAG_OR_BRANCH}/cp-all-in-one-kraft/update_run.sh
 chmod 744 update_run.sh
 
+export COMPOSE_FILE=docker-compose.yml
 ./stop-docker.sh
 
 docker-compose up -d


### PR DESCRIPTION
### Description 

See #1113 for details.

The way this PR addresses the problem is by being explicit about specifying the `docker-compose.yml` file, and that file only.  It avoids pulling in the override file (effectively ignores it), but it can't be deleted because it is used by other quickstarts in this folder.  Those use ksqlDB, whereas the KRaft one currently does not.

Note: this is a temporary quick fix to suppress the error.  The longer term fix is https://github.com/confluentinc/cp-all-in-one/issues/101 which is to get ksqlDB into the cp-all-in-one-kraft Docker Compose at https://github.com/confluentinc/cp-all-in-one/blob/7.2.1-post/cp-all-in-one-kraft/docker-compose.yml