### PR TITLE
Removes cleanup command from run.sh after running rbac example

### DIFF
--- a/security/rbac/scripts/run.sh
+++ b/security/rbac/scripts/run.sh
@@ -43,5 +43,3 @@ sleep 1
 ./enable-rbac-rest-proxy.sh
 ./enable-rbac-ksqldb-server.sh
 ./enable-rbac-control-center.sh
-
-# ./cleanup.sh

--- a/security/rbac/scripts/run.sh
+++ b/security/rbac/scripts/run.sh
@@ -44,4 +44,4 @@ sleep 1
 ./enable-rbac-ksqldb-server.sh
 ./enable-rbac-control-center.sh
 
-./cleanup.sh
+# ./cleanup.sh


### PR DESCRIPTION
### Description 

Removes cleanup after running rbac script `run.sh` as this voids above commands.


### Author Validation

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
[X] security/rbac


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
