### PR TITLE
Clarify use of docker compose vs. docker-compose in Multi-region tutorial

### DIFF
--- a/multiregion/docs/multiregion.rst
+++ b/multiregion/docs/multiregion.rst
@@ -112,6 +112,13 @@ Topic
 -  ``--replica-placement <path-to-replica-placement-policy-json>``: at
    topic creation, this argument defines the replica placement policy for a given
    topic
+   
+Docker commands
+---------------
+
+This version of the tutorial shows ``docker compose`` commands. Earlier versions of the Docker Compose CLI
+used ``docker-compose`` (hyphenated). If ``docker compose`` doesn't work for you, then ``docker-compose`` should work.
+To learn more, see `https://docs.docker.com/compose/reference/ <https://docs.docker.com/compose/reference/>`__.
 
 Download and run the tutorial
 -----------------------------

--- a/multiregion/docs/multiregion.rst
+++ b/multiregion/docs/multiregion.rst
@@ -113,12 +113,20 @@ Topic
    topic creation, this argument defines the replica placement policy for a given
    topic
    
-Docker commands
----------------
+Prerequisites
+-------------
 
-This version of the tutorial shows ``docker compose`` commands. Earlier versions of the Docker Compose CLI
-used ``docker-compose`` (hyphenated). If ``docker compose`` doesn't work for you, then ``docker-compose`` should work.
-To learn more, see `https://docs.docker.com/compose/reference/ <https://docs.docker.com/compose/reference/>`__.
+- Install `Docker Desktop <https://docs.docker.com/desktop/>`__ (version ``4.0.0`` or later) or `Docker Engine <https://docs.docker.com/engine/install/>`__ (version ``19.03.0`` or later) if you don’t already have it.
+
+- Install the `Docker Compose plugin <https://docs.docker.com/compose/install/>`__ if you don’t already have it. This isn’t necessary if you have Docker Desktop, since it includes Docker Compose.
+
+- Start Docker if it’s not already running, either by starting Docker Desktop or, if you manage Docker Engine with ``systemd``, via `systemctl <https://docs.docker.com/config/daemon/systemd/>`__.
+
+- Verify that Docker is set up properly by ensuring no errors are output when you run ``docker info`` and ``docker compose version`` on the command line.
+
+.. tip:: Earlier versions of Docker did not include Docker Compose, so a separate (hyphenated) ``docker-compose`` CLI was required. If your local Docker installation does not support
+         Docker Compose (``docker compose version`` throws an error), then you can either upgrade Docker or install the Compose plugin as documented above; or, if you have the standalone ``docker-compose`` CLI
+         installed and you don't wish to modify your local Docker installation, then you can substitute ``docker-compose`` wherever ``docker compose`` is used in this tutorial.
 
 Download and run the tutorial
 -----------------------------


### PR DESCRIPTION
### Description 

Field feedback.

_What behavior does this PR change, and why?_

Docker compose commands are version specific, so if you have an older version of Docker, the newer version of the CLI won't work. 


### Staging server


- http://staging-docs-independent.confluent.io.s3-website-us-west-2.amazonaws.com/docs-platform/PR/2734/7.4/tutorials/examples/multiregion/docs/multiregion.html#prerequisites


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
 [ ] Documentation review
