### PR TITLE
DEVX-2783: increase sleep before ksqldb queries from 30s to 60s.

### DIFF
--- a/cp-quickstart/start-cloud.sh
+++ b/cp-quickstart/start-cloud.sh
@@ -81,7 +81,7 @@ ccloud::create_connector connectors/ccloud-datagen-pageviews.json || exit 1
 ccloud::create_connector connectors/ccloud-datagen-users.json || exit 1
 ccloud::wait_for_connector_up connectors/ccloud-datagen-pageviews.json 300 || exit 1
 ccloud::wait_for_connector_up connectors/ccloud-datagen-users.json 300 || exit 1
-printf "\nSleeping 30 seconds to give the Datagen Source Connectors a chance to start producing messages\n"
+printf "\nSleeping 60 seconds to give the Datagen Source Connectors a chance to start producing messages\n"
 sleep 60
 
 printf "\n====== Setting up ksqlDB\n"

--- a/cp-quickstart/start-cloud.sh
+++ b/cp-quickstart/start-cloud.sh
@@ -82,7 +82,7 @@ ccloud::create_connector connectors/ccloud-datagen-users.json || exit 1
 ccloud::wait_for_connector_up connectors/ccloud-datagen-pageviews.json 300 || exit 1
 ccloud::wait_for_connector_up connectors/ccloud-datagen-users.json 300 || exit 1
 printf "\nSleeping 30 seconds to give the Datagen Source Connectors a chance to start producing messages\n"
-sleep 30
+sleep 60
 
 printf "\n====== Setting up ksqlDB\n"
 


### PR DESCRIPTION
### Description 

Prior to this change, ksqlDB queries were failing fairly often due to connectors not yet registering a schema.

https://confluentinc.atlassian.net/browse/DEVX-2783

_What behavior does this PR change, and why?_

Sleep is now 60s, seems to improve success rate of ksqlDB queries.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->

 - [X] cp-quickstart

