### PR TITLE
DEVX-2766: CP community quickstart bugfix

### DIFF
--- a/cp-quickstart/start-docker-community.sh
+++ b/cp-quickstart/start-docker-community.sh
@@ -17,9 +17,9 @@ sleep 2 # give connect an exta moment to fully mature
 echo "connect has started!"
 
 # Configure datagen connectors
-curl -sS -o connector_pageviews_cos.config  https://github.com/confluentinc/kafka-connect-datagen/raw/master/config/connector_pageviews_cos.config || exit 1
+curl -sS -o connector_pageviews_cos.config https://raw.githubusercontent.com/confluentinc/kafka-connect-datagen/master/config/connector_pageviews_cos.config || exit 1
 curl -X POST -H "Content-Type: application/json" --data @connector_pageviews_cos.config http://localhost:8083/connectors
-curl -sS -o connector_users_cos.config https://github.com/confluentinc/kafka-connect-datagen/raw/master/config/connector_users_cos.config || exit 1
+curl -sS -o connector_users_cos.config https://raw.githubusercontent.com/confluentinc/kafka-connect-datagen/master/config/connector_users_cos.config || exit 1
 curl -X POST -H "Content-Type: application/json" --data @connector_users_cos.config http://localhost:8083/connectors
 
 # Verify topics exist


### PR DESCRIPTION
Connector config URLs now redirect to raw.githubusercontent.com, so we pull directly from this domain.

### Description 

https://confluentinc.atlassian.net/browse/DEVX-2766

_What behavior does this PR change, and why?_

The community quickstart fails with error:
```
Waiting up to 180 seconds for Connect to start
.....
connect has started!
{"error_code":500,"message":null}{"error_code":500,"message":null}
Waiting up to 30 seconds for topics (pageviews, users) to exist
[2022-09-19 21:49:23,146] ERROR java.lang.IllegalArgumentException: Topic 'pageviews' does not exist as expected
	at kafka.admin.TopicCommand$.kafka$admin$TopicCommand$$ensureTopicExists(TopicCommand.scala:401)
	at kafka.admin.TopicCommand$TopicService.describeTopic(TopicCommand.scala:313)
	at kafka.admin.TopicCommand$.main(TopicCommand.scala:61)
	at kafka.admin.TopicCommand.main(TopicCommand.scala)
 (kafka.admin.TopicCommand$)
```
This is due to connector config URLs redirecting, and by default curl won't follow the redirects

### Author Validation

Manually tested
<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
- [x] cp-quickstart
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
