### PR TITLE
🎁 Fixing some issues with p8s and docker compose

### DIFF
--- a/ccloud-observability/docker-compose.yml
+++ b/ccloud-observability/docker-compose.yml
@@ -60,19 +60,17 @@ services:
       - ./monitoring_configs/grafana/provisioning/:/etc/grafana/provisioning/
 
   producer:
-    <<: *client-base
+    <<: [*client-base, *client-base]
     command: >
       bash -c "mvn clean compile -f /tmp/java/
       &&  mvn -q -f /tmp/java/pom.xml exec:java -Dexec.mainClass=\"io.confluent.examples.clients.cloud.ProducerExample\" -Dexec.args=\"/tmp/client.config demo-topic-1\""
-    <<: *cap-add
 
   consumer:
-    <<: *client-base
+    <<: [*client-base, *client-base]
     command: >
       bash -c "sleep 15 &&
       mvn compile -f /tmp/java/
       &&  mvn -q -f /tmp/java/pom.xml exec:java -Dexec.mainClass=\"io.confluent.examples.clients.cloud.ConsumerExample\" -Dexec.args=\"/tmp/client.config demo-topic-1\""
-    <<: *cap-add
 
   kafka-lag-exporter:
     image: lightbend/kafka-lag-exporter:0.5.5

--- a/ccloud-observability/start.sh
+++ b/ccloud-observability/start.sh
@@ -61,11 +61,11 @@ if [[ $status != 0 ]]; then
   exit 1
 fi
 echo "$OUTPUT" | jq .
-export METRICS_API_KEY=$(echo "$OUTPUT" | jq -r ".key")
-export METRICS_API_SECRET=$(echo "$OUTPUT" | jq -r ".secret")
+export METRICS_API_KEY=$(echo "$OUTPUT" | jq -r ".api_key")
+export METRICS_API_SECRET=$(echo "$OUTPUT" | jq -r ".api_secret")
 export CLOUD_CLUSTER=$(confluent kafka cluster describe -o json |  jq -c '[.id]')
 export LAG_EXPORTER_ID=$CLUSTER
-export CLOUD_CONNECTORS=$(confluent connect list -o json | jq -c '. | map(.id)')
+export CLOUD_CONNECTORS=$(confluent connect cluster list -o json | jq -c '. | map(.id)')
 export CLOUD_KSQLDB_APPS=$(confluent ksql cluster list -o json |  jq -c '. | map(.id)')
 export CLOUD_SCHEMA_REGISTRY=$(confluent schema-registry cluster describe -o json |  jq -c '[.cluster_id]')
 


### PR DESCRIPTION
### Description 

`start.sh` was failing because of various issues:
- docker compose yaml parser was updated in 2.17 (cf. https://github.com/docker/compose/issues/10407 ) and is not supporting anymore more than one '<<' merge key 
- `confluent connect list` is not a valid CLI command, and as a side effect, it makes the p8s config file generation failing, has a result it has no target at all. 

### Author Validation

I've run multiple `start.sh` --> `stop.sh` cycles on my laptop and on a colleague's one.
 - [ x ] ccloud-observability


### Reviewer Tasks

 - [ x ] ccloud-observability
