### PR TITLE
Revert kafka client configs deletion

### DIFF
--- a/clients/docs/includes/configs/cloud/hocon-sr.config
+++ b/clients/docs/includes/configs/cloud/hocon-sr.config
@@ -1,0 +1,32 @@
+kafka {
+  # Required connection configs for Kafka producer, consumer, and admin
+  bootstrap.servers = ["{{ BROKER_ENDPOINT }}"]
+
+  properties {
+    security.protocol = SASL_SSL
+    sasl.jaas.config = "org.apache.kafka.common.security.plain.PlainLoginModule   required username='{{ CLUSTER_API_KEY }}'   password='{{ CLUSTER_API_SECRET }}';"
+    sasl.mechanism = PLAIN
+    # Required for correctness in Apache Kafka clients prior to 2.6
+    client.dns.lookup = use_all_dns_ips
+    # Best practice for Kafka producer to prevent data loss
+    acks = all
+
+    # Required connection configs for Confluent Cloud Schema Registry
+    schema.registry.url = "https://{{ SR_ENDPOINT }}"
+    basic.auth.credentials.source = USER_INFO
+    basic.auth.user.info = "{{ SR_API_KEY }}:{{ SR_API_SECRET }}"
+  }
+  consumer {
+    group.id = "ktor-consumer"
+    key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+    value.deserializer = io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer
+    json.value.type = io.confluent.developer.Question
+    # Best practice for higher availability in Apache Kafka clients prior to 3.0
+    session.timeout.ms=45000
+  }
+  producer {
+    client.id = "ktor-producer"
+    key.serializer = org.apache.kafka.common.serialization.StringSerializer
+    value.serializer = io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer
+  }
+}

--- a/clients/docs/includes/configs/cloud/hocon.config
+++ b/clients/docs/includes/configs/cloud/hocon.config
@@ -1,0 +1,26 @@
+kafka {
+  # Required connection configs for Kafka producer, consumer, and admin
+  bootstrap.servers = ["{{ BROKER_ENDPOINT }}"]
+
+  properties {
+    security.protocol = SASL_SSL
+    sasl.jaas.config = "org.apache.kafka.common.security.plain.PlainLoginModule   required username='{{ CLUSTER_API_KEY }}'   password='{{ CLUSTER_API_SECRET }}';"
+    sasl.mechanism = PLAIN
+    # Required for correctness in Apache Kafka clients prior to 2.6
+    client.dns.lookup = use_all_dns_ips
+    # Best practice for Kafka producer to prevent data loss
+    acks = all
+  }
+  consumer {
+    group.id = "consumer"
+    key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+    value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+    # Best practice for higher availability in Apache Kafka clients prior to 3.0
+    session.timeout.ms=45000
+  }
+  producer {
+    client.id = "producer"
+    key.serializer = org.apache.kafka.common.serialization.StringSerializer
+    value.serializer = org.apache.kafka.common.serialization.StringSerializer
+  }
+}

--- a/clients/docs/includes/configs/cloud/java-sr.config
+++ b/clients/docs/includes/configs/cloud/java-sr.config
@@ -1,0 +1,18 @@
+# Required connection configs for Kafka producer, consumer, and admin
+bootstrap.servers={{ BROKER_ENDPOINT }}
+security.protocol=SASL_SSL
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
+sasl.mechanism=PLAIN
+# Required for correctness in Apache Kafka clients prior to 2.6
+client.dns.lookup=use_all_dns_ips
+
+# Best practice for higher availability in Apache Kafka clients prior to 3.0
+session.timeout.ms=45000
+
+# Best practice for Kafka producer to prevent data loss
+acks=all
+
+# Required connection configs for Confluent Cloud Schema Registry
+schema.registry.url=https://{{ SR_ENDPOINT }}
+basic.auth.credentials.source=USER_INFO
+basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}

--- a/clients/docs/includes/configs/cloud/java.config
+++ b/clients/docs/includes/configs/cloud/java.config
@@ -1,0 +1,13 @@
+# Required connection configs for Kafka producer, consumer, and admin
+bootstrap.servers={{ BROKER_ENDPOINT }}
+security.protocol=SASL_SSL
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
+sasl.mechanism=PLAIN
+# Required for correctness in Apache Kafka clients prior to 2.6
+client.dns.lookup=use_all_dns_ips
+
+# Best practice for higher availability in Apache Kafka clients prior to 3.0
+session.timeout.ms=45000
+
+# Best practice for Kafka producer to prevent data loss
+acks=all

--- a/clients/docs/includes/configs/cloud/librdkafka-sr.config
+++ b/clients/docs/includes/configs/cloud/librdkafka-sr.config
@@ -1,0 +1,14 @@
+# Required connection configs for Kafka producer, consumer, and admin
+bootstrap.servers={{ BROKER_ENDPOINT }}
+security.protocol=SASL_SSL
+sasl.mechanisms=PLAIN
+sasl.username={{ CLUSTER_API_KEY }}
+sasl.password={{ CLUSTER_API_SECRET }}
+
+# Best practice for higher availability in librdkafka clients prior to 1.7
+session.timeout.ms=45000
+
+# Required connection configs for Confluent Cloud Schema Registry
+schema.registry.url=https://{{ SR_ENDPOINT }}
+basic.auth.credentials.source=USER_INFO
+basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}

--- a/clients/docs/includes/configs/cloud/librdkafka.config
+++ b/clients/docs/includes/configs/cloud/librdkafka.config
@@ -1,0 +1,9 @@
+# Required connection configs for Kafka producer, consumer, and admin
+bootstrap.servers={{ BROKER_ENDPOINT }}
+security.protocol=SASL_SSL
+sasl.mechanisms=PLAIN
+sasl.username={{ CLUSTER_API_KEY }}
+sasl.password={{ CLUSTER_API_SECRET }}
+
+# Best practice for higher availability in librdkafka clients prior to 1.7
+session.timeout.ms=45000

--- a/clients/docs/includes/configs/cloud/restproxy-sr.config
+++ b/clients/docs/includes/configs/cloud/restproxy-sr.config
@@ -1,0 +1,14 @@
+# Required connection configs for Kafka producer, consumer, and admin
+bootstrap.servers={{ BROKER_ENDPOINT }}
+security.protocol=SASL_SSL
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
+sasl.mechanism=PLAIN
+client.bootstrap.servers={{ BROKER_ENDPOINT }}
+client.security.protocol=SASL_SSL
+client.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
+client.sasl.mechanism=PLAIN
+
+# Required connection configs for Confluent Cloud Schema Registry
+client.basic.auth.credentials.source=USER_INFO
+client.schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
+schema.registry.url=https://{{ SR_ENDPOINT }}

--- a/clients/docs/includes/configs/cloud/restproxy.config
+++ b/clients/docs/includes/configs/cloud/restproxy.config
@@ -1,0 +1,9 @@
+# Required connection configs for Kafka producer, consumer, and admin
+bootstrap.servers={{ BROKER_ENDPOINT }}
+security.protocol=SASL_SSL
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
+sasl.mechanism=PLAIN
+client.bootstrap.servers={{ BROKER_ENDPOINT }}
+client.security.protocol=SASL_SSL
+client.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
+client.sasl.mechanism=PLAIN

--- a/clients/docs/includes/configs/cloud/springboot-sr.config
+++ b/clients/docs/includes/configs/cloud/springboot-sr.config
@@ -1,0 +1,13 @@
+# Required connection configs for Kafka producer, consumer, and admin
+spring.kafka.properties.sasl.mechanism=PLAIN
+spring.kafka.properties.bootstrap.servers={{ BROKER_ENDPOINT }}
+spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
+spring.kafka.properties.security.protocol=SASL_SSL
+
+# Best practice for higher availability in Apache Kafka clients prior to 3.0
+spring.kafka.properties.session.timeout.ms=45000
+
+# Required connection configs for Confluent Cloud Schema Registry
+spring.kafka.properties.basic.auth.credentials.source=USER_INFO
+spring.kafka.properties.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
+spring.kafka.properties.schema.registry.url=https://{{ SR_ENDPOINT }}

--- a/clients/docs/includes/configs/cloud/springboot.config
+++ b/clients/docs/includes/configs/cloud/springboot.config
@@ -1,0 +1,8 @@
+# Required connection configs for Kafka producer, consumer, and admin
+spring.kafka.properties.sasl.mechanism=PLAIN
+spring.kafka.bootstrap-servers={{ BROKER_ENDPOINT }}
+spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ CLUSTER_API_KEY }}' password='{{ CLUSTER_API_SECRET }}';
+spring.kafka.properties.security.protocol=SASL_SSL
+
+# Best practice for higher availability in Apache Kafka clients prior to 3.0
+spring.kafka.properties.session.timeout.ms=45000


### PR DESCRIPTION
### Description 

Deleting these files in #1238 broke `confluent kafka client-config create` commands in production.

_What behavior does this PR change, and why?_


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter. Please note submitters are expected to build docs-platform locally to validate before merging from examples._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] ccloud/beginner-cloud -->
<!-- - [ ] ccloud/ccloud-stack -->
<!-- - [ ] ccloud-observability -->
<!-- - [ ] clickstream -->
<!-- - [ ] clients/avro -->
<!-- - [ ] clients/cloud -->
<!-- - [ ] cloud-etl -->
<!-- - [ ] connect-streams-pipeline -->
<!-- - [ ] cp-quickstart -->
<!-- - [ ] microservices-orders -->
<!-- - [ ] multi-datacenter -->
<!-- - [ ] multiregion -->
<!-- - [ ] replicator-schema-translation -->
<!-- - [ ] replicator-security -->
<!-- - [ ] security/rbac -->
