### PR TITLE
Update Rust dependencie Cargo.toml

### DIFF
--- a/clients/cloud/rust/Cargo.toml
+++ b/clients/cloud/rust/Cargo.toml
@@ -9,6 +9,7 @@ build   = "build.rs"
 futures = "0.1"
 tokio   = "0.1.21"
 clap    = "2.33.0"
+rdkafka-sys = "=1.2.2"
 
     [dependencies.rdkafka]
     version     = "~0.21"


### PR DESCRIPTION
add rdkafka-sys = "=1.2.2" as dependencie cause newer versions dont provide primitive_to_rd_kafka_resp_err_t

https://github.com/fede1024/rust-rdkafka/issues/211

### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

_What behavior does this PR change, and why?_
per default, cargo installs a new version of rdkafka-sys which is not compatible with the installed rdkafka version anymore

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] clients/cloud -->



### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._
build the rust example 

<!-- Uncomment any of the following that are required -->
<!-- - [ ] clients/cloud -->
