### PR TITLE
Replacing confluent-log4j with reload4j

### DIFF
--- a/clients/cloud/java/pom.xml
+++ b/clients/cloud/java/pom.xml
@@ -99,10 +99,10 @@
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j-api.version}</version>
         </dependency>
-        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+        <!-- Backport reload4j to replace confluent-log4j -->
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
### Description
The original removal of log4j:log4j is done because it was introduced through org.slf4j:slf4j-log4j12 Tracing vulnerable packages in CP (docker images to git repository) | Log4j-update . This was done by excluding log4j:log4j from it and brining confluent-log4j. Now we have a fixed version of org.slf4j:slf4j-log4j12  which is org.slf4j:slf4j-reload4j. It is based on a fixed version of reload4j already. The only change we need to make is to migrate from org.slf4j:slf4j-log4j12 to  org.slf4j:slf4j-reload4j. 
 
https://confluentinc.atlassian.net/wiki/spaces/~913794610/pages/2772764716/Backport+reload4j+to+replace+Confluent-log4j

_What behavior does this PR change, and why?_
This PR removes the confluent-log4j from pom.xml and replaces it with reload4j.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

