### PR TITLE
Remove duplicate environment keys from Docker Compose file

### DIFF
--- a/microservices-orders/docker-compose.yml
+++ b/microservices-orders/docker-compose.yml
@@ -54,7 +54,6 @@ services:
       CONNECT_BOOTSTRAP_SERVERS: $BOOTSTRAP_SERVERS
       CONNECT_REST_ADVERTISED_HOST_NAME: connect
       CONNECT_GROUP_ID: "examples-microservices-orders"
-      CONNECT_REST_ADVERTISED_HOST_NAME: connect
 
       CONNECT_SECURITY_PROTOCOL: SASL_SSL
       CONNECT_SASL_JAAS_CONFIG: $SASL_JAAS_CONFIG
@@ -154,7 +153,6 @@ services:
       XPACK_GRAPH_ENABLED: "false"
       XPACK_MONITORING_ENABLED: "false"
       XPACK_REPORTING_ENABLED: "false"
-      XPACK_SECURITY_ENABLED: "false"
     command: 
       - bash
       - -c


### PR DESCRIPTION
Docker may have got more strict in this area - started throwing these errors:

```
line 57: mapping key CONNECT_REST_ADVERTISED_HOST_NAME already defined at line 55
line 157: mapping key XPACK_SECURITY_ENABLED already defined at line 146
```
### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter. Please note submitters are expected to build docs-platform locally to validate before merging from examples._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
- [X] microservices-orders
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
