### PR TITLE
CC-17419: fix missing log4j / slf4j dependency error in connect-streams-pipeline example

### DIFF
--- a/connect-streams-pipeline/pom.xml
+++ b/connect-streams-pipeline/pom.xml
@@ -26,6 +26,8 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <properties>
     <java.version>8</java.version>
     <gson.version>2.2.4</gson.version>
+    <reload4j.version>1.2.19</reload4j.version>
+    <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
@@ -66,13 +68,14 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       <version>${gson.version}</version>
     </dependency>
     <dependency>
-       <groupId>org.slf4j</groupId>
-       <artifactId>slf4j-log4j12</artifactId>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>${reload4j.version}</version>
     </dependency>
-   <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
     <dependency>
-       <groupId>io.confluent</groupId>
-       <artifactId>confluent-log4j</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-reload4j</artifactId>
+      <version>${slf4j-reload4j.version}</version>
     </dependency>
   </dependencies>
 

--- a/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/consoleproducer/StreamsIngest.java
+++ b/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/consoleproducer/StreamsIngest.java
@@ -18,7 +18,6 @@ package io.confluent.examples.connectandstreams.consoleproducer;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -26,9 +25,9 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Printed;
-import org.apache.kafka.streams.state.KeyValueStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
 
@@ -36,10 +35,9 @@ import io.confluent.examples.connectandstreams.avro.Location;
 
 public class StreamsIngest {
 
-  static final String INPUT_TOPIC = "consoleproducer-locations";
-  static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
-  static final String KEYS_STORE = "consoleproducer-count-keys";
-  static final String SALES_STORE = "consoleproducer-aggregate-sales";
+  private static final Logger LOGGER = LoggerFactory.getLogger(StreamsIngest.class);
+  private static final String INPUT_TOPIC = "consoleproducer-locations";
+  private static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
 
   public static void main(final String[] args) {
 
@@ -51,7 +49,7 @@ public class StreamsIngest {
 
     final String bootstrapServers = args.length > 0 ? args[0] : DEFAULT_BOOTSTRAP_SERVERS;
 
-    System.out.println("Connecting to Kafka cluster via bootstrap servers " + bootstrapServers);
+    LOGGER.info("Connecting to Kafka cluster via bootstrap servers " + bootstrapServers);
 
     final StreamsBuilder builder = new StreamsBuilder();
 

--- a/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/javaproducer/Driver.java
+++ b/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/javaproducer/Driver.java
@@ -20,6 +20,8 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.LongSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -34,6 +36,7 @@ import io.confluent.kafka.serializers.KafkaAvroSerializer;
 
 public class Driver {
 
+  static final Logger LOGGER = LoggerFactory.getLogger(Driver.class);
   static final String INPUT_TOPIC = "javaproducer-locations";
   static final String DEFAULT_TABLE_LOCATIONS = "/usr/local/lib/table.locations";
   static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
@@ -54,9 +57,9 @@ public class Driver {
     final String schemaRegistryUrl = args.length > 1 ? args[1] : DEFAULT_SCHEMA_REGISTRY_URL;
     final String tableLocations = args.length > 2 ? args[2] : DEFAULT_TABLE_LOCATIONS;
 
-    System.out.println("Connecting to Kafka cluster via bootstrap servers " + bootstrapServers);
-    System.out.println("Connecting to Confluent schema registry at " + schemaRegistryUrl);
-    System.out.println("Reading locations table from file " + tableLocations);
+    LOGGER.info("Connecting to Kafka cluster via bootstrap servers " + bootstrapServers);
+    LOGGER.info("Connecting to Confluent schema registry at " + schemaRegistryUrl);
+    LOGGER.info("Reading locations table from file " + tableLocations);
 
     final List<Location> locationsList = new ArrayList<>();
     try (final BufferedReader br = new BufferedReader(new FileReader(tableLocations))) {
@@ -78,10 +81,8 @@ public class Driver {
         new KafkaProducer<Long, Location>(props);
 
     locationsList.forEach(t -> {
-      System.out.println("Writing location information for '" + t.getId()
-                         + "' to input topic " + INPUT_TOPIC);
-      final ProducerRecord<Long, Location> record = new ProducerRecord<Long, Location>(INPUT_TOPIC,
-                                                                                       t.getId(), t);
+      LOGGER.info("Writing location information for '" + t.getId() + "' to input topic " + INPUT_TOPIC);
+      final ProducerRecord<Long, Location> record = new ProducerRecord<>(INPUT_TOPIC, t.getId(), t);
       locationProducer.send(record);
     });
 
@@ -90,4 +91,3 @@ public class Driver {
   }
 
 }
-

--- a/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/javaproducer/StreamsIngest.java
+++ b/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/javaproducer/StreamsIngest.java
@@ -19,17 +19,15 @@ package io.confluent.examples.connectandstreams.javaproducer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Printed;
-import org.apache.kafka.streams.state.KeyValueStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.Properties;
@@ -40,11 +38,10 @@ import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
 
 public class StreamsIngest {
 
-  static final String INPUT_TOPIC = "javaproducer-locations";
-  static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
-  static final String DEFAULT_SCHEMA_REGISTRY_URL = "http://localhost:8081";
-  static final String KEYS_STORE = "javaproducer-count-keys";
-  static final String SALES_STORE = "javaproducer-aggregate-sales";
+  private static final Logger LOGGER = LoggerFactory.getLogger(StreamsIngest.class);
+  private static final String INPUT_TOPIC = "javaproducer-locations";
+  private static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
+  private static final String DEFAULT_SCHEMA_REGISTRY_URL = "http://localhost:8081";
 
   public static void main(final String[] args) {
 
@@ -59,8 +56,8 @@ public class StreamsIngest {
     final String bootstrapServers = args.length > 0 ? args[0] : DEFAULT_BOOTSTRAP_SERVERS;
     final String SCHEMA_REGISTRY_URL = args.length > 1 ? args[1] : DEFAULT_SCHEMA_REGISTRY_URL;
 
-    System.out.println("Connecting to Kafka cluster via bootstrap servers " + bootstrapServers);
-    System.out.println("Connecting to Confluent schema registry at " + SCHEMA_REGISTRY_URL);
+    LOGGER.info("Connecting to Kafka cluster via bootstrap servers " + bootstrapServers);
+    LOGGER.info("Connecting to Confluent schema registry at " + SCHEMA_REGISTRY_URL);
 
     final StreamsBuilder builder = new StreamsBuilder();
 

--- a/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/jdbcgenericavro/StreamsIngest.java
+++ b/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/jdbcgenericavro/StreamsIngest.java
@@ -19,16 +19,15 @@ package io.confluent.examples.connectandstreams.jdbcgenericavro;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Printed;
-import org.apache.kafka.streams.state.KeyValueStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
 
@@ -38,10 +37,10 @@ import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
 
 public class StreamsIngest {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(StreamsIngest.class);
   private static final String INPUT_TOPIC = "jdbcgenericavro-locations";
   private static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
   private static final String DEFAULT_SCHEMA_REGISTRY_URL = "http://localhost:8081";
-  private static final String KEYS_STORE = "jdbcgenericavro-count-keys";
 
   public static void main(final String[] args) {
 
@@ -56,8 +55,8 @@ public class StreamsIngest {
     final String bootstrapServers = args.length > 0 ? args[0] : DEFAULT_BOOTSTRAP_SERVERS;
     final String SCHEMA_REGISTRY_URL = args.length > 1 ? args[1] : DEFAULT_SCHEMA_REGISTRY_URL;
 
-    System.out.println("Connecting to Kafka cluster via bootstrap servers " + bootstrapServers);
-    System.out.println("Connecting to Confluent schema registry at " + SCHEMA_REGISTRY_URL);
+    LOGGER.info("Connecting to Kafka cluster via bootstrap servers " + bootstrapServers);
+    LOGGER.info("Connecting to Confluent schema registry at " + SCHEMA_REGISTRY_URL);
 
     final StreamsBuilder builder = new StreamsBuilder();
 

--- a/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/jdbcjson/StreamsIngest.java
+++ b/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/jdbcjson/StreamsIngest.java
@@ -19,17 +19,15 @@ package io.confluent.examples.connectandstreams.jdbcjson;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Printed;
-import org.apache.kafka.streams.state.KeyValueStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
 
@@ -39,10 +37,9 @@ import io.confluent.examples.connectandstreams.jdbcjson.serde.JsonSerializer;
 
 public class StreamsIngest {
 
-  static final String INPUT_TOPIC = "jdbcjson-locations";
-  static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
-  static final String KEYS_STORE = "jdbcjson-count-keys";
-  static final String SALES_STORE = "jdbcjson-aggregate-sales";
+  private static final Logger LOGGER = LoggerFactory.getLogger(StreamsIngest.class);
+  private static final String INPUT_TOPIC = "jdbcjson-locations";
+  private static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
 
   public static void main(final String[] args) {
 
@@ -54,7 +51,7 @@ public class StreamsIngest {
 
     final String bootstrapServers = args.length > 0 ? args[0] : DEFAULT_BOOTSTRAP_SERVERS;
 
-    System.out.println("Connecting to Kafka cluster via bootstrap servers " + bootstrapServers);
+    LOGGER.info("Connecting to Kafka cluster via bootstrap servers " + bootstrapServers);
 
     final StreamsBuilder builder = new StreamsBuilder();
 

--- a/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/jdbcspecificavro/StreamsIngest.java
+++ b/connect-streams-pipeline/src/main/java/io/confluent/examples/connectandstreams/jdbcspecificavro/StreamsIngest.java
@@ -19,7 +19,6 @@ package io.confluent.examples.connectandstreams.jdbcspecificavro;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -27,9 +26,9 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Printed;
-import org.apache.kafka.streams.state.KeyValueStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.Properties;
@@ -40,10 +39,10 @@ import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
 
 public class StreamsIngest {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(StreamsIngest.class);
   private static final String INPUT_TOPIC = "jdbcspecificavro-locations";
   private static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
   private static final String DEFAULT_SCHEMA_REGISTRY_URL = "http://localhost:8081";
-  private static final String KEYS_STORE = "jdbcspecificavro-count-keys";
 
   public static void main(final String[] args) {
 
@@ -58,8 +57,8 @@ public class StreamsIngest {
     final String bootstrapServers = args.length > 0 ? args[0] : DEFAULT_BOOTSTRAP_SERVERS;
     final String SCHEMA_REGISTRY_URL = args.length > 1 ? args[1] : DEFAULT_SCHEMA_REGISTRY_URL;
 
-    System.out.println("Connecting to Kafka cluster via bootstrap servers " + bootstrapServers);
-    System.out.println("Connecting to Confluent schema registry at " + SCHEMA_REGISTRY_URL);
+    LOGGER.info("Connecting to Kafka cluster via bootstrap servers " + bootstrapServers);
+    LOGGER.info("Connecting to Confluent schema registry at " + SCHEMA_REGISTRY_URL);
 
     final StreamsBuilder builder = new StreamsBuilder();
 

--- a/connect-streams-pipeline/src/main/resources/log4j.properties
+++ b/connect-streams-pipeline/src/main/resources/log4j.properties
@@ -6,3 +6,5 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.err
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+log4j.logger.io.confluent.examples=INFO


### PR DESCRIPTION
* switch to reload4j to address log4j CVE
* use slf4j instead of System.out.println
* remove some unused imports / variables

### Description 

https://confluentinc.atlassian.net/browse/CC-17419

This PR addresses the missing dependency version error reported in CC-17419

### Author Validation

Manually validated:
<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
 - [x] connect-streams-pipeline
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

Code review and optionally run through example:

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
 - [ ] connect-streams-pipeline
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
