### PR TITLE
update Ruby example to use rdkafka client library

### DIFF
--- a/clients/cloud/ruby/Gemfile
+++ b/clients/cloud/ruby/Gemfile
@@ -1,1 +1,3 @@
-gem 'ruby-kafka'
+source 'https://rubygems.org'
+
+gem 'rdkafka'

--- a/clients/cloud/ruby/Gemfile.lock
+++ b/clients/cloud/ruby/Gemfile.lock
@@ -1,14 +1,19 @@
 GEM
+  remote: https://rubygems.org/
   specs:
-    digest-crc (0.4.1)
-    ruby-kafka (0.7.4)
-      digest-crc
+    ffi (1.15.5)
+    mini_portile2 (2.8.0)
+    rake (13.0.6)
+    rdkafka (0.12.0)
+      ffi (~> 1.15)
+      mini_portile2 (~> 2.6)
+      rake (> 12)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  ruby-kafka
+  rdkafka
 
 BUNDLED WITH
-   1.17.1
+   2.3.26

--- a/clients/cloud/ruby/README.md
+++ b/clients/cloud/ruby/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-Produce messages to and consume messages from a Kafka cluster using the [ Zendesk Ruby Client for Apache Kafka](https://github.com/zendesk/ruby-kafka).
+Produce messages to and consume messages from a Kafka cluster using the [rdkafka](https://github.com/appsignal/rdkafka-ruby) gem that exposes [librdkafka](https://github.com/edenhill/librdkafka/).
 
 
 # Documentation

--- a/clients/cloud/ruby/consumer.rb
+++ b/clients/cloud/ruby/consumer.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 #
-# Copyright 2020 Confluent Inc.
+# Copyright 2022 Confluent Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,27 +28,30 @@ require './c_cloud'
 ccloud = CCloud.new
 topic = ccloud.topic
 
-# subscribe to a topic with default_offset earliest
-# to start reading from the beginning of the topic
-# if no committed offsets exist
-ccloud.consumer.subscribe(topic, default_offset: :earliest)
+# subscribe to a topic with auto.offset.reset earliest to start reading from the beginning of the
+# topic if no committed offsets exist
+ccloud.consumer.subscribe(topic)
 
 total_count = 0
 puts "Consuming messages from #{topic}"
 # Process messages
 while true
   begin
-    ccloud.consumer.each_message do |message|
+    ccloud.consumer.each do |message|
       record_key = message.key
-      record_value = message.value
+      record_value = message.payload
       data = JSON.parse(record_value)
-      count = data['count']
-      total_count += count
+      total_count += data['count']
 
       puts "Consumed record with key #{record_key} and value #{record_value}, " \
          "and updated total count #{total_count}"
     end
-  rescue Kafka::Error => e
+  rescue Interrupt
+    puts "Exiting"
+  rescue => e
     puts "Consuming messages from #{topic} failed: #{e.message}"
+  ensure
+    ccloud.consumer.close
+    break
   end
 end

--- a/clients/docs/ruby.rst
+++ b/clients/docs/ruby.rst
@@ -3,8 +3,7 @@
 Ruby: Code Example for |ak-tm|
 ==============================
 
-In this tutorial, you will run a Ruby client application using the `Zendesk Ruby
-Client for Apache Kafka <https://github.com/zendesk/ruby-kafka>`__ that produces
+In this tutorial, you will run a Ruby client application using the `rdkafka <https://github.com/appsignal/rdkafka-ruby>`__ gem that produces
 messages to and consumes messages from an |ak-tm| cluster.
 
 .. include:: includes/client-example-overview.rst


### PR DESCRIPTION
The Zendesk ruby-kafka gem that was previously used has been deprecated.

### Description 

[asana](https://app.asana.com/0/1201906632362444/1203516264611984/f)

### Author Validation

manually ran new example

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
 - [x] clients/cloud
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
