### PR TITLE
rework RBAC example to not require `confluent local services` command

### DIFF
--- a/security/rbac/docs/index.rst
+++ b/security/rbac/docs/index.rst
@@ -91,12 +91,7 @@ Run example
       ls /tmp/rbac_configs/
 
 #. After you run the example, view the log files for each of the services.
-   Since this example uses Confluent CLI, all logs are saved in a temporary
-   directory specified by ``confluent local current``.
-
-   .. code:: bash
-
-      ls `confluent local current | tail -1`
+   All logs are saved in the temporary directory ``/tmp/rbac_logs/``.
 
    In that directory, you can step through the configuration properties for each of the services:
 
@@ -110,11 +105,11 @@ Run example
       schema-registry
       zookeeper
    
-#. In this example, the metadata service (MDS) logs are saved in a temporary directory.
+#. In this example, the metadata service (MDS) logs are saved under your |cp| installation directory.
 
    .. code:: bash
 
-      cat `confluent local current | tail -1`/kafka/logs/metadata-service.log
+      cat $CONFLUENT_HOME/logs/metadata-service.log
 
 
 Stop example

--- a/security/rbac/scripts/cleanup.sh
+++ b/security/rbac/scripts/cleanup.sh
@@ -16,7 +16,7 @@ rm -f /tmp/tokenKeyPair.pem || true
 rm -f /tmp/tokenPublicKey.pem || true
 rm -f /tmp/login.properties || true
 
-confluent local destroy
+./stop-cp-services.sh
 
 # Clean up each individual properties file
 for propfile in $CONFLUENT_HOME/etc/kafka/server.properties $CONFLUENT_HOME/etc/schema-registry/connect-avro-distributed.properties $CONFLUENT_HOME/etc/confluent-control-center/control-center-dev.properties $CONFLUENT_HOME/etc/ksqldb/ksql-server.properties $CONFLUENT_HOME/etc/kafka-rest/kafka-rest.properties $CONFLUENT_HOME/etc/schema-registry/schema-registry.properties; do

--- a/security/rbac/scripts/enable-rbac-control-center.sh
+++ b/security/rbac/scripts/enable-rbac-control-center.sh
@@ -20,6 +20,7 @@ check_jq || exit 1
 ##################################################
 
 source ../config/local-demo.env
+LOGS_DIR=/tmp/rbac_logs
 ORIGINAL_CONFIGS_DIR=/tmp/original_configs
 DELTA_CONFIGS_DIR=../delta_configs
 FILENAME=control-center-dev.properties
@@ -39,15 +40,15 @@ echo -e "\n# Grant principal User:$USER_ADMIN_C3 the SystemAdmin role to the Kaf
 echo "confluent iam rbac role-binding create --principal User:$USER_ADMIN_C3 --role SystemAdmin --kafka-cluster $KAFKA_CLUSTER_ID"
 confluent iam rbac role-binding create --principal User:$USER_ADMIN_C3 --role SystemAdmin --kafka-cluster $KAFKA_CLUSTER_ID
 
-echo -e "\n# Bring up Control Center"
-confluent local services control-center start
+echo -e "\n# Bring up Confluent Control Center"
+control-center-start $CONFLUENT_HOME/etc/confluent-control-center/$FILENAME > $LOGS_DIR/control-center.log 2>&1 &
 
 echo "Sleeping 10 seconds"
 sleep 10
 
 ##################################################
-# Control Center client functions
-# From the Control Center UI, login with username=clientc and password=clientc1
+# Confluent Control Center client functions
+# From the Confluent Control Center UI, login with username=clientc and password=clientc1
 #
 # For C3 topic inspection on topic with non-Avro data
 # - Grant principal User:$USER_CLIENT_C the DeveloperRead role to Topic:$TOPIC1
@@ -82,7 +83,7 @@ echo -e "\n# List the role bindings for User:$USER_CLIENT_C to the Kafka cluster
 echo "confluent iam rbac role-binding list --principal User:$USER_CLIENT_C --kafka-cluster $KAFKA_CLUSTER_ID"
 confluent iam rbac role-binding list --principal User:$USER_CLIENT_C --kafka-cluster $KAFKA_CLUSTER_ID
 
-echo -e "\n # Note: From the Control Center UI, login with username=clientc and password=clientc1"
+echo -e "\n # Note: From the Confluent Control Center UI, login with username=clientc and password=clientc1"
 
 ##################################################
 # Cleanup

--- a/security/rbac/scripts/enable-rbac-ksqldb-server.sh
+++ b/security/rbac/scripts/enable-rbac-ksqldb-server.sh
@@ -20,6 +20,7 @@ check_jq || exit 1
 ##################################################
 
 source ../config/local-demo.env
+LOGS_DIR=/tmp/rbac_logs
 ORIGINAL_CONFIGS_DIR=/tmp/original_configs
 DELTA_CONFIGS_DIR=../delta_configs
 FILENAME=ksql-server.properties
@@ -52,7 +53,7 @@ echo "confluent iam rbac role-binding create --principal User:$USER_ADMIN_KSQLDB
 confluent iam rbac role-binding create --principal User:$USER_ADMIN_KSQLDB --role ResourceOwner --resource Topic:${KSQL_SERVICE_ID}ksql_processing_log --kafka-cluster $KAFKA_CLUSTER_ID
 
 echo -e "\n# Bring up KSQL server"
-confluent local services ksql-server start
+ksql-server-start $CONFLUENT_HOME/etc/ksqldb/$FILENAME  > $LOGS_DIR/ksql-server.log 2>&1 &
 
 echo "Sleeping 10 seconds"
 sleep 10

--- a/security/rbac/scripts/enable-rbac-rest-proxy.sh
+++ b/security/rbac/scripts/enable-rbac-rest-proxy.sh
@@ -20,6 +20,7 @@ check_jq || exit 1
 ##################################################
 
 source ../config/local-demo.env
+LOGS_DIR=/tmp/rbac_logs
 ORIGINAL_CONFIGS_DIR=/tmp/original_configs
 DELTA_CONFIGS_DIR=../delta_configs
 FILENAME=kafka-rest.properties
@@ -45,7 +46,7 @@ echo "confluent iam rbac role-binding create --principal User:$USER_CLIENT_RP --
 confluent iam rbac role-binding create --principal User:$USER_CLIENT_RP --role DeveloperRead --resource Topic:$LICENSE_TOPIC --kafka-cluster $KAFKA_CLUSTER_ID
 confluent iam rbac role-binding create --principal User:$USER_CLIENT_RP --role DeveloperWrite --resource Topic:$LICENSE_TOPIC --kafka-cluster $KAFKA_CLUSTER_ID
 
-confluent local services kafka-rest start
+kafka-rest-start $CONFLUENT_HOME/etc/kafka-rest/$FILENAME > $LOGS_DIR/kafka-rest.log 2>&1 &
 
 ##################################################
 # REST Proxy client functions

--- a/security/rbac/scripts/enable-rbac-schema-registry.sh
+++ b/security/rbac/scripts/enable-rbac-schema-registry.sh
@@ -20,6 +20,7 @@ check_jq || exit 1
 ##################################################
 
 source ../config/local-demo.env
+LOGS_DIR=/tmp/rbac_logs
 ORIGINAL_CONFIGS_DIR=/tmp/original_configs
 DELTA_CONFIGS_DIR=../delta_configs
 FILENAME=schema-registry.properties
@@ -61,7 +62,7 @@ confluent iam rbac role-binding create --principal User:$USER_ADMIN_SCHEMA_REGIS
 confluent iam rbac role-binding create --principal User:$USER_ADMIN_SCHEMA_REGISTRY --role DeveloperWrite --resource Topic:$LICENSE_TOPIC --kafka-cluster $KAFKA_CLUSTER_ID
 
 echo -e "\n# Bring up Schema Registry"
-confluent local services schema-registry start
+schema-registry-start $CONFLUENT_HOME/etc/schema-registry/$FILENAME > $LOGS_DIR/schema-registry.log 2>&1 &
 
 echo -e "Sleeping 10 seconds before getting the Schema Registry cluster ID"
 sleep 10

--- a/security/rbac/scripts/init.sh
+++ b/security/rbac/scripts/init.sh
@@ -12,6 +12,13 @@ check_jq || exit 1
 # Initialize
 ##################################################
 
+# remove any logs / configs from previous runs for which users didn't run cleanup.sh
+rm -f /tmp/rbac_logs || true
+rm -f /tmp/original_configs || true
+rm -f /tmp/rbac_configs || true
+rm -f /tmp/control-center || true
+
+mkdir -p /tmp/rbac_logs
 mkdir -p /tmp/original_configs
 mkdir -p /tmp/rbac_configs
 
@@ -23,4 +30,4 @@ openssl rsa -in /tmp/tokenKeypair.pem -outform PEM -pubout -out /tmp/tokenPublic
 
 source ../config/local-demo.env
 
-confluent local destroy
+./stop-cp-services.sh

--- a/security/rbac/scripts/run.sh
+++ b/security/rbac/scripts/run.sh
@@ -44,4 +44,4 @@ sleep 1
 ./enable-rbac-ksqldb-server.sh
 ./enable-rbac-control-center.sh
 
-#./cleanup.sh
+./cleanup.sh

--- a/security/rbac/scripts/stop-cp-services.sh
+++ b/security/rbac/scripts/stop-cp-services.sh
@@ -1,0 +1,15 @@
+control-center-stop
+ksql-server-stop
+kafka-rest-stop
+
+# Shut down connect worker as documented here: https://docs.confluent.io/platform/current/connect/userguide.html#shut-down-kconnect-long
+# The square bracket around 'C' will match the process we want but not the grep command itself. Note that this will
+# kill multiple distributed workers if there are any
+CONNECT_WORKER_PID=`ps aux | grep '[C]onnectDistributed' | awk '{print $2}'`
+if [[ $CONNECT_WORKER_PID ]]; then
+  echo "Stopping distributed worker with process ID(s) $CONNECT_WORKER_PID"
+  kill $CONNECT_WORKER_PID
+fi
+schema-registry-stop
+kafka-server-stop
+zookeeper-server-stop

--- a/utils/helper.sh
+++ b/utils/helper.sh
@@ -134,7 +134,13 @@ function check_running_cp() {
 
   expected_version=$1
 
-  actual_version=$( confluent local version 2>&1 | tail -1 | awk -F':' '{print $2;}' | awk '$1 > 0 { print $1}' )
+  # Temporary workaround: `confluent local version` was removed in version 3.16.0 of the CLI, so grab the latest CLI
+  # in a temp dir in order to run the command. Under the hood this command searches version strings in CONFLUENT_HOME.
+  TMP_DIR=`mktemp -d`
+  curl -sL https://raw.githubusercontent.com/confluentinc/cli/main/install.sh | sh -s -- -b $TMP_DIR 3.15.1
+  actual_version=$( $TMP_DIR/confluent local version 2>&1 | tail -1 | awk -F':' '{print $2;}' | awk '$1 > 0 { print $1}' )
+  rm -rf $TMP_DIR
+
   if [[ $expected_version != $actual_version ]]; then
     printf "\nThis script expects Confluent Platform version $expected_version but the running version is $actual_version.\nTo proceed please either: change the examples repo branch to $actual_version or update the running Confluent Platform to version $expected_version.\n"
     exit 1


### PR DESCRIPTION
This command was removed in version 3.16 of the CLI

### Description 

[asana](https://app.asana.com/0/1201906632362444/1204738563449396/f)

### Author Validation

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
 - [x] security/rbac


### Reviewer Tasks

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
 - [x] security/rbac
