### PR TITLE
DEVX-2763: Update the security.protocol property to use "SSL" instead of "ssl"

### DIFF
--- a/replicator-security/scripts/security/destKafkaClient_ssl.properties
+++ b/replicator-security/scripts/security/destKafkaClient_ssl.properties
@@ -3,4 +3,4 @@ ssl.truststore.password=confluent
 ssl.keystore.location=/etc/kafka/secrets/kafka.destKafkaClient.keystore.jks
 ssl.keystore.password=confluent 
 ssl.key.password=confluent 
-security.protocol=ssl
+security.protocol=SSL

--- a/replicator-security/scripts/security/srcKafkaClient_ssl.properties
+++ b/replicator-security/scripts/security/srcKafkaClient_ssl.properties
@@ -3,4 +3,4 @@ ssl.truststore.password=confluent
 ssl.keystore.location=/etc/kafka/secrets/kafka.srcKafkaClient.keystore.jks
 ssl.keystore.password=confluent
 ssl.key.password=confluent
-security.protocol=ssl
+security.protocol=SSL


### PR DESCRIPTION
### Description 

Fix for https://confluentinc.atlassian.net/browse/DEVX-2763

_What behavior does this PR change, and why?_

This PR updates the `destKafkaClient_ssl.properties` and `srcKafkaClient_ssl.properties` files in the `/scripts/security` directory to use `SSL` for the `security.protocol` config.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
