### PR TITLE
Make CC Java Client Tutorial Commands Runnable

### DIFF
--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerAvroExample.java
@@ -15,21 +15,14 @@
  */
 package io.confluent.examples.clients.cloud;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+import org.apache.kafka.clients.consumer.*;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Properties;
+
+import static io.confluent.examples.clients.cloud.Util.loadConfig;
 
 public class ConsumerAvroExample {
 
@@ -73,17 +66,4 @@ public class ConsumerAvroExample {
       consumer.close();
     }
   }
-
-
-  public static Properties loadConfig(String configFile) throws IOException {
-    if (!Files.exists(Paths.get(configFile))) {
-      throw new IOException(configFile + " not found.");
-    }
-    final Properties cfg = new Properties();
-    try (InputStream inputStream = new FileInputStream(configFile)) {
-      cfg.load(inputStream);
-    }
-    return cfg;
-  }
-
 }

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerAvroExample.java
@@ -17,7 +17,11 @@ package io.confluent.examples.clients.cloud;
 
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
-import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 
 import java.util.Arrays;
 import java.util.Properties;

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
@@ -17,7 +17,11 @@ package io.confluent.examples.clients.cloud;
 
 import io.confluent.examples.clients.cloud.model.DataRecord;
 import io.confluent.kafka.serializers.KafkaJsonDeserializerConfig;
-import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 
 import java.util.Arrays;
 import java.util.Properties;

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
@@ -15,21 +15,14 @@
  */
 package io.confluent.examples.clients.cloud;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import io.confluent.examples.clients.cloud.model.DataRecord;
 import io.confluent.kafka.serializers.KafkaJsonDeserializerConfig;
+import org.apache.kafka.clients.consumer.*;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Properties;
+
+import static io.confluent.examples.clients.cloud.Util.loadConfig;
 
 public class ConsumerExample {
 
@@ -74,17 +67,4 @@ public class ConsumerExample {
       consumer.close();
     }
   }
-
-
-  public static Properties loadConfig(String configFile) throws IOException {
-    if (!Files.exists(Paths.get(configFile))) {
-      throw new IOException(configFile + " not found.");
-    }
-    final Properties cfg = new Properties();
-    try (InputStream inputStream = new FileInputStream(configFile)) {
-      cfg.load(inputStream);
-    }
-    return cfg;
-  }
-
 }

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExamplePageviews.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExamplePageviews.java
@@ -17,7 +17,11 @@ package io.confluent.examples.clients.cloud;
 
 import io.confluent.examples.clients.cloud.model.PageviewRecord;
 import io.confluent.kafka.serializers.KafkaJsonDeserializerConfig;
-import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 
 import java.util.Arrays;
 import java.util.Properties;

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExamplePageviews.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExamplePageviews.java
@@ -15,21 +15,14 @@
  */
 package io.confluent.examples.clients.cloud;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import io.confluent.examples.clients.cloud.model.PageviewRecord;
 import io.confluent.kafka.serializers.KafkaJsonDeserializerConfig;
+import org.apache.kafka.clients.consumer.*;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Properties;
+
+import static io.confluent.examples.clients.cloud.Util.loadConfig;
 
 public class ConsumerExamplePageviews {
 
@@ -71,17 +64,4 @@ public class ConsumerExamplePageviews {
       consumer.close();
     }
   }
-
-
-  public static Properties loadConfig(String configFile) throws IOException {
-    if (!Files.exists(Paths.get(configFile))) {
-      throw new IOException(configFile + " not found.");
-    }
-    final Properties cfg = new Properties();
-    try (InputStream inputStream = new FileInputStream(configFile)) {
-      cfg.load(inputStream);
-    }
-    return cfg;
-  }
-
 }

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerAvroExample.java
@@ -15,30 +15,19 @@
  */
 package io.confluent.examples.clients.cloud;
 
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.clients.producer.Callback;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.Producer;
-
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
-
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
+import org.apache.kafka.clients.producer.*;
 import org.apache.kafka.common.errors.TopicExistsException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Properties;
+
+import java.io.IOException;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import static io.confluent.examples.clients.cloud.Util.loadConfig;
 
 public class ProducerAvroExample {
 
@@ -104,16 +93,4 @@ public class ProducerAvroExample {
 
     producer.close();
   }
-
-  public static Properties loadConfig(final String configFile) throws IOException {
-    if (!Files.exists(Paths.get(configFile))) {
-      throw new IOException(configFile + " not found.");
-    }
-    final Properties cfg = new Properties();
-    try (InputStream inputStream = new FileInputStream(configFile)) {
-      cfg.load(inputStream);
-    }
-    return cfg;
-  }
-
 }

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerAvroExample.java
@@ -18,7 +18,12 @@ package io.confluent.examples.clients.cloud;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.producer.*;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.errors.TopicExistsException;
 
 import java.io.IOException;

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerExample.java
@@ -18,7 +18,12 @@ package io.confluent.examples.clients.cloud;
 import io.confluent.examples.clients.cloud.model.DataRecord;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.producer.*;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.errors.TopicExistsException;
 
 import java.io.IOException;

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerExample.java
@@ -15,30 +15,19 @@
  */
 package io.confluent.examples.clients.cloud;
 
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.clients.producer.Callback;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.Producer;
-
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.admin.NewTopic;
-
 import io.confluent.examples.clients.cloud.model.DataRecord;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.*;
 import org.apache.kafka.common.errors.TopicExistsException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Properties;
+
+import java.io.IOException;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import static io.confluent.examples.clients.cloud.Util.loadConfig;
 
 public class ProducerExample {
 
@@ -104,16 +93,4 @@ public class ProducerExample {
 
     producer.close();
   }
-
-  public static Properties loadConfig(final String configFile) throws IOException {
-    if (!Files.exists(Paths.get(configFile))) {
-      throw new IOException(configFile + " not found.");
-    }
-    final Properties cfg = new Properties();
-    try (InputStream inputStream = new FileInputStream(configFile)) {
-      cfg.load(inputStream);
-    }
-    return cfg;
-  }
-
 }

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsAvroExample.java
@@ -16,36 +16,23 @@
 
 package io.confluent.examples.clients.cloud;
 
-import java.util.Properties;
-
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.kstream.KGroupedStream;
-import org.apache.kafka.streams.kstream.Printed;
-import org.apache.kafka.streams.kstream.Consumed;
-import org.apache.kafka.streams.kstream.Grouped;
-import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.state.KeyValueStore;
-
-import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerializer;
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Printed;
 
-import java.util.Collections;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.util.Map;
+import java.util.Properties;
+
+import static io.confluent.examples.clients.cloud.Util.loadConfig;
 
 public class StreamsAvroExample {
 
@@ -98,16 +85,4 @@ public class StreamsAvroExample {
         Runtime.getRuntime().addShutdownHook(new Thread(streams::close));
 
     }
-
-    public static Properties loadConfig(final String configFile) throws IOException {
-      if (!Files.exists(Paths.get(configFile))) {
-        throw new IOException(configFile + " not found.");
-      }
-      final Properties cfg = new Properties();
-      try (InputStream inputStream = new FileInputStream(configFile)) {
-        cfg.load(inputStream);
-      }
-      return cfg;
-    }
-
 }

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/StreamsExample.java
@@ -16,39 +16,28 @@
 
 package io.confluent.examples.clients.cloud;
 
-import java.util.Properties;
-
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.kstream.KGroupedStream;
-import org.apache.kafka.streams.kstream.Printed;
-import org.apache.kafka.streams.kstream.Consumed;
-import org.apache.kafka.streams.kstream.Grouped;
-import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.state.KeyValueStore;
-
 import io.confluent.examples.clients.cloud.model.DataRecord;
+import io.confluent.kafka.serializers.KafkaJsonDeserializer;
+import io.confluent.kafka.serializers.KafkaJsonSerializer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
-import io.confluent.kafka.serializers.KafkaJsonSerializer;
-import io.confluent.kafka.serializers.KafkaJsonDeserializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Printed;
 
-import java.util.Collections;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
+
+import static io.confluent.examples.clients.cloud.Util.loadConfig;
 
 public class StreamsExample {
 
@@ -109,16 +98,4 @@ public class StreamsExample {
 
         return Serdes.serdeFrom(mySerializer, myDeserializer);
     }
-
-    public static Properties loadConfig(final String configFile) throws IOException {
-      if (!Files.exists(Paths.get(configFile))) {
-        throw new IOException(configFile + " not found.");
-      }
-      final Properties cfg = new Properties();
-      try (InputStream inputStream = new FileInputStream(configFile)) {
-        cfg.load(inputStream);
-      }
-      return cfg;
-    }
-
 }

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/Util.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/Util.java
@@ -9,6 +9,7 @@ import java.util.Properties;
 
 public class Util {
     public static Properties loadConfig(String configFile) throws IOException {
+        configFile = configFile.replaceFirst("^~", System.getProperty("user.home"));
         if (!Files.exists(Paths.get(configFile))) {
             throw new IOException(configFile + " not found.");
         }

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/Util.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/Util.java
@@ -1,0 +1,21 @@
+package io.confluent.examples.clients.cloud;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+public class Util {
+    public static Properties loadConfig(String configFile) throws IOException {
+        if (!Files.exists(Paths.get(configFile))) {
+            throw new IOException(configFile + " not found.");
+        }
+        final Properties cfg = new Properties();
+        try (InputStream inputStream = new FileInputStream(configFile)) {
+            cfg.load(inputStream);
+        }
+        return cfg;
+    }
+}


### PR DESCRIPTION
### Description 

On Confluent Cloud, the Java Client tutorial suggests creating the file `~/.confluent/java.config` and gives copyable commands for running an example producer and consumer

Producer:`mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.ProducerExample" \
-Dexec.args="~/.confluent/java.config test1"`

Consumer: `mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.ConsumerExample" \
-Dexec.args="~/.confluent/java.config test1"`

This throws an error because `~` is not converted into the path to the user's home directory
`[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.2.1:java (default-cli) on project clients-example: An exception occured while executing the Java class. null: InvocationTargetException: ~/.confluent/java.config not found.`

I have updated the Java Cloud Client examples to support `~` in the config path so the copyable tutorial commands will work

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

- [x] clients/cloud

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

- [ ] clients/cloud
