### PR TITLE
fix Cloud ETL example navigation

### DIFF
--- a/cloud-etl/docs/index.rst
+++ b/cloud-etl/docs/index.rst
@@ -52,6 +52,7 @@ This enables you to:
 .. tip:: For more information about building a cloud ETL pipeline on |ccloud|, see this
          `blog post <https://www.confluent.io/blog/build-a-cloud-etl-pipeline-with-confluent-cloud/>`__.
 
+=========
 Data Flow
 =========
 


### PR DESCRIPTION
* make Data Flow a section of the page rather than title within

### Description 

[asana](https://app.asana.com/0/1201906632362444/1203262787296520/f)