### PR TITLE
ccloud-observability: Fix JMX client metrics for Docker Compose 2.x

### DIFF
--- a/ccloud-observability/docker-compose.yml
+++ b/ccloud-observability/docker-compose.yml
@@ -48,6 +48,9 @@ services:
   prometheus:
     image: prom/prometheus:v2.24.1
     container_name: prometheus
+    links:
+      - producer
+      - consumer
     ports:
       - 9090:9090
     volumes:

--- a/ccloud-observability/monitoring_configs/prometheus/prometheus.yml
+++ b/ccloud-observability/monitoring_configs/prometheus/prometheus.yml
@@ -31,13 +31,13 @@ scrape_configs:
 
   - job_name: "producer"
     static_configs:
-      - targets: ["ccloud-observability_producer_1:1234"]
+      - targets: ["producer:1234"]
         labels:
           env: "dev"
 
   - job_name: "consumer"
     static_configs:
-      - targets: ["ccloud-observability_consumer_1:1234"]
+      - targets: ["consumer:1234"]
         labels:
           env: 'dev'
 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2769

_What behavior does this PR change, and why?_

JMX client metrics are broken when running with Docker Compose 2.x, due to problems with the expect container/host name (1.x uses underscores, 2.x uses hyphens).  Solution uses container link aliases to make the hostname predictable for the Prometheus scrape config.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
- [X] ccloud-observability
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

Looking for one reviewer with Docker Compose 1.x and one with Docker Compose 2.x to test works with both version.  Author has 2.x, which highlighted the problem.

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
- [X] ccloud-observability
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] kubernetes/gke-base -->
<!-- - [ ] kubernetes/replicator-gke-cc -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
