### PR TITLE
DOCS-28118 - Remove empty promo codes

### DIFF
--- a/ccloud/docs/ccloud-stack.rst
+++ b/ccloud/docs/ccloud-stack.rst
@@ -59,11 +59,6 @@ By default, the |ccloud| ksqlDB app is not created with ``ccloud-stack``, you ha
    confluent ksql cluster create --cluster $CLUSTER --api-key "$KAFKA_API_KEY" --api-secret "$KAFKA_API_SECRET" --csu 1 -o json "$KSQLDB_NAME"
    confluent api-key create --service-account $SERVICE_ACCOUNT_ID --resource $RESOURCE -o json    // for ksqlDB REST API
 
-|ccloud| Promo Code
--------------------
-
-.. include:: includes/ccloud-examples-promo-code.rst
-
 
 =============
 Prerequisites

--- a/ccloud/docs/replicator-to-cloud-configuration-types.rst
+++ b/ccloud/docs/replicator-to-cloud-configuration-types.rst
@@ -21,11 +21,6 @@ Caution
 
 .. include:: includes/ccloud-examples-caution.rst
 
-|ccloud| Promo Code
--------------------
-
-.. include:: includes/ccloud-examples-promo-code.rst
-
 ===============
 Concepts Review
 ===============

--- a/cloud-etl/docs/index.rst
+++ b/cloud-etl/docs/index.rst
@@ -117,11 +117,6 @@ This example also uses real resources from other cloud providers, including:
 * AWS Kinesis or RDS PostgreSQL
 * Cloud storage providers (one of GCP GCS, AWS S3, or Azure Blob) depending on your configuration
 
-|ccloud| Promo Code
-~~~~~~~~~~~~~~~~~~~
-
-.. include:: ../../ccloud/docs/includes/ccloud-examples-promo-code.rst
-
 ===========
 Run Example
 ===========


### PR DESCRIPTION
### Description 

Remove empty content from the following topics:
https://docs.confluent.io/cloud/current/get-started/examples/ccloud/docs/replicator-to-cloud-configuration-types.html#ccloud-promo-code
https://docs.confluent.io/cloud/current/get-started/examples/ccloud/docs/ccloud-stack.html#ccloud-promo-code
https://docs.confluent.io/cloud/current/get-started/examples/cloud-etl/docs/index.html#ccloud-promo-code
<img width="882" alt="image" src="https://github.com/confluentinc/examples/assets/11722533/5bff85a3-7e66-4c03-b410-23d59068ec6a">

- related PR https://github.com/confluentinc/examples/pull/1201/files


