### PR TITLE
Backport reload4j to replace confluent-log4j

### DIFF
--- a/clients/avro/pom.xml
+++ b/clients/avro/pom.xml
@@ -68,14 +68,10 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>
     </dependency>
+    <!-- Backport reload4j to replace confluent-log4j -->
     <dependency>
-       <groupId>org.slf4j</groupId>
-       <artifactId>slf4j-log4j12</artifactId>
-   </dependency>
-   <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
-    <dependency>
-        <groupId>io.confluent</groupId>
-        <artifactId>confluent-log4j</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### Description 

Replaced confluent-log4j with reload4j - in a previously missed project (others have been updated).  Makes this project buildable from source and public repos.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter. Please note submitters are expected to build docs-platform locally to validate before merging from examples._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
- [X] clients/avro
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

Could build `clients/avro` - might need to be with clean Maven cache and only public repos available to be perfect test.
