### PR TITLE
Allow S3-Compatible Cloud Object Storage in CloudETL Example

### DIFF
--- a/cloud-etl/connectors/s3_avro.json
+++ b/cloud-etl/connectors/s3_avro.json
@@ -6,6 +6,7 @@
     "kafka.api.secret": "$CLOUD_SECRET",
     "aws.access.key.id": "$AWS_ACCESS_KEY_ID",
     "aws.secret.access.key": "$AWS_SECRET_ACCESS_KEY",
+    "store.url": "$S3_ENDPOINT_URL",
     "s3.bucket.name": "$S3_BUCKET",
     "data.format": "AVRO",
     "time.interval" : "HOURLY",

--- a/cloud-etl/connectors/s3_no_avro.json
+++ b/cloud-etl/connectors/s3_no_avro.json
@@ -6,6 +6,7 @@
     "kafka.api.secret": "$CLOUD_SECRET",
     "aws.access.key.id": "$AWS_ACCESS_KEY_ID",
     "aws.secret.access.key": "$AWS_SECRET_ACCESS_KEY",
+    "store.url": "$S3_ENDPOINT_URL",
     "s3.bucket.name": "$S3_BUCKET",
     "time.interval" : "HOURLY",
     "data.format": "BYTES",

--- a/cloud-etl/read-data.sh
+++ b/cloud-etl/read-data.sh
@@ -81,7 +81,7 @@ else
     --schema-registry-endpoint $SCHEMA_REGISTRY_URL\
     --from-beginning\
     --print-key\
-    --value-format avro 
+    --value-format avro
 fi
 
 
@@ -92,7 +92,7 @@ AVRO_VERSION=1.9.1
 #fi
 if [[ "$DESTINATION_STORAGE" == "s3" ]]; then
 
-  for key in $(aws s3api list-objects --bucket $S3_BUCKET | jq -r '.Contents[].Key'); do
+  for key in $(aws s3api list-objects --bucket $S3_BUCKET --profile $S3_PROFILE | jq -r '.Contents[].Key'); do
     echo "S3 key: $key"
     #aws s3 cp s3://$S3_BUCKET/$key data.avro
     #echo "java -Dlog4j.configuration="file:log4j.properties" -jar avro-tools-${AVRO_VERSION}.jar tojson data.avro"

--- a/cloud-etl/setup_storage_s3.sh
+++ b/cloud-etl/setup_storage_s3.sh
@@ -25,8 +25,8 @@ fi
 
 export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile $S3_PROFILE)
 export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile $S3_PROFILE)
-export S3_ENDPOINT_URL=$(aws configure get endpoint_url --profile $S3_PROFILE) || "https://s3.amazonaws.com"
-export S3_ENDPOINT_URL="${S3_ENDPOINT_URL:-https://s3.amazonaws.com}"
+export S3_ENDPOINT_URL=$(aws configure get endpoint_url --profile $S3_PROFILE)
+export S3_ENDPOINT_URL="${S3_ENDPOINT_URL:-https://s3.$STORAGE_REGION.amazonaws.com}"
 
 ccloud::create_connector connectors/s3_no_avro.json || exit 1
 ccloud::wait_for_connector_up connectors/s3_no_avro.json 300 || exit 1

--- a/cloud-etl/setup_storage_s3.sh
+++ b/cloud-etl/setup_storage_s3.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-  
+
 # Source library
 source ../utils/helper.sh
 source ../utils/ccloud_library.sh
@@ -25,6 +25,9 @@ fi
 
 export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile $S3_PROFILE)
 export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile $S3_PROFILE)
+export S3_ENDPOINT_URL=$(aws configure get endpoint_url --profile $S3_PROFILE) || "https://s3.amazonaws.com"
+export S3_ENDPOINT_URL="${S3_ENDPOINT_URL:-https://s3.amazonaws.com}"
+
 ccloud::create_connector connectors/s3_no_avro.json || exit 1
 ccloud::wait_for_connector_up connectors/s3_no_avro.json 300 || exit 1
 ccloud::create_connector connectors/s3_avro.json || exit 1


### PR DESCRIPTION
### Description 

This change allows the use of an S3-compatible cloud object store such as [Backblaze B2](https://www.backblaze.com/cloud-storage) with the CloudETL example as an alternative to Amazon S3.

With this change, the user may configure an AWS profile with `endpoint_url` set to a value such as `https://s3.us-west-004.backblazeb2.com` in the `config` file. For example:

```
[profile b2-example]
endpoint_url = https://s3.us-west-004.backblazeb2.com
region = us-west-004
```

The `setup_s3_storage.sh` script reads this value (via `aws configure get endpoint_url --profile $S3_PROFILE`) into a new `S3_ENDPOINT_URL` environment variable which is used as `store.url` for the connectors. If the endpoint URL is not set in the profile, then the Amazon S3 global default, `https://s3.amazonaws.com`, is used.

There is also a fix to `read-data.sh` - the `list-objects` call was missing the `--profile $S3_PROFILE`, so it incorrectly used the default profile.

### Author Validation

[x] cloud-etl

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

[ ] cloud-etl