### PR TITLE
DEVX-2757: cluster name fix in multi-DC example

### DIFF
--- a/multi-datacenter/start.sh
+++ b/multi-datacenter/start.sh
@@ -52,6 +52,13 @@ MAX_WAIT=300
 echo "Waiting up to $MAX_WAIT seconds for Confluent Control Center to start"
 retry $MAX_WAIT check_control_center_up control-center || exit 1
 
+# Give dc2 cluster a friendlier name. This is a temporary workaround for default cluster naming bug introduced in
+# Confluent Platform 7.3 (MMA-11616).
+CLUSTER_ID=`curl http://localhost:9021/2.0/clusters/kafka | jq -r '.[] | select (.displayName=="controlcenter.cluster") | .clusterId'`
+if [ ! -z "$CLUSTER_ID" ]; then
+  curl http://localhost:9021/2.0/clusters/kafka/$CLUSTER_ID  -X PATCH -H 'Content-Type:application/merge-patch+json' -d '{ "displayName":"dc2" }'
+fi
+
 echo -e "\n\n\n******************************************************************"
 echo -e "DONE! Connect to Confluent Control Center at http://localhost:9021"
 echo -e "******************************************************************\n"


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2757

Show friendlier cluster name in multi-datacenter example. This is a temp fix for cluster naming regression introduced in CP 7.3

### Author Validation

Manually ran multi-datacenter example against 7.3.x-latest images

### Reviewer Tasks

Code review
Optionally run example

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
